### PR TITLE
EKF: Improve control of magnetometer fusion and declination usage

### DIFF
--- a/EKF/common.h
+++ b/EKF/common.h
@@ -211,14 +211,15 @@ union gps_check_fail_status_u {
 // bitmask containing filter control status
 union filter_control_status_u {
 	struct {
-		uint8_t angle_align : 1; // 0 - true if the filter angular alignment is complete
-		uint8_t gps         : 1; // 1 - true if GPS measurements are being fused
-		uint8_t opt_flow    : 1; // 2 - true if optical flow measurements are being fused
-		uint8_t mag_hdg     : 1; // 3 - true if a simple magnetic heading is being fused
-		uint8_t mag_3D      : 1; // 4 - true if 3-axis magnetometer measurement are being fused
-		uint8_t mag_dec     : 1; // 5 - true if synthetic magnetic declination measurements are being fused
-		uint8_t in_air      : 1; // 6 - true when the vehicle is airborne
-		uint8_t armed       : 1; // 7 - true when the vehicle motors are armed
+		uint8_t tilt_align  : 1; // 0 - true if the filter tilt alignment is complete
+		uint8_t yaw_align   : 1; // 1 - true if the filter yaw alignment is complete
+		uint8_t gps         : 1; // 2 - true if GPS measurements are being fused
+		uint8_t opt_flow    : 1; // 3 - true if optical flow measurements are being fused
+		uint8_t mag_hdg     : 1; // 4 - true if a simple magnetic heading is being fused
+		uint8_t mag_3D      : 1; // 5 - true if 3-axis magnetometer measurement are being fused
+		uint8_t mag_dec     : 1; // 6 - true if synthetic magnetic declination measurements are being fused
+		uint8_t in_air      : 1; // 7 - true when the vehicle is airborne
+		uint8_t armed       : 1; // 8 - true when the vehicle motors are armed
 	} flags;
 	uint16_t value;
 };

--- a/EKF/common.h
+++ b/EKF/common.h
@@ -141,6 +141,8 @@ struct parameters {
 	float mag_declination_deg = 0.0f;   // magnetic declination in degrees
 	float heading_innov_gate = 3.0f;    // heading fusion innovation consistency gate size in standard deviations
 	float mag_innov_gate = 3.0f;        // magnetometer fusion innovation consistency gate size in standard deviations
+	int mag_declination_source = 7;     // bitmask used to control the handling of declination data
+	int mag_fusion_type = 0;            // integer used to specify the type of magnetometer fusion used
 
 	// these parameters control the strictness of GPS quality checks used to determine uf the GPS is
 	// good enough to set a local origin and commence aiding
@@ -153,6 +155,16 @@ struct parameters {
 	float req_hdrift = 0.3f;    // maximum acceptable horizontal drift speed
 	float req_vdrift = 0.5f;    // maximum acceptable vertical drift speed
 };
+
+// Bit locations for mag_declination_source
+#define MASK_USE_GEO_DECL   (1<<0)  // set to true to use the declination from the geo library when the GPS position becomes available, set to false to always use the EKF2_MAG_DECL value
+#define MASK_SAVE_GEO_DECL  (1<<1)  // set to true to set the EKF2_MAG_DECL parameter to the value returned by the geo library
+#define MASK_FUSE_DECL      (1<<2)  // set to true if the declination is always fused as an observation to contrain drift when 3-axis fusion is performed
+
+// Integer definitions for mag_fusion_type
+#define MAG_FUSE_TYPE_AUTO      0   // The selection of either heading or 3D magnetometer fusion will be automatic
+#define MAG_FUSE_TYPE_HEADING   1   // Magnetic heading fusion will alays be used. This is less accurate, but less affected by earth field distortions
+#define MAG_FUSE_TYPE_3D        2   // Magnetometer 3-axis fusion will always be used. This is more accurate, but more affected by localised earth field distortions
 
 struct stateSample {
 	Vector3f    ang_error;	// attitude axis angle error (error state formulation)

--- a/EKF/control.cpp
+++ b/EKF/control.cpp
@@ -46,6 +46,9 @@ void Ekf::controlFusionModes()
 	// Determine the vehicle status
 	calculateVehicleStatus();
 
+	// Get the magnetic declination
+	calcMagDeclination();
+
 	// optical flow fusion mode selection logic
 	_control_status.flags.opt_flow = false;
 

--- a/EKF/control.cpp
+++ b/EKF/control.cpp
@@ -57,9 +57,15 @@ void Ekf::controlFusionModes()
 	if (!_control_status.flags.gps) {
 		if (_control_status.flags.tilt_align && (_time_last_imu - _time_last_gps) < 5e5 && _NED_origin_initialised
 		    && (_time_last_imu - _last_gps_fail_us > 5e6)) {
-			_control_status.flags.gps = true;
+			// Reset the yaw and magnetic field states
+			_control_status.flags.yaw_align = resetMagHeading(_mag_sample_delayed.mag);
+
+			// If the heading is valid, reset the positon and velocity and start using gps aiding
+			if (_control_status.flags.yaw_align) {
 			resetPosition();
 			resetVelocity();
+				_control_status.flags.gps = true;
+			}
 		}
 	}
 

--- a/EKF/control.cpp
+++ b/EKF/control.cpp
@@ -53,9 +53,9 @@ void Ekf::controlFusionModes()
 	_control_status.flags.opt_flow = false;
 
 	// GPS fusion mode selection logic
-	// To start use GPS we need angular alignment completed, the local NED origin set and fresh GPS data
+	// To start using GPS we need tilt and yaw alignment completed, the local NED origin set and fresh GPS data
 	if (!_control_status.flags.gps) {
-		if (_control_status.flags.angle_align && (_time_last_imu - _time_last_gps) < 5e5 && _NED_origin_initialised
+		if (_control_status.flags.tilt_align && (_time_last_imu - _time_last_gps) < 5e5 && _NED_origin_initialised
 		    && (_time_last_imu - _last_gps_fail_us > 5e6)) {
 			_control_status.flags.gps = true;
 			resetPosition();

--- a/EKF/control.cpp
+++ b/EKF/control.cpp
@@ -62,8 +62,8 @@ void Ekf::controlFusionModes()
 
 			// If the heading is valid, reset the positon and velocity and start using gps aiding
 			if (_control_status.flags.yaw_align) {
-			resetPosition();
-			resetVelocity();
+				resetPosition();
+				resetVelocity();
 				_control_status.flags.gps = true;
 			}
 		}
@@ -101,31 +101,50 @@ void Ekf::controlFusionModes()
 
 	// Determine if we should use simple magnetic heading fusion which works better when there are large external disturbances
 	// or the more accurate 3-axis fusion
-	if (!_control_status.flags.armed) {
-		// always use simple mag fusion for initial startup
+	if (_params.mag_fusion_type == MAG_FUSE_TYPE_AUTO) {
+		if (!_control_status.flags.armed) {
+			// always use simple mag fusion for initial startup
+			_control_status.flags.mag_hdg = true;
+			_control_status.flags.mag_3D = false;
+
+		} else {
+			if (_control_status.flags.in_air) {
+				// always use 3-axis mag fusion when airborne
+				_control_status.flags.mag_hdg = false;
+				_control_status.flags.mag_3D = true;
+
+			} else {
+				// always use simple heading fusion when on the ground
+				_control_status.flags.mag_hdg = true;
+				_control_status.flags.mag_3D = false;
+			}
+		}
+
+	} else if (_params.mag_fusion_type == MAG_FUSE_TYPE_HEADING) {
+		// always use simple heading fusion
 		_control_status.flags.mag_hdg = true;
 		_control_status.flags.mag_3D = false;
 
-	} else {
-		if (_control_status.flags.in_air) {
-			// always use 3-axis mag fusion when airborne
-			_control_status.flags.mag_hdg = false;
-			_control_status.flags.mag_3D = true;
+	} else if (_params.mag_fusion_type == MAG_FUSE_TYPE_3D) {
+		// always use 3-axis mag fusion
+		_control_status.flags.mag_hdg = false;
+		_control_status.flags.mag_3D = true;
 
-		} else {
-			// always use simple heading fusion when on the ground
-			_control_status.flags.mag_hdg = true;
-			_control_status.flags.mag_3D = false;
-		}
+	} else {
+		// do no magnetometer fusion at all
+		_control_status.flags.mag_hdg = false;
+		_control_status.flags.mag_3D = false;
 	}
 
-	// if we are using 3-axis magnetometer fusion, but without external aiding, then the declination needs to be fused as an observation to prevent long term heading drift
-	if (_control_status.flags.mag_3D && !_control_status.flags.gps) {
+	// if we are using 3-axis magnetometer fusion, but without external aiding, then the declination must be fused as an observation to prevent long term heading drift
+	// fusing declination when gps aiding is available is optional, but recommneded to prevent problem if the vehicle is static for extended periods of time
+	if (_control_status.flags.mag_3D && (!_control_status.flags.gps || (_params.mag_declination_source & MASK_FUSE_DECL))) {
 		_control_status.flags.mag_dec = true;
 
 	} else {
 		_control_status.flags.mag_dec = false;
 	}
+
 }
 
 void Ekf::calculateVehicleStatus()

--- a/EKF/ekf.cpp
+++ b/EKF/ekf.cpp
@@ -143,15 +143,18 @@ bool Ekf::update()
 
 	// Fuse magnetometer data using the selected fuson method and only if angular alignment is complete
 	if (_mag_buffer.pop_first_older_than(_imu_sample_delayed.time_us, &_mag_sample_delayed)) {
-		if (_control_status.flags.mag_3D && _control_status.flags.angle_align) {
+		if (_control_status.flags.mag_3D && _control_status.flags.yaw_align) {
 			fuseMag();
 
 			if (_control_status.flags.mag_dec) {
 				fuseDeclination();
 			}
 
-		} else if (_control_status.flags.mag_hdg && _control_status.flags.angle_align) {
+		} else if (_control_status.flags.mag_hdg && _control_status.flags.yaw_align) {
 			fuseHeading();
+
+		} else {
+			// do no fusion at all
 		}
 	}
 

--- a/EKF/ekf.cpp
+++ b/EKF/ekf.cpp
@@ -246,27 +246,17 @@ bool Ekf::initialiseFilter(void)
 			return false;
 		}
 
+		// calculate initial tilt alignment
+		matrix::Euler<float> euler_init(roll, pitch, 0.0f);
+		_state.quat_nominal = Quaternion(euler_init);
+		_output_new.quat_nominal = _state.quat_nominal;
+		_control_status.flags.tilt_align = true;
+
 		// calculate the averaged magnetometer reading
 		Vector3f mag_init = _mag_sum * (1.0f / (float(_mag_counter)));
 
-		// rotate magnetic field into earth frame assuming zero yaw and estimate yaw angle assuming zero declination
-		// TODO use declination if available
-		matrix::Euler<float> euler_init(roll, pitch, 0.0f);
-		matrix::Dcm<float> R_to_earth_zeroyaw(euler_init);
-		Vector3f mag_ef_zeroyaw = R_to_earth_zeroyaw * mag_init;
-		float declination = 0.0f;
-		euler_init(2) = declination - atan2f(mag_ef_zeroyaw(1), mag_ef_zeroyaw(0));
-
-		// calculate initial quaternion states
-		_state.quat_nominal = Quaternion(euler_init);
-		_output_new.quat_nominal = _state.quat_nominal;
-
-		// TODO replace this with a conditional test based on fitered angle error states.
-		_control_status.flags.angle_align = true;
-
-		// calculate initial earth magnetic field states
-		matrix::Dcm<float> R_to_earth(euler_init);
-		_state.mag_I = R_to_earth * mag_init;
+		// calculate the initial magnetic field and yaw alignment
+		_control_status.flags.yaw_align = resetMagHeading(mag_init);
 
 		// calculate the averaged barometer reading
 		_baro_at_alignment = _baro_sum / (float)_baro_counter;

--- a/EKF/ekf.h
+++ b/EKF/ekf.h
@@ -242,4 +242,10 @@ private:
 	{
 		return var * var;
 	}
+
+	// zero the specified range of rows in the state covariance matricx
+	void zeroRows(float (&cov_mat)[_k_num_states][_k_num_states], uint8_t first, uint8_t last);
+
+	// zero the specified range of columns in the state covariance matricx
+	void zeroCols(float (&cov_mat)[_k_num_states][_k_num_states], uint8_t first, uint8_t last);
 };

--- a/EKF/ekf.h
+++ b/EKF/ekf.h
@@ -201,6 +201,9 @@ private:
 	// return true if successful
 	bool resetMagHeading(Vector3f &mag_init);
 
+	// calculate the magnetic declination to be used by the alignment and fusion processing
+	void calcMagDeclination();
+
 	// reset position states of the ekf (only vertical position)
 	void resetPosition();
 

--- a/EKF/ekf.h
+++ b/EKF/ekf.h
@@ -128,6 +128,8 @@ private:
 	float _mag_innov_var[3]; // earth magnetic field innovation variance
 	float _heading_innov_var; // heading measurement innovation variance
 
+	float _mag_declination = 0.0f; // magnetic declination used by reset and fusion functions (rad)
+
 	// complementary filter states
 	Vector3f _delta_angle_corr;	// delta angle correction vector
 	Vector3f _delta_vel_corr;	// delta velocity correction vector
@@ -194,6 +196,10 @@ private:
 
 	// reset velocity states of the ekf
 	void resetVelocity();
+
+	// reset the heading and magnetic field states using the declination and magnetometer measurements
+	// return true if successful
+	bool resetMagHeading(Vector3f &mag_init);
 
 	// reset position states of the ekf (only vertical position)
 	void resetPosition();

--- a/EKF/ekf_helper.cpp
+++ b/EKF/ekf_helper.cpp
@@ -124,6 +124,28 @@ bool Ekf::resetMagHeading(Vector3f &mag_init)
 	return true;
 }
 
+// Calculate the magnetic declination to be used by the alignment and fusion processing
+void Ekf::calcMagDeclination()
+{
+	// set source of magnetic declination for internal use
+	if (_params.mag_declination_source & MASK_USE_GEO_DECL) {
+		// use parameter value until GPS is available, then use value returned by geo library
+		if (_NED_origin_initialised) {
+			_mag_declination = _mag_declination_gps;
+			_mag_declination_to_save_deg = math::degrees(_mag_declination);
+
+		} else {
+			_mag_declination = math::radians(_params.mag_declination_deg);
+			_mag_declination_to_save_deg = _params.mag_declination_deg;
+		}
+
+	} else {
+		// always use the parameter value
+		_mag_declination = math::radians(_params.mag_declination_deg);
+		_mag_declination_to_save_deg = _params.mag_declination_deg;
+	}
+}
+
 // This function forces the covariance matrix to be symmetric
 void Ekf::makeSymmetrical()
 {

--- a/EKF/estimator_interface.h
+++ b/EKF/estimator_interface.h
@@ -154,6 +154,12 @@ public:
 		*time_us = _time_last_imu;
 	}
 
+	// Copy the magnetic declination that we wish to save to the EKF2_MAG_DECL parameter for the next startup
+	void copy_mag_decl_deg(float *val)
+	{
+		*val = _mag_declination_to_save_deg;
+	}
+
 protected:
 
 	parameters _params;		// filter parameters
@@ -220,4 +226,9 @@ protected:
 
 	// free buffer memory
 	void unallocate_buffers();
+
+	float _mag_declination_gps =
+		0.0f; // magnetic declination returned by the geo library using the last valid GPS position (rad)
+
+	float _mag_declination_to_save_deg = 0.0f; // magnetic declination to save to EKF2_MAG_DECL (deg)
 };

--- a/EKF/gps_checks.cpp
+++ b/EKF/gps_checks.cpp
@@ -40,6 +40,7 @@
  */
 
 #include "ekf.h"
+#include <mathlib/mathlib.h>
 
 // GPS pre-flight check bit locations
 #define MASK_GPS_NSATS  (1<<0)
@@ -67,6 +68,8 @@ bool Ekf::collect_gps(uint64_t time_usec, struct gps_message *gps)
 			_gps_alt_ref = 1e-3f * (float)gps->alt + _state.pos(2);
 			_NED_origin_initialised = true;
 			_last_gps_origin_time_us = _time_last_imu;
+			// set the magnetic declination returned by the geo library using the current GPS position
+			_mag_declination_gps = math::radians(get_mag_declination(lat, lon));
 		}
 	}
 

--- a/EKF/mag_fusion.cpp
+++ b/EKF/mag_fusion.cpp
@@ -515,7 +515,7 @@ void Ekf::fuseHeading()
 	matrix::Dcm<float> R_to_earth(_state.quat_nominal);
 	matrix::Vector3f mag_earth_pred = R_to_earth * _mag_sample_delayed.mag;
 
-	float innovation = atan2f(mag_earth_pred(1), mag_earth_pred(0)) - math::radians(_params.mag_declination_deg);
+	float innovation = atan2f(mag_earth_pred(1), mag_earth_pred(0)) - _mag_declination;
 
 	innovation = math::constrain(innovation, -0.5f, 0.5f);
 	_heading_innov = innovation;
@@ -694,7 +694,7 @@ void Ekf::fuseDeclination()
 	Kfusion[23] = t14 * (P[23][17] * t25 - P[23][16] * t26);
 
 	// calculate innovation and constrain
-	float innovation = atanf(t4) - math::radians(_params.mag_declination_deg);
+	float innovation = atanf(t4) - _mag_declination;
 	innovation = math::constrain(innovation, -0.5f, 0.5f);
 
 	// zero attitude error states and perform the state correction


### PR DESCRIPTION
Add a parameter allowing the different magnetometer fusion methods to be selected (heading or 3-axis). The default behaviour is auto selection. 

Add a parameter allowing the user to specify use of declination from geo_lookup library or EKF2 parameter. The default behaviour is to use the declination from the lookup. 

Publish the declination to be saved to non-volatile memory for the next startup.

TODO: The corresponding parameters need to be added on the PX4 side to enable tuning over mavlink.
TODO: The published declination needs to be saved to the EKF2_MAG_DECL parameter on disarm

This has been successfully flight tested with PX4 master with just the ecl library reference updated to point to the head of this branch:

http://logs.uaventure.com/view/RV6Yoa4jvKuAqS8oafwUuF
http://logs.uaventure.com/view/iEi9hroV6qvyrBb3jn3oFD
http://logs.uaventure.com/view/zayVJwSkEpBdDzEn6zSNwD

I need some support with implementing the parameter save on the PX4 side. I have a branch here, but it is generating unpredictable behaviour at run-time. 

https://github.com/priseborough/Firmware/tree/pr-ekf2MagFusionControl