### PR TITLE
EKF Tuning Update

### DIFF
--- a/EKF/common.h
+++ b/EKF/common.h
@@ -50,7 +50,7 @@ struct gps_message {
 	float eph;                  // GPS horizontal position accuracy in m
 	float epv;                  // GPS vertical position accuracy in m
 	float sacc;                 // GPS speed accuracy in m/s
-        uint64_t time_usec_vel;     // Timestamp for velocity informations
+	uint64_t time_usec_vel;     // Timestamp for velocity informations
 	float vel_m_s;              // GPS ground speed (m/s)
 	float vel_ned[3];           // GPS ground speed NED
 	bool vel_ned_valid;         // GPS ground speed is valid
@@ -112,35 +112,35 @@ struct flowSample {
 };
 
 struct parameters {
-        float mag_delay_ms = 0.0f;          // magnetometer measurement delay relative to the IMU
-        float baro_delay_ms = 0.0f;         // barometer height measurement delay relative to the IMU
-        float gps_delay_ms = 200.0f;        // GPS measurement delay relative to the IMU
-        float airspeed_delay_ms = 200.0f;   // airspeed measurement delay relative to the IMU
+	float mag_delay_ms = 0.0f;          // magnetometer measurement delay relative to the IMU
+	float baro_delay_ms = 0.0f;         // barometer height measurement delay relative to the IMU
+	float gps_delay_ms = 200.0f;        // GPS measurement delay relative to the IMU
+	float airspeed_delay_ms = 200.0f;   // airspeed measurement delay relative to the IMU
 
 	// input noise
-        float gyro_noise = 1.0e-3f;         // IMU angular rate noise used for covariance prediction
-        float accel_noise = 2.5e-1f;        // IMU acceleration noise use for covariance prediction
+	float gyro_noise = 1.0e-3f;         // IMU angular rate noise used for covariance prediction
+	float accel_noise = 2.5e-1f;        // IMU acceleration noise use for covariance prediction
 
 	// process noise
-        float gyro_bias_p_noise = 7.0e-5f;  // process noise for IMU delta angle bias prediction
-        float accel_bias_p_noise = 1.0e-4f; // process noise for IMU delta velocity bias prediction
-        float gyro_scale_p_noise = 3.0e-3f; // process noise for gyro scale factor prediction
-        float mag_p_noise = 2.5e-2f;        // process noise for magnetic field prediction
-        float wind_vel_p_noise = 1.0e-1f;   // process noise for wind velocity prediction
+	float gyro_bias_p_noise = 7.0e-5f;  // process noise for IMU delta angle bias prediction
+	float accel_bias_p_noise = 1.0e-4f; // process noise for IMU delta velocity bias prediction
+	float gyro_scale_p_noise = 3.0e-3f; // process noise for gyro scale factor prediction
+	float mag_p_noise = 2.5e-2f;        // process noise for magnetic field prediction
+	float wind_vel_p_noise = 1.0e-1f;   // process noise for wind velocity prediction
 
-        float gps_vel_noise = 5.0e-1f;      // observation noise for gps velocity fusion
-        float gps_pos_noise = 1.0f;         // observation noise for gps position fusion
-        float pos_noaid_noise = 10.0f;      // observation noise for non-aiding position fusion
-        float baro_noise = 3.0f;            // observation noise for barometric height fusion
-        float baro_innov_gate = 3.0f;       // barometric height innovation consistency gate size in standard deviations
-        float posNE_innov_gate = 3.0f;      // GPS horizontal position innovation consistency gate size in standard deviations
+	float gps_vel_noise = 5.0e-1f;      // observation noise for gps velocity fusion
+	float gps_pos_noise = 1.0f;         // observation noise for gps position fusion
+	float pos_noaid_noise = 10.0f;      // observation noise for non-aiding position fusion
+	float baro_noise = 3.0f;            // observation noise for barometric height fusion
+	float baro_innov_gate = 3.0f;       // barometric height innovation consistency gate size in standard deviations
+	float posNE_innov_gate = 3.0f;      // GPS horizontal position innovation consistency gate size in standard deviations
 	float vel_innov_gate = 3.0f;        // GPS velocity innovation consistency gate size in standard deviations
 
-        float mag_heading_noise = 1.7e-1f;  // measurement noise used for simple heading fusion
-        float mag_noise = 5.0e-2f;          // measurement noise used for 3-axis magnetoemeter fusion
-        float mag_declination_deg = 0.0f;   // magnetic declination in degrees
-        float heading_innov_gate = 3.0f;    // heading fusion innovation consistency gate size in standard deviations
-        float mag_innov_gate = 3.0f;        // magnetometer fusion innovation consistency gate size in standard deviations
+	float mag_heading_noise = 1.7e-1f;  // measurement noise used for simple heading fusion
+	float mag_noise = 5.0e-2f;          // measurement noise used for 3-axis magnetoemeter fusion
+	float mag_declination_deg = 0.0f;   // magnetic declination in degrees
+	float heading_innov_gate = 3.0f;    // heading fusion innovation consistency gate size in standard deviations
+	float mag_innov_gate = 3.0f;        // magnetometer fusion innovation consistency gate size in standard deviations
 
 	// these parameters control the strictness of GPS quality checks used to determine uf the GPS is
 	// good enough to set a local origin and commence aiding

--- a/EKF/common.h
+++ b/EKF/common.h
@@ -50,7 +50,7 @@ struct gps_message {
 	float eph;                  // GPS horizontal position accuracy in m
 	float epv;                  // GPS vertical position accuracy in m
 	float sacc;                 // GPS speed accuracy in m/s
-	uint64_t time_usec_vel; 	// Timestamp for velocity informations
+        uint64_t time_usec_vel;     // Timestamp for velocity informations
 	float vel_m_s;              // GPS ground speed (m/s)
 	float vel_ned[3];           // GPS ground speed NED
 	bool vel_ned_valid;         // GPS ground speed is valid
@@ -112,33 +112,34 @@ struct flowSample {
 };
 
 struct parameters {
-	float mag_delay_ms = 0.0f;
-	float baro_delay_ms = 0.0f;
-	float gps_delay_ms = 200.0f;
-	float airspeed_delay_ms = 200.0f;
+        float mag_delay_ms = 0.0f;          // magnetometer measurement delay relative to the IMU
+        float baro_delay_ms = 0.0f;         // barometer height measurement delay relative to the IMU
+        float gps_delay_ms = 200.0f;        // GPS measurement delay relative to the IMU
+        float airspeed_delay_ms = 200.0f;   // airspeed measurement delay relative to the IMU
 
 	// input noise
-	float gyro_noise = 0.001f;
-	float accel_noise = 0.1f;
+        float gyro_noise = 1.0e-3f;         // IMU angular rate noise used for covariance prediction
+        float accel_noise = 2.5e-1f;        // IMU acceleration noise use for covariance prediction
 
 	// process noise
-	float gyro_bias_p_noise = 1e-5f;
-	float accel_bias_p_noise = 1e-3f;
-	float gyro_scale_p_noise = 1e-4f;
-	float mag_p_noise = 1e-2f;
-	float wind_vel_p_noise = 0.05f;
+        float gyro_bias_p_noise = 7.0e-5f;  // process noise for IMU delta angle bias prediction
+        float accel_bias_p_noise = 1.0e-4f; // process noise for IMU delta velocity bias prediction
+        float gyro_scale_p_noise = 3.0e-3f; // process noise for gyro scale factor prediction
+        float mag_p_noise = 2.5e-2f;        // process noise for magnetic field prediction
+        float wind_vel_p_noise = 1.0e-1f;   // process noise for wind velocity prediction
 
-	float gps_vel_noise = 0.05f;
-	float gps_pos_noise = 1.0f;
-	float baro_noise = 0.1f;
-	float baro_innov_gate = 5.0f;       // barometric height innovation consistency gate size in standard deviations
-	float posNE_innov_gate = 5.0f;      // GPS horizontal position innovation consistency gate size in standard deviations
+        float gps_vel_noise = 5.0e-1f;      // observation noise for gps velocity fusion
+        float gps_pos_noise = 1.0f;         // observation noise for gps position fusion
+        float baro_noise = 3.0f;            // observation noise for barometric height fusion
+        float baro_innov_gate = 3.0f;       // barometric height innovation consistency gate size in standard deviations
+        float posNE_innov_gate = 3.0f;      // GPS horizontal position innovation consistency gate size in standard deviations
 	float vel_innov_gate = 3.0f;        // GPS velocity innovation consistency gate size in standard deviations
 
-	float mag_heading_noise = 3e-2f;	// measurement noise used for simple heading fusion
-	float mag_declination_deg = 0.0f;	// magnetic declination in degrees
-	float heading_innov_gate = 3.0f;	// heading fusion innovation consistency gate size in standard deviations
-	float mag_innov_gate = 3.0f;        // magnetometer fusion innovation consistency gate size in standard deviations
+        float mag_heading_noise = 1.7e-1f;  // measurement noise used for simple heading fusion
+        float mag_noise = 5.0e-2f;          // measurement noise used for 3-axis magnetoemeter fusion
+        float mag_declination_deg = 0.0f;   // magnetic declination in degrees
+        float heading_innov_gate = 3.0f;    // heading fusion innovation consistency gate size in standard deviations
+        float mag_innov_gate = 3.0f;        // magnetometer fusion innovation consistency gate size in standard deviations
 
 	// these parameters control the strictness of GPS quality checks used to determine uf the GPS is
 	// good enough to set a local origin and commence aiding

--- a/EKF/common.h
+++ b/EKF/common.h
@@ -130,6 +130,7 @@ struct parameters {
 
         float gps_vel_noise = 5.0e-1f;      // observation noise for gps velocity fusion
         float gps_pos_noise = 1.0f;         // observation noise for gps position fusion
+        float pos_noaid_noise = 10.0f;      // observation noise for non-aiding position fusion
         float baro_noise = 3.0f;            // observation noise for barometric height fusion
         float baro_innov_gate = 3.0f;       // barometric height innovation consistency gate size in standard deviations
         float posNE_innov_gate = 3.0f;      // GPS horizontal position innovation consistency gate size in standard deviations

--- a/EKF/covariance.cpp
+++ b/EKF/covariance.cpp
@@ -130,12 +130,12 @@ void Ekf::predictCovariance()
 	// compute process noise
 	float process_noise[_k_num_states] = {};
 
-	float d_ang_bias_sig = dt * math::constrain(_params.gyro_bias_p_noise, 0.0f, 1e-4f);
-	float d_vel_bias_sig = dt * math::constrain(_params.accel_bias_p_noise, 1e-6f, 1e-2f);
-	float d_ang_scale_sig = dt * math::constrain(_params.gyro_scale_p_noise, 1e-6f, 1e-2f);
-	float mag_I_sig = dt * math::constrain(_params.mag_p_noise, 1e-4f, 1e-1f);
-	float mag_B_sig = dt * math::constrain(_params.mag_p_noise, 1e-4f, 1e-1f);
-	float wind_vel_sig = dt * math::constrain(_params.wind_vel_p_noise, 0.01f, 1.0f);
+    float d_ang_bias_sig = dt * math::constrain(_params.gyro_bias_p_noise, 0.0f, 1e-4f);
+    float d_vel_bias_sig = dt * math::constrain(_params.accel_bias_p_noise, 0.0f, 1e-2f);
+    float d_ang_scale_sig = dt * math::constrain(_params.gyro_scale_p_noise, 0.0f, 1e-2f);
+    float mag_I_sig = dt * math::constrain(_params.mag_p_noise, 0.0f, 1e-1f);
+    float mag_B_sig = dt * math::constrain(_params.mag_p_noise, 0.0f, 1e-1f);
+    float wind_vel_sig = dt * math::constrain(_params.wind_vel_p_noise, 0.0f, 1.0f);
 
 	for (unsigned i = 0; i < 9; i++) {
 		process_noise[i] = 0.0f;

--- a/EKF/covariance.cpp
+++ b/EKF/covariance.cpp
@@ -130,12 +130,12 @@ void Ekf::predictCovariance()
 	// compute process noise
 	float process_noise[_k_num_states] = {};
 
-    float d_ang_bias_sig = dt * math::constrain(_params.gyro_bias_p_noise, 0.0f, 1e-4f);
-    float d_vel_bias_sig = dt * math::constrain(_params.accel_bias_p_noise, 0.0f, 1e-2f);
-    float d_ang_scale_sig = dt * math::constrain(_params.gyro_scale_p_noise, 0.0f, 1e-2f);
-    float mag_I_sig = dt * math::constrain(_params.mag_p_noise, 0.0f, 1e-1f);
-    float mag_B_sig = dt * math::constrain(_params.mag_p_noise, 0.0f, 1e-1f);
-    float wind_vel_sig = dt * math::constrain(_params.wind_vel_p_noise, 0.0f, 1.0f);
+	float d_ang_bias_sig = dt * math::constrain(_params.gyro_bias_p_noise, 0.0f, 1e-4f);
+	float d_vel_bias_sig = dt * math::constrain(_params.accel_bias_p_noise, 0.0f, 1e-2f);
+	float d_ang_scale_sig = dt * math::constrain(_params.gyro_scale_p_noise, 0.0f, 1e-2f);
+	float mag_I_sig = dt * math::constrain(_params.mag_p_noise, 0.0f, 1e-1f);
+	float mag_B_sig = dt * math::constrain(_params.mag_p_noise, 0.0f, 1e-1f);
+	float wind_vel_sig = dt * math::constrain(_params.wind_vel_p_noise, 0.0f, 1.0f);
 
 	for (unsigned i = 0; i < 9; i++) {
 		process_noise[i] = 0.0f;

--- a/EKF/ekf.cpp
+++ b/EKF/ekf.cpp
@@ -330,8 +330,8 @@ bool Ekf::collect_imu(imuSample &imu)
 	_imu_down_sampled.delta_vel = delta_R * _imu_down_sampled.delta_vel;
 	_imu_down_sampled.delta_vel += imu.delta_vel;
 
-	if ((_dt_imu_avg * _imu_ticks >= (float)(FILTER_UPDATE_PERRIOD_MS) / 1000) || 
-		_dt_imu_avg * _imu_ticks >= 0.02f){
+	if ((_dt_imu_avg * _imu_ticks >= (float)(FILTER_UPDATE_PERRIOD_MS) / 1000) ||
+	    _dt_imu_avg * _imu_ticks >= 0.02f) {
 		imu = {
 			.delta_ang	= _q_down_sampled.to_axis_angle(),
 			.delta_vel	= _imu_down_sampled.delta_vel,

--- a/EKF/estimator_interface.cpp
+++ b/EKF/estimator_interface.cpp
@@ -137,7 +137,7 @@ void EstimatorInterface::setGpsData(uint64_t time_usec, struct gps_message *gps)
 		memcpy(gps_sample_new.vel._data[0], gps->vel_ned, sizeof(gps_sample_new.vel._data));
 
 		_gps_speed_valid = gps->vel_ned_valid;
-                _gps_speed_accuracy = gps->sacc;
+		_gps_speed_accuracy = gps->sacc;
 
 		float lpos_x = 0.0f;
 		float lpos_y = 0.0f;

--- a/EKF/estimator_interface.cpp
+++ b/EKF/estimator_interface.cpp
@@ -137,6 +137,7 @@ void EstimatorInterface::setGpsData(uint64_t time_usec, struct gps_message *gps)
 		memcpy(gps_sample_new.vel._data[0], gps->vel_ned, sizeof(gps_sample_new.vel._data));
 
 		_gps_speed_valid = gps->vel_ned_valid;
+                _gps_speed_accuracy = gps->sacc;
 
 		float lpos_x = 0.0f;
 		float lpos_y = 0.0f;

--- a/EKF/estimator_interface.h
+++ b/EKF/estimator_interface.h
@@ -197,8 +197,8 @@ protected:
 
 	bool _NED_origin_initialised = false;
 	bool _gps_speed_valid = false;
-        float _gps_speed_accuracy = 0.0f; // GPS receiver reported speed accuracy (m/s)
-        struct map_projection_reference_s _pos_ref = {};    // Contains WGS-84 position latitude and longitude (radians)
+	float _gps_speed_accuracy = 0.0f; // GPS receiver reported speed accuracy (m/s)
+	struct map_projection_reference_s _pos_ref = {};    // Contains WGS-84 position latitude and longitude (radians)
 
 	bool _mag_healthy = false;		// computed by mag innovation test
 	float _yaw_test_ratio;          // yaw innovation consistency check ratio

--- a/EKF/estimator_interface.h
+++ b/EKF/estimator_interface.h
@@ -197,7 +197,8 @@ protected:
 
 	bool _NED_origin_initialised = false;
 	bool _gps_speed_valid = false;
-	struct map_projection_reference_s _pos_ref = {};    // Contains WGS-84 position latitude and longitude (radians)
+        float _gps_speed_accuracy = 0.0f; // GPS receiver reported speed accuracy (m/s)
+        struct map_projection_reference_s _pos_ref = {};    // Contains WGS-84 position latitude and longitude (radians)
 
 	bool _mag_healthy = false;		// computed by mag innovation test
 	float _yaw_test_ratio;          // yaw innovation consistency check ratio

--- a/EKF/gps_checks.cpp
+++ b/EKF/gps_checks.cpp
@@ -84,7 +84,7 @@ bool Ekf::collect_gps(uint64_t time_usec, struct gps_message *gps)
  * Return true if the GPS solution quality is adequate to set an origin for the EKF
  * and start GPS aiding.
  * All activated checks must pass for 10 seconds.
- * Checks are activated using the EKF2_GPS_CHECKS bitmask parameter
+ * Checks are activated using the EKF2_GPS_CHECK bitmask parameter
  * Checks are adjusted using the EKF2_REQ_* parameters
 */
 bool Ekf::gps_is_good(struct gps_message *gps)

--- a/EKF/mag_fusion.cpp
+++ b/EKF/mag_fusion.cpp
@@ -55,8 +55,8 @@ void Ekf::fuseMag()
 	float magD = _state.mag_I(2);
 
 	// XYZ Measurement uncertainty. Need to consider timing errors for fast rotations
-    float R_MAG = fmaxf(_params.mag_noise, 1.0e-3f);
-    R_MAG = R_MAG*R_MAG;
+	float R_MAG = fmaxf(_params.mag_noise, 1.0e-3f);
+	R_MAG = R_MAG * R_MAG;
 
 	// intermediate variables from algebraic optimisation
 	float SH_MAG[9];
@@ -472,8 +472,8 @@ void Ekf::fuseHeading()
 	float magY = _mag_sample_delayed.mag(1);
 	float magZ = _mag_sample_delayed.mag(2);
 
-    float R_mag = fmaxf(_params.mag_heading_noise, 1.0e-2f);
-    R_mag = R_mag*R_mag;
+	float R_mag = fmaxf(_params.mag_heading_noise, 1.0e-2f);
+	R_mag = R_mag * R_mag;
 
 	float t2 = q0 * q0;
 	float t3 = q1 * q1;

--- a/EKF/mag_fusion.cpp
+++ b/EKF/mag_fusion.cpp
@@ -55,7 +55,8 @@ void Ekf::fuseMag()
 	float magD = _state.mag_I(2);
 
 	// XYZ Measurement uncertainty. Need to consider timing errors for fast rotations
-	float R_MAG = 1e-3f;
+    float R_MAG = fmaxf(_params.mag_noise, 1.0e-3f);
+    R_MAG = R_MAG*R_MAG;
 
 	// intermediate variables from algebraic optimisation
 	float SH_MAG[9];
@@ -471,7 +472,8 @@ void Ekf::fuseHeading()
 	float magY = _mag_sample_delayed.mag(1);
 	float magZ = _mag_sample_delayed.mag(2);
 
-	float R_mag = _params.mag_heading_noise;
+    float R_mag = fmaxf(_params.mag_heading_noise, 1.0e-2f);
+    R_mag = R_mag*R_mag;
 
 	float t2 = q0 * q0;
 	float t3 = q1 * q1;

--- a/EKF/vel_pos_fusion.cpp
+++ b/EKF/vel_pos_fusion.cpp
@@ -84,7 +84,12 @@ void Ekf::fuseVelPosHeight()
 		_vel_pos_innov[3] = _state.pos(0) - _gps_sample_delayed.pos(0);
 		_vel_pos_innov[4] = _state.pos(1) - _gps_sample_delayed.pos(1);
         // observation variance - user parameter defined
-        R[3] = fmaxf(_params.gps_pos_noise, 0.01f);
+        // if we are in flight and not using GPS, then use a specific parameter
+        if (!_control_status.flags.gps && _control_status.flags.in_air) {
+            R[3] = fmaxf(_params.pos_noaid_noise, 0.5f);
+        } else {
+            R[3] = fmaxf(_params.gps_pos_noise, 0.01f);
+        }
         R[3] = R[3] * R[3];
         R[4] = R[3];
         // innovation gate sizes

--- a/EKF/vel_pos_fusion.cpp
+++ b/EKF/vel_pos_fusion.cpp
@@ -54,8 +54,8 @@ void Ekf::fuseVelPosHeight()
 		fuse_map[0] = fuse_map[1] = true;
 		_vel_pos_innov[0] = _state.vel(0) - _gps_sample_delayed.vel(0);
 		_vel_pos_innov[1] = _state.vel(1) - _gps_sample_delayed.vel(1);
-		R[0] = _params.gps_vel_noise;
-		R[1] = _params.gps_vel_noise;
+        R[0] = fmaxf(_params.gps_vel_noise, 0.01f);
+        R[1] = R[0];
         gate_size[0] = fmaxf(_params.vel_innov_gate, 1.0f);
         gate_size[1] = gate_size[0];
     }
@@ -63,7 +63,7 @@ void Ekf::fuseVelPosHeight()
 	if (_fuse_vert_vel) {
 		fuse_map[2] = true;
 		_vel_pos_innov[2] = _state.vel(2) - _gps_sample_delayed.vel(2);
-		R[2] = _params.gps_vel_noise;
+        R[2] = 1.5f * fmaxf(_params.gps_vel_noise, 0.01f);
         gate_size[2] = fmaxf(_params.vel_innov_gate, 1.0f);
     }
 
@@ -71,8 +71,8 @@ void Ekf::fuseVelPosHeight()
 		fuse_map[3] = fuse_map[4] = true;
 		_vel_pos_innov[3] = _state.pos(0) - _gps_sample_delayed.pos(0);
 		_vel_pos_innov[4] = _state.pos(1) - _gps_sample_delayed.pos(1);
-		R[3] = _params.gps_pos_noise;
-		R[4] = _params.gps_pos_noise;
+        R[3] = fmaxf(_params.gps_pos_noise, 0.01f);
+        R[4] = R[3];
         gate_size[3] = fmaxf(_params.posNE_innov_gate, 1.0f);
         gate_size[4] = gate_size[3];
 	}
@@ -80,7 +80,7 @@ void Ekf::fuseVelPosHeight()
 	if (_fuse_height) {
 		fuse_map[5] = true;
 		_vel_pos_innov[5] = _state.pos(2) - (-_baro_sample_delayed.hgt);		// baro measurement has inversed z axis
-		R[5] = _params.baro_noise;
+        R[5] = fmaxf(_params.baro_noise, 0.01f);
         gate_size[5] = fmaxf(_params.baro_innov_gate, 1.0f);
     }
 


### PR DESCRIPTION
- The tuning parameter defaults have been changed to a conservative set to handle larger magnetometer and IMU errors. This is an equivalent tune to the APM copter defaults and prioritises robustness to sensor error over accuracy. A tuning activity to obtain a 'performance' oriented tune will be performed later when the replay functionality is available in master.

- An error in in conversion from observation noise to observation variance in pos vel  fusion has been fixed.
- Velocity observation noise adapts with reported GPS speed accuracy.
- A separate position observation noise is used in-flight for operation without aiding. This reduces attitude errors due to manoeuvres.
- The missing magnetometer observation noise parameter has been added.

Flight testing has been completed (see following figures). The sensor error estimates are now more reactive which improves robustness at he expense of accuracy.

![posne innov](https://cloud.githubusercontent.com/assets/3596952/12777124/f2e3ac8a-caae-11e5-965f-5f0055a60a7c.png)
![velne innov](https://cloud.githubusercontent.com/assets/3596952/12777126/f3414cdc-caae-11e5-9582-3672d55ed353.png)
![veld innov](https://cloud.githubusercontent.com/assets/3596952/12777140/f3da32c6-caae-11e5-8ee4-f3fef78d7836.png)
![posd innov](https://cloud.githubusercontent.com/assets/3596952/12777128/f34924ca-caae-11e5-8bcd-5d0ca32c8d21.png)
![dangx bias](https://cloud.githubusercontent.com/assets/3596952/12777129/f34b3512-caae-11e5-9cba-6f183c724464.png)
![dangy bias](https://cloud.githubusercontent.com/assets/3596952/12777127/f345280c-caae-11e5-95d1-8542e667a181.png)
![dangz bias](https://cloud.githubusercontent.com/assets/3596952/12777125/f3269770-caae-11e5-9ca6-088684100439.png)
![scalex](https://cloud.githubusercontent.com/assets/3596952/12777130/f363271c-caae-11e5-8120-ab36933290ad.png)
![scaley](https://cloud.githubusercontent.com/assets/3596952/12777131/f37c328e-caae-11e5-9233-ba66901c9b6f.png)
![scalez](https://cloud.githubusercontent.com/assets/3596952/12777132/f380a2d8-caae-11e5-862d-1230afdfe37d.png)
![magx innov](https://cloud.githubusercontent.com/assets/3596952/12777133/f3847282-caae-11e5-9314-5697d8763f15.png)
![magy innov](https://cloud.githubusercontent.com/assets/3596952/12777134/f3874714-caae-11e5-83e5-82596f1353f4.png)
![magz innov](https://cloud.githubusercontent.com/assets/3596952/12777135/f39c8ad4-caae-11e5-9d1a-8a658f26772c.png)
![mag innov](https://cloud.githubusercontent.com/assets/3596952/12777136/f3b5a154-caae-11e5-8fb1-eeab1eb68bdd.png)
![mag bias](https://cloud.githubusercontent.com/assets/3596952/12777137/f3b8409e-caae-11e5-84f7-ec83d2622fb3.png)
![mag earth](https://cloud.githubusercontent.com/assets/3596952/12777138/f3bc090e-caae-11e5-8de6-95bfff642824.png)
![declination estimate](https://cloud.githubusercontent.com/assets/3596952/12777139/f3bf5ed8-caae-11e5-8f19-e201001c8287.png)
![dvelz bias](https://cloud.githubusercontent.com/assets/3596952/12777141/f3dbafc0-caae-11e5-97a7-e7313f81430d.png)
