### PR TITLE
Added hexagon support

### DIFF
--- a/EKF/ekf_helper.cpp
+++ b/EKF/ekf_helper.cpp
@@ -81,7 +81,7 @@ void Ekf::resetPosition()
 	_state.pos(2) = baro_newest.hgt;
 }
 
-#ifdef __PX4_POSIX
+#if defined(__PX4_POSIX) && !defined(__PX4_QURT)
 void Ekf::printCovToFile(char const *filename)
 {
 	std::ofstream myfile;


### PR DESCRIPTION
std::to_string is not supported in the Hexagon complier

Signed-off-by: Mark Charlebois <charlebm@gmail.com>