### PR TITLE
EKF: Improve control of magnetometer fusion

### DIFF
--- a/EKF/common.h
+++ b/EKF/common.h
@@ -141,6 +141,7 @@ struct parameters {
 	float mag_declination_deg = 0.0f;   // magnetic declination in degrees
 	float heading_innov_gate = 3.0f;    // heading fusion innovation consistency gate size in standard deviations
 	float mag_innov_gate = 3.0f;        // magnetometer fusion innovation consistency gate size in standard deviations
+	int mag_declination_source = 3;     // bitmask used to control the handling of declination data
 
 	// these parameters control the strictness of GPS quality checks used to determine uf the GPS is
 	// good enough to set a local origin and commence aiding
@@ -199,14 +200,15 @@ union gps_check_fail_status_u {
 // bitmask containing filter control status
 union filter_control_status_u {
 	struct {
-		uint8_t angle_align : 1; // 0 - true if the filter angular alignment is complete
-		uint8_t gps         : 1; // 1 - true if GPS measurements are being fused
-		uint8_t opt_flow    : 1; // 2 - true if optical flow measurements are being fused
-		uint8_t mag_hdg     : 1; // 3 - true if a simple magnetic heading is being fused
-		uint8_t mag_3D      : 1; // 4 - true if 3-axis magnetometer measurement are being fused
-		uint8_t mag_dec     : 1; // 5 - true if synthetic magnetic declination measurements are being fused
-		uint8_t in_air      : 1; // 6 - true when the vehicle is airborne
-		uint8_t armed       : 1; // 7 - true when the vehicle motors are armed
+		uint8_t tilt_align  : 1; // 0 - true if the filter tilt alignment is complete
+		uint8_t yaw_align   : 1; // 1 - true if the filter yaw alignment is complete
+		uint8_t gps         : 1; // 2 - true if GPS measurements are being fused
+		uint8_t opt_flow    : 1; // 3 - true if optical flow measurements are being fused
+		uint8_t mag_hdg     : 1; // 4 - true if a simple magnetic heading is being fused
+		uint8_t mag_3D      : 1; // 5 - true if 3-axis magnetometer measurement are being fused
+		uint8_t mag_dec     : 1; // 6 - true if synthetic magnetic declination measurements are being fused
+		uint8_t in_air      : 1; // 7 - true when the vehicle is airborne
+		uint8_t armed       : 1; // 8 - true when the vehicle motors are armed
 	} flags;
 	uint16_t value;
 };

--- a/EKF/common.h
+++ b/EKF/common.h
@@ -142,6 +142,7 @@ struct parameters {
 	float heading_innov_gate = 3.0f;    // heading fusion innovation consistency gate size in standard deviations
 	float mag_innov_gate = 3.0f;        // magnetometer fusion innovation consistency gate size in standard deviations
 	int mag_declination_source = 3;     // bitmask used to control the handling of declination data
+	int mag_fusion_type = 0;            // integer used to specify the type of magnetometer fusioin used
 
 	// these parameters control the strictness of GPS quality checks used to determine uf the GPS is
 	// good enough to set a local origin and commence aiding
@@ -154,6 +155,15 @@ struct parameters {
 	float req_hdrift = 0.3f;    // maximum acceptable horizontal drift speed
 	float req_vdrift = 0.5f;    // maximum acceptable vertical drift speed
 };
+
+// Bit locations for mag_declination_source
+#define MASK_USE_GEO_DECL   (1<<0)  // set to true to use the declination from the geo library when the GPS position becomes available, set to false to always use the EKF2_MAG_DECL value
+#define MASK_SAVE_GEO_DECL  (1<<1)  // set to true to set the EKF2_MAG_DECL parameter to the value returned by the geo library
+
+// Integer definitions for mag_fusion_type
+#define MAG_FUSE_TYPE_AUTO      0   // The selection of either heading or 3D magnetometer fusion will be automatic
+#define MAG_FUSE_TYPE_HEADING   1   // Magnetic heading fusion will alays be used. This is less accurate, but less affected by earth field distortions
+#define MAG_FUSE_TYPE_3D        2   // Magnetometer 3-axis fusion will always be used. This is more accurate, but more affected by localised earth field distortions
 
 struct stateSample {
 	Vector3f    ang_error;

--- a/EKF/control.cpp
+++ b/EKF/control.cpp
@@ -102,22 +102,39 @@ void Ekf::controlFusionModes()
 
 	// Determine if we should use simple magnetic heading fusion which works better when there are large external disturbances
 	// or the more accurate 3-axis fusion
-	if (!_control_status.flags.armed) {
-		// always use simple mag fusion for initial startup
+	if (_params.mag_fusion_type == MAG_FUSE_TYPE_AUTO) {
+		if (!_control_status.flags.armed) {
+			// always use simple mag fusion for initial startup
+			_control_status.flags.mag_hdg = true;
+			_control_status.flags.mag_3D = false;
+
+		} else {
+			if (_control_status.flags.in_air) {
+				// always use 3-axis mag fusion when airborne
+				_control_status.flags.mag_hdg = false;
+				_control_status.flags.mag_3D = true;
+
+			} else {
+				// always use simple heading fusion when on the ground
+				_control_status.flags.mag_hdg = true;
+				_control_status.flags.mag_3D = false;
+			}
+		}
+
+	} else if (_params.mag_fusion_type == MAG_FUSE_TYPE_HEADING) {
+		// always use simple heading fusion
 		_control_status.flags.mag_hdg = true;
 		_control_status.flags.mag_3D = false;
 
-	} else {
-		if (_control_status.flags.in_air) {
-			// always use 3-axis mag fusion when airborne
-			_control_status.flags.mag_hdg = false;
-			_control_status.flags.mag_3D = true;
+	} else if (_params.mag_fusion_type == MAG_FUSE_TYPE_3D) {
+		// always use 3-axis mag fusion
+		_control_status.flags.mag_hdg = false;
+		_control_status.flags.mag_3D = true;
 
-		} else {
-			// always use simple heading fusion when on the ground
-			_control_status.flags.mag_hdg = true;
-			_control_status.flags.mag_3D = false;
-		}
+	} else {
+		// do no magnetometer fusion at all
+		_control_status.flags.mag_hdg = false;
+		_control_status.flags.mag_3D = false;
 	}
 
 	// if we are using 3-axis magnetometer fusion, but without external aiding, then the declination needs to be fused as an observation to prevent long term heading drift

--- a/EKF/ekf.cpp
+++ b/EKF/ekf.cpp
@@ -153,6 +153,9 @@ bool Ekf::update()
 
 		} else if (_control_status.flags.mag_hdg && _control_status.flags.yaw_align) {
 			fuseHeading();
+
+		} else {
+			// do no fusion at all
 		}
 	}
 

--- a/EKF/ekf.h
+++ b/EKF/ekf.h
@@ -127,10 +127,6 @@ private:
 
 	float _mag_declination = 0.0f; // magnetic declination used by reset and fusion functions (rad)
 
-	// Magnetic declination management bit locations
-#define MASK_USE_GEO_DECL   (1<<0)  // set to true to use the declination from the geo library when the GPS position becomes available, set to false to always use the EKF2_MAG_DECL value
-#define MASK_SAVE_GEO_DECL  (1<<1)  // set to true to set the EKF2_MAG_DECL parameter to the value returned by the geo library
-
 	// complementary filter states
 	Vector3f _delta_angle_corr;
 	Vector3f _delta_vel_corr;

--- a/EKF/ekf.h
+++ b/EKF/ekf.h
@@ -125,6 +125,12 @@ private:
 	float _mag_innov_var[3]; // earth magnetic field innovation variance
 	float _heading_innov_var; // heading measurement innovation variance
 
+	float _mag_declination = 0.0f; // magnetic declination used by reset and fusion functions (rad)
+
+	// Magnetic declination management bit locations
+#define MASK_USE_GEO_DECL   (1<<0)  // set to true to use the declination from the geo library when the GPS position becomes available, set to false to always use the EKF2_MAG_DECL value
+#define MASK_SAVE_GEO_DECL  (1<<1)  // set to true to set the EKF2_MAG_DECL parameter to the value returned by the geo library
+
 	// complementary filter states
 	Vector3f _delta_angle_corr;
 	Vector3f _delta_vel_corr;
@@ -178,6 +184,13 @@ private:
 	void fuseVelPosHeight();
 
 	void resetVelocity();
+
+	// reset the heading and magnetic field states using the declination and magnetometer measurements
+	// return true if successful
+	bool resetMagHeading(Vector3f &mag_init);
+
+	// calculate the magnetic declination to be used by the alignment and fusion processing
+	void calcMagDeclination();
 
 	void resetPosition();
 

--- a/EKF/ekf_helper.cpp
+++ b/EKF/ekf_helper.cpp
@@ -127,19 +127,22 @@ bool Ekf::resetMagHeading(Vector3f &mag_init)
 // Calculate the magnetic declination to be used by the alignment and fusion processing
 void Ekf::calcMagDeclination()
 {
-	// set source of magnetic declination
+	// set source of magnetic declination for internal use
 	if (_params.mag_declination_source & MASK_USE_GEO_DECL) {
 		// use parameter value until GPS is available, then use value returned by geo library
 		if (_NED_origin_initialised) {
 			_mag_declination = _mag_declination_gps;
+			_mag_declination_to_save_deg = math::degrees(_mag_declination);
 
 		} else {
 			_mag_declination = math::radians(_params.mag_declination_deg);
+			_mag_declination_to_save_deg = _params.mag_declination_deg;
 		}
 
 	} else {
 		// always use the parameter value
 		_mag_declination = math::radians(_params.mag_declination_deg);
+		_mag_declination_to_save_deg = _params.mag_declination_deg;
 	}
 }
 

--- a/EKF/estimator_interface.cpp
+++ b/EKF/estimator_interface.cpp
@@ -147,6 +147,7 @@ void EstimatorInterface::setGpsData(uint64_t time_usec, struct gps_message *gps)
 		gps_sample_new.hgt = gps->alt / 1e3f;
 
 		_gps_buffer.push(gps_sample_new);
+
 	}
 }
 

--- a/EKF/estimator_interface.h
+++ b/EKF/estimator_interface.h
@@ -226,4 +226,7 @@ protected:
 	fault_status_t _fault_status;
 	bool initialise_interface(uint64_t timestamp);
 	void unallocate_buffers();
+
+	float _mag_declination_gps =
+		0.0f; // magnetic declination returned by the geo library using the last valid GPS position (rad)
 };

--- a/EKF/estimator_interface.h
+++ b/EKF/estimator_interface.h
@@ -165,6 +165,12 @@ public:
 		*time_us = _imu_time_last;
 	}
 
+	// Copy the magnetic declination that we wish to save to the EKF2_MAG_DECL parameter for the next startup
+	void copy_mag_decl_deg(float *val)
+	{
+		*val = _mag_declination_to_save_deg;
+	}
+
 protected:
 
 	parameters _params;		// filter parameters
@@ -229,4 +235,6 @@ protected:
 
 	float _mag_declination_gps =
 		0.0f; // magnetic declination returned by the geo library using the last valid GPS position (rad)
+
+	float _mag_declination_to_save_deg = 0.0f; // magnetic declination to save to EKF2_MAG_DECL (deg)
 };

--- a/EKF/gps_checks.cpp
+++ b/EKF/gps_checks.cpp
@@ -40,6 +40,7 @@
  */
 
 #include "ekf.h"
+#include <mathlib/mathlib.h>
 
 // GPS pre-flight check bit locations
 #define MASK_GPS_NSATS  (1<<0)
@@ -67,6 +68,13 @@ bool Ekf::collect_gps(uint64_t time_usec, struct gps_message *gps)
 			_gps_alt_ref = 1e-3f * (float)gps->alt + _state.pos(2);
 			_NED_origin_initialised = true;
 			_last_gps_origin_time_us = _time_last_imu;
+			// set the magnetic declination returned by the geo library using the current GPS position
+			_mag_declination_gps = math::radians(get_mag_declination(lat, lon));
+
+			// save the declination to the relevant parameter
+			if (_params.mag_declination_source & MASK_SAVE_GEO_DECL) {
+				param_set(param_find("EKF2_MAG_DECL"), &_mag_declination_gps);
+			}
 		}
 	}
 

--- a/EKF/gps_checks.cpp
+++ b/EKF/gps_checks.cpp
@@ -70,11 +70,6 @@ bool Ekf::collect_gps(uint64_t time_usec, struct gps_message *gps)
 			_last_gps_origin_time_us = _time_last_imu;
 			// set the magnetic declination returned by the geo library using the current GPS position
 			_mag_declination_gps = math::radians(get_mag_declination(lat, lon));
-
-			// save the declination to the relevant parameter
-			if (_params.mag_declination_source & MASK_SAVE_GEO_DECL) {
-				param_set(param_find("EKF2_MAG_DECL"), &_mag_declination_gps);
-			}
 		}
 	}
 

--- a/EKF/mag_fusion.cpp
+++ b/EKF/mag_fusion.cpp
@@ -515,7 +515,7 @@ void Ekf::fuseHeading()
 	matrix::Dcm<float> R_to_earth(_state.quat_nominal);
 	matrix::Vector3f mag_earth_pred = R_to_earth * _mag_sample_delayed.mag;
 
-	float innovation = atan2f(mag_earth_pred(1), mag_earth_pred(0)) - math::radians(_params.mag_declination_deg);
+        float innovation = atan2f(mag_earth_pred(1), mag_earth_pred(0)) - _mag_declination;
 
 	innovation = math::constrain(innovation, -0.5f, 0.5f);
 	_heading_innov = innovation;
@@ -694,7 +694,7 @@ void Ekf::fuseDeclination()
 	Kfusion[23] = t14 * (P[23][17] * t25 - P[23][16] * t26);
 
 	// calculate innovation and constrain
-	float innovation = atanf(t4) - math::radians(_params.mag_declination_deg);
+        float innovation = atanf(t4) - _mag_declination;
 	innovation = math::constrain(innovation, -0.5f, 0.5f);
 
 	// zero attitude error states and perform the state correction

--- a/EKF/mag_fusion.cpp
+++ b/EKF/mag_fusion.cpp
@@ -515,7 +515,7 @@ void Ekf::fuseHeading()
 	matrix::Dcm<float> R_to_earth(_state.quat_nominal);
 	matrix::Vector3f mag_earth_pred = R_to_earth * _mag_sample_delayed.mag;
 
-        float innovation = atan2f(mag_earth_pred(1), mag_earth_pred(0)) - _mag_declination;
+	float innovation = atan2f(mag_earth_pred(1), mag_earth_pred(0)) - _mag_declination;
 
 	innovation = math::constrain(innovation, -0.5f, 0.5f);
 	_heading_innov = innovation;
@@ -694,7 +694,7 @@ void Ekf::fuseDeclination()
 	Kfusion[23] = t14 * (P[23][17] * t25 - P[23][16] * t26);
 
 	// calculate innovation and constrain
-        float innovation = atanf(t4) - _mag_declination;
+	float innovation = atanf(t4) - _mag_declination;
 	innovation = math::constrain(innovation, -0.5f, 0.5f);
 
 	// zero attitude error states and perform the state correction


### PR DESCRIPTION
Allow the different magnetometer fusion methods to be selected (heading or 3-axis). The default behaviour is auto selection. This is controlled by the EKF2_MAG_TYPE parameter.

Allow user to specify use of declination from geo_lookup library or EKF2 parameter. The default behaviour is to use the declination from the lookup. This is controlled by the EKF2_DECL_TYPE bitmask parameter.

Allow the value obtained from the table lookup to be saved to EKF2_MAG_DECL parameter in non-volatile memory when the EKF origin is initialised. The default behaviour is to save the parameter for the next start-up, this can be disabled via a parameter setting. This is controlled by the EKF2_DECL_TYPE bitmask parameter.
