### PR TITLE
Correct for sensor noise and baro offset during alignment

### DIFF
--- a/EKF/ekf.cpp
+++ b/EKF/ekf.cpp
@@ -272,9 +272,10 @@ bool Ekf::initialiseFilter(void)
 		// calculate the averaged barometer reading
 		_baro_at_alignment = _baro_sum / (float)_baro_counter;
 
+		// set the velocity to the GPS measurement (by definition, the initial position and height is at the origin)
 		resetVelocity();
-		resetPosition();
 
+		// initialise the state covariance matrix
 		initialiseCovariance();
 
 		return true;

--- a/EKF/ekf.h
+++ b/EKF/ekf.h
@@ -145,6 +145,13 @@ private:
 	uint64_t _last_gps_origin_time_us = 0;              // time the origin was last set (uSec)
 	float _gps_alt_ref = 0.0f;                          // WGS-84 height (m)
 
+	// Variables used to initialise the filter states
+	uint8_t _baro_counter = 0;      // number of baro samples averaged
+	float _baro_sum = 0.0f;         // summed baro measurement
+	uint8_t _mag_counter = 0;       // number of magnetometer samples averaged
+	Vector3f _mag_sum = {};         // summed magnetometer measurement
+	Vector3f _delVel_sum = {};      // summed delta velocity
+	float _baro_at_alignment;       // baro offset relative to alignment position
 
 	gps_check_fail_status_u _gps_check_fail_status;
 

--- a/EKF/ekf.h
+++ b/EKF/ekf.h
@@ -181,6 +181,8 @@ private:
 
 	void resetPosition();
 
+	void resetHeight();
+
 	void makeCovSymetrical();
 
 	void limitCov();

--- a/EKF/ekf_helper.cpp
+++ b/EKF/ekf_helper.cpp
@@ -78,7 +78,7 @@ void Ekf::resetPosition()
 	}
 
 	baroSample baro_newest = _baro_buffer.get_newest();
-	_state.pos(2) = -baro_newest.hgt;
+	_state.pos(2) = _baro_at_alignment - baro_newest.hgt;
 }
 
 #if defined(__PX4_POSIX) && !defined(__PX4_QURT)

--- a/EKF/ekf_helper.cpp
+++ b/EKF/ekf_helper.cpp
@@ -54,7 +54,7 @@ void Ekf::resetVelocity()
 	// if we have a valid GPS measurement use it to initialise velocity states
 	gpsSample gps_newest = _gps_buffer.get_newest();
 
-	if (_time_last_imu - gps_newest.time_us < 100000) {
+	if (_time_last_imu - gps_newest.time_us < 400000) {
 		_state.vel = gps_newest.vel;
 
 	} else {
@@ -66,19 +66,32 @@ void Ekf::resetVelocity()
 // gps measurement then use for position initialisation
 void Ekf::resetPosition()
 {
-	// if we have a valid GPS measurement use it to initialise position states
+	// if we have a fresh GPS measurement, use it to initialise position states and correct the position for the measurement delay
 	gpsSample gps_newest = _gps_buffer.get_newest();
 
-	if (_time_last_imu - gps_newest.time_us < 100000) {
-		_state.pos(0) = gps_newest.pos(0);
-		_state.pos(1) = gps_newest.pos(1);
+	float time_delay = 1e-6f * (float)(_time_last_imu - gps_newest.time_us);
+
+	if (time_delay < 0.4f) {
+		_state.pos(0) = gps_newest.pos(0) + gps_newest.vel(0) * time_delay;
+		_state.pos(1) = gps_newest.pos(1) + gps_newest.vel(1) * time_delay;
 
 	} else {
 		// XXX use the value of the last known position
 	}
+}
 
+// Reset height state using the last baro measurement
+void Ekf::resetHeight()
+{
+	// if we have a valid height measurement, use it to initialise the vertical position state
 	baroSample baro_newest = _baro_buffer.get_newest();
-	_state.pos(2) = _baro_at_alignment - baro_newest.hgt;
+
+	if (_time_last_imu - baro_newest.time_us < 200000) {
+		_state.pos(2) = _baro_at_alignment - baro_newest.hgt;
+
+	} else {
+		// XXX use the value of the last known position
+	}
 }
 
 #if defined(__PX4_POSIX) && !defined(__PX4_QURT)

--- a/EKF/gps_checks.cpp
+++ b/EKF/gps_checks.cpp
@@ -63,7 +63,8 @@ bool Ekf::collect_gps(uint64_t time_usec, struct gps_message *gps)
 			double lat = gps->lat / 1.0e7;
 			double lon = gps->lon / 1.0e7;
 			map_projection_init(&_pos_ref, lat, lon);
-			_gps_alt_ref = gps->alt / 1e3f;
+			// Take the current GPS height and subtract the filter height above origin to estimate the GPS height of the origin
+			_gps_alt_ref = 1e-3f * (float)gps->alt + _state.pos(2);
 			_NED_origin_initialised = true;
 			_last_gps_origin_time_us = _time_last_imu;
 		}

--- a/EKF/vel_pos_fusion.cpp
+++ b/EKF/vel_pos_fusion.cpp
@@ -100,7 +100,7 @@ void Ekf::fuseVelPosHeight()
 	if (_fuse_height) {
 		fuse_map[5] = true;
         // vertical position innovation - baro measurement has opposite sign to earth z axis
-        _vel_pos_innov[5] = _state.pos(2) - (-_baro_sample_delayed.hgt);
+        _vel_pos_innov[5] = _state.pos(2) - (_baro_at_alignment -_baro_sample_delayed.hgt);
         // observation variance - user parameter defined
         R[5] = fmaxf(_params.baro_noise, 0.01f);
         R[5] = R[5] * R[5];


### PR DESCRIPTION
The baro is averaged during alignment and an offset calculated that is used subsequently to ensure that the reported height of the EKF origin is correct, even for in-air GPs gain and that the filter correctly reports both absolute and relative height.

Some additional averaging is used during initialisation of the states to improve accuracy.