### PR TITLE
Fix bug in magnetic heading fusion

### DIFF
--- a/EKF/common.h
+++ b/EKF/common.h
@@ -163,8 +163,9 @@ struct parameters {
 
 // Integer definitions for mag_fusion_type
 #define MAG_FUSE_TYPE_AUTO      0   // The selection of either heading or 3D magnetometer fusion will be automatic
-#define MAG_FUSE_TYPE_HEADING   1   // Magnetic heading fusion will alays be used. This is less accurate, but less affected by earth field distortions
+#define MAG_FUSE_TYPE_HEADING   1   // Simple yaw angle fusion will always be used. This is less accurate, but less affected by earth field distortions. It should not be used for pitch angles outside the range from -60 to +60 deg
 #define MAG_FUSE_TYPE_3D        2   // Magnetometer 3-axis fusion will always be used. This is more accurate, but more affected by localised earth field distortions
+#define MAG_FUSE_TYPE_2D        3   // A 2D fusion that uses the horizontal projection of the magnetic fields measurement will alays be used. This is less accurate, but less affected by earth field distortions.
 
 struct stateSample {
 	Vector3f    ang_error;	// attitude axis angle error (error state formulation)
@@ -215,12 +216,13 @@ union filter_control_status_u {
 		uint8_t yaw_align   : 1; // 1 - true if the filter yaw alignment is complete
 		uint8_t gps         : 1; // 2 - true if GPS measurements are being fused
 		uint8_t opt_flow    : 1; // 3 - true if optical flow measurements are being fused
-		uint8_t mag_hdg     : 1; // 4 - true if a simple magnetic heading is being fused
-		uint8_t mag_3D      : 1; // 5 - true if 3-axis magnetometer measurement are being fused
-		uint8_t mag_dec     : 1; // 6 - true if synthetic magnetic declination measurements are being fused
-		uint8_t in_air      : 1; // 7 - true when the vehicle is airborne
-		uint8_t armed       : 1; // 8 - true when the vehicle motors are armed
-		uint8_t wind        : 1; // 9 - true when wind velocity is being estimated
+		uint8_t mag_hdg     : 1; // 4 - true if a simple magnetic yaw heading is being fused
+		uint8_t mag_2D      : 1; // 5 - true if the horizontal projection of magnetometer data is being fused
+		uint8_t mag_3D      : 1; // 6 - true if 3-axis magnetometer measurement are being fused
+		uint8_t mag_dec     : 1; // 7 - true if synthetic magnetic declination measurements are being fused
+		uint8_t in_air      : 1; // 8 - true when the vehicle is airborne
+		uint8_t armed       : 1; // 9 - true when the vehicle motors are armed
+		uint8_t wind        : 1; // 10 - true when wind velocity is being estimated
 	} flags;
 	uint16_t value;
 };

--- a/EKF/control.cpp
+++ b/EKF/control.cpp
@@ -103,36 +103,55 @@ void Ekf::controlFusionModes()
 	// or the more accurate 3-axis fusion
 	if (_params.mag_fusion_type == MAG_FUSE_TYPE_AUTO) {
 		if (!_control_status.flags.armed) {
-			// always use simple mag fusion for initial startup
-			_control_status.flags.mag_hdg = true;
+			// always use 2D mag fusion for initial startup
+			_control_status.flags.mag_hdg = false;
+			_control_status.flags.mag_2D = true;
 			_control_status.flags.mag_3D = false;
 
 		} else {
 			if (_control_status.flags.in_air) {
-				// always use 3-axis mag fusion when airborne
+				// always use 3D mag fusion when airborne
 				_control_status.flags.mag_hdg = false;
+				_control_status.flags.mag_2D = false;
 				_control_status.flags.mag_3D = true;
 
 			} else {
-				// always use simple heading fusion when on the ground
-				_control_status.flags.mag_hdg = true;
+				// always use 2D mag fusion when on the ground
+				_control_status.flags.mag_hdg = false;
+				_control_status.flags.mag_2D = true;
 				_control_status.flags.mag_3D = false;
 			}
 		}
 
 	} else if (_params.mag_fusion_type == MAG_FUSE_TYPE_HEADING) {
-		// always use simple heading fusion
-		_control_status.flags.mag_hdg = true;
+		// always use yaw fusion unless tilt is over 45 deg, otherwise use 2D fusion
+		if (_R_prev(2, 2) > 0.7071f) {
+			_control_status.flags.mag_hdg = true;
+			_control_status.flags.mag_2D = false;
+
+		} else {
+			_control_status.flags.mag_hdg = false;
+			_control_status.flags.mag_2D = true;
+		}
+
+		_control_status.flags.mag_3D = false;
+
+	} else if (_params.mag_fusion_type == MAG_FUSE_TYPE_2D) {
+		// always use 2D mag fusion
+		_control_status.flags.mag_hdg = false;
+		_control_status.flags.mag_2D = true;
 		_control_status.flags.mag_3D = false;
 
 	} else if (_params.mag_fusion_type == MAG_FUSE_TYPE_3D) {
 		// always use 3-axis mag fusion
 		_control_status.flags.mag_hdg = false;
+		_control_status.flags.mag_2D = false;
 		_control_status.flags.mag_3D = true;
 
 	} else {
 		// do no magnetometer fusion at all
 		_control_status.flags.mag_hdg = false;
+		_control_status.flags.mag_2D = false;
 		_control_status.flags.mag_3D = false;
 	}
 

--- a/EKF/ekf.cpp
+++ b/EKF/ekf.cpp
@@ -150,6 +150,9 @@ bool Ekf::update()
 				fuseDeclination();
 			}
 
+		} else if (_control_status.flags.mag_2D && _control_status.flags.yaw_align) {
+			fuseMag2D();
+
 		} else if (_control_status.flags.mag_hdg && _control_status.flags.yaw_align) {
 			fuseHeading();
 

--- a/EKF/ekf.h
+++ b/EKF/ekf.h
@@ -183,8 +183,11 @@ private:
 	// ekf sequential fusion of magnetometer measurements
 	void fuseMag();
 
-	// fuse magnetometer heading measurement
+	// fuse heading measurement (currently uses estimate from magnetometer)
 	void fuseHeading();
+
+	// fuse projecton of magnetometer onto horizontal plane
+	void fuseMag2D();
 
 	// fuse magnetometer declination measurement
 	void fuseDeclination();

--- a/EKF/mag_fusion.cpp
+++ b/EKF/mag_fusion.cpp
@@ -532,12 +532,15 @@ void Ekf::fuseHeading()
 	H_YAW[1] = t14 * (t15 * (q0 * q1 * 2.0f - q2 * q3 * 2.0f) + t9 * t10 * (q0 * q2 * 2.0f + q1 * q3 * 2.0f));
 	H_YAW[2] = t14 * (t15 * (t2 - t3 + t4 - t5) + t9 * t10 * (t7 - t8));
 
-	// calculate innovation
-	// rotate body field magnetic field measurement into earth frame and compare to published declination to get heading measurement
-	// TODO - enable use of an off-board heading measurement
+	// rotate body field magnetic field measurement into earth frame and compare horizontal vector with published declination to get yaw measurement
+	// TODO - enable use of an off-board yaw measurement
 	matrix::Dcm<float> R_to_earth(_state.quat_nominal);
 	matrix::Vector3f mag_earth_pred = R_to_earth * _mag_sample_delayed.mag;
-	float innovation = atan2f(mag_earth_pred(1), mag_earth_pred(0)) - _mag_declination;
+	float measured_yaw = atan2f(mag_earth_pred(1), mag_earth_pred(0)) - _mag_declination;
+
+	// calculate the innovation
+	matrix::Euler<float> euler(_state.quat_nominal);
+	float innovation = euler(2) - measured_yaw;
 
 	// wrap the innovation to the interval between +-pi
 	innovation = matrix::wrap_pi(innovation);

--- a/EKF/mag_fusion.cpp
+++ b/EKF/mag_fusion.cpp
@@ -613,6 +613,9 @@ void Ekf::fuseHeading()
 	matrix::Vector3f mag_earth_pred = R_to_earth * _mag_sample_delayed.mag;
 	float measured_yaw = atan2f(mag_earth_pred(1), mag_earth_pred(0)) - _mag_declination;
 
+	// wrap the yaw to the interval between +-pi
+	measured_yaw = matrix::wrap_pi(measured_yaw);
+
 	// calculate the innovation
 	matrix::Euler<float> euler(_state.quat_nominal);
 	float innovation = euler(2) - measured_yaw;

--- a/EKF/mag_fusion.cpp
+++ b/EKF/mag_fusion.cpp
@@ -495,7 +495,7 @@ void Ekf::fuseHeading()
 	float R_YAW = fmaxf(_params.mag_heading_noise, 1.0e-2f);
 	R_YAW = R_YAW * R_YAW;
 
-	// calculate intermediate variables for observation jacobian
+	// calculate intermediate variables for observation jacobians
 	float t2 = q0 * q0;
 	float t3 = q1 * q1;
 	float t4 = q2 * q2;
@@ -509,7 +509,7 @@ void Ekf::fuseHeading()
 	if (fabsf(t6) > 1e-6f) {
 		t10 = 1.0f / (t6 * t6);
 
-	} else  {
+	} else {
 		return;
 	}
 
@@ -527,10 +527,85 @@ void Ekf::fuseHeading()
 
 	float t15 = 1.0f / t6;
 
-	// calculate observation jacobian
 	float H_YAW[3] = {};
 	H_YAW[1] = t14 * (t15 * (q0 * q1 * 2.0f - q2 * q3 * 2.0f) + t9 * t10 * (q0 * q2 * 2.0f + q1 * q3 * 2.0f));
-	H_YAW[2] = t14 * (t15 * (t2 - t3 + t4 - t5) + t9 * t10 * (t7 - t8));
+	H_YAW[2] = t14 * (t15 * (t2 - t3 + t4 - t5) + t9 * t10 * (t7 - t8));	// calculate observation jacobian
+
+	// calculate Kalman gains
+	float t16 = q0 * q1 * 2.0f;
+	float t29 = q2 * q3 * 2.0f;
+	float t17 = t16 - t29;
+	float t18 = t15 * t17;
+	float t19 = q0 * q2 * 2.0f;
+	float t20 = q1 * q3 * 2.0f;
+	float t21 = t19 + t20;
+	float t22 = t9 * t10 * t21;
+	float t23 = t18 + t22;
+	float t40 = t14 * t23;
+	float t24 = t2 - t3 + t4 - t5;
+	float t25 = t15 * t24;
+	float t26 = t7 - t8;
+	float t27 = t9 * t10 * t26;
+	float t28 = t25 + t27;
+	float t41 = t14 * t28;
+	float t30 = P[1][1] * t40;
+	float t31 = P[1][2] * t40;
+	float t32 = P[2][2] * t41;
+	float t33 = t31 + t32;
+	float t34 = t41 * t33;
+	float t35 = P[2][1] * t41;
+	float t36 = t30 + t35;
+	float t37 = t40 * t36;
+	float t38 = R_YAW + t34 + t37; // Innovation variance
+	float t39;
+
+	if (t38 >= R_YAW) {
+		// the innovation variance contribution from the state covariances is not negative, no fault
+		_fault_status.bad_mag_hdg = false;
+		t39 = 1.0f / t38;
+		_heading_innov_var = t38;
+
+	} else {
+		// the innovation variance contribution from the state covariances is negative which means the covariance matrix is badly conditioned
+		_fault_status.bad_mag_hdg = true;
+
+		// we reinitialise the covariance matrix and abort this fusion step
+		initialiseCovariance();
+		return;
+	}
+
+	float Kfusion[24] = {};
+	Kfusion[0] = t39 * (P[0][1] * t40 + P[0][2] * t41);
+	Kfusion[1] = t39 * (t30 + P[1][2] * t41);
+	Kfusion[2] = t39 * (t32 + P[2][1] * t40);
+	Kfusion[3] = t39 * (P[3][1] * t40 + P[3][2] * t41);
+	Kfusion[4] = t39 * (P[4][1] * t40 + P[4][2] * t41);
+	Kfusion[5] = t39 * (P[5][1] * t40 + P[5][2] * t41);
+	Kfusion[6] = t39 * (P[6][1] * t40 + P[6][2] * t41);
+	Kfusion[7] = t39 * (P[7][1] * t40 + P[7][2] * t41);
+	Kfusion[8] = t39 * (P[8][1] * t40 + P[8][2] * t41);
+	Kfusion[9] = t39 * (P[9][1] * t40 + P[9][2] * t41);
+	Kfusion[10] = t39 * (P[10][1] * t40 + P[10][2] * t41);
+	Kfusion[11] = t39 * (P[11][1] * t40 + P[11][2] * t41);
+	Kfusion[12] = t39 * (P[12][1] * t40 + P[12][2] * t41);
+	Kfusion[13] = t39 * (P[13][1] * t40 + P[13][2] * t41);
+	Kfusion[14] = t39 * (P[14][1] * t40 + P[14][2] * t41);
+	Kfusion[15] = t39 * (P[15][1] * t40 + P[15][2] * t41);
+
+	/* we won't be using these states because we are doing heading fusion
+	Kfusion[16] = t39*(P[16][1]*t40+P[16][2]*t41);
+	Kfusion[17] = t39*(P[17][1]*t40+P[17][2]*t41);
+	Kfusion[18] = t39*(P[18][1]*t40+P[18][2]*t41);
+	Kfusion[19] = t39*(P[19][1]*t40+P[19][2]*t41);
+	Kfusion[20] = t39*(P[20][1]*t40+P[20][2]*t41);
+	Kfusion[21] = t39*(P[21][1]*t40+P[21][2]*t41);
+	*/
+
+	// don't adjust these states if we are not using them
+	if (_control_status.flags.wind) {
+		Kfusion[22] = t39 * (P[22][1] * t40 + P[22][2] * t41);
+		Kfusion[23] = t39 * (P[23][1] * t40 + P[23][2] * t41);
+	}
 
 	// rotate body field magnetic field measurement into earth frame and compare horizontal vector with published declination to get yaw measurement
 	// TODO - enable use of an off-board yaw measurement
@@ -546,70 +621,8 @@ void Ekf::fuseHeading()
 	innovation = matrix::wrap_pi(innovation);
 	_heading_innov = innovation;
 
-	// calculate innovation variance
-	float innovation_var = R_YAW;
-	_heading_innov_var = innovation_var;
-	float PH[3] = {};
-
-	for (unsigned row = 0; row < 3; row++) {
-		for (unsigned column = 0; column < 3; column++) {
-			PH[row] += P[row][column] * H_YAW[column];
-		}
-
-		innovation_var += H_YAW[row] * PH[row];
-	}
-
-	if (innovation_var >= R_YAW) {
-		// the innovation variance contribution from the state covariances is not negative, no fault
-		_fault_status.bad_mag_hdg = false;
-
-	} else {
-		// the innovation variance contribution from the state covariances is negative which means the covariance matrix is badly conditioned
-		_fault_status.bad_mag_hdg = true;
-
-		// we reinitialise the covariance matrix and abort this fusion step
-		initialiseCovariance();
-		return;
-	}
-
-	float innovation_var_inv = 1.0f / innovation_var;
-
-	// calculate the kalman gains taking dvantage of the reduce size of H_YAW
-	float Kfusion[_k_num_states] = {};
-
-	// gains for states that are always used
-	for (unsigned row = 0; row <= 15; row++) {
-		for (unsigned column = 0; column < 3; column++) {
-			Kfusion[row] += P[row][column] * H_YAW[column];
-		}
-
-		Kfusion[row] *= innovation_var_inv;
-	}
-
-	// only calculate gains for magnetic field states if they are being used
-	if (_control_status.flags.mag_3D) {
-		for (unsigned row = 16; row <= 21; row++) {
-			for (unsigned column = 0; column < 3; column++) {
-				Kfusion[row] += P[row][column] * H_YAW[column];
-			}
-
-			Kfusion[row] *= innovation_var_inv;
-		}
-	}
-
-	// only calculate gains for wind states if they are being used
-	if (_control_status.flags.wind) {
-		for (unsigned row = 22; row <= 23; row++) {
-			for (unsigned column = 0; column < 3; column++) {
-				Kfusion[row] += P[row][column] * H_YAW[column];
-			}
-
-			Kfusion[row] *= innovation_var_inv;
-		}
-	}
-
 	// innovation test ratio
-	_yaw_test_ratio = sq(innovation) / (sq(math::max(_params.heading_innov_gate, 1.0f)) * innovation_var);
+	_yaw_test_ratio = sq(innovation) / (sq(math::max(_params.heading_innov_gate, 1.0f)) * _heading_innov_var);
 
 	// set the magnetometer unhealthy if the test fails
 	if (_yaw_test_ratio > 1.0f) {
@@ -623,7 +636,7 @@ void Ekf::fuseHeading()
 
 		} else {
 			// constrain the innovation to the maximum set by the gate
-			float gate_limit = sqrtf((sq(math::max(_params.heading_innov_gate, 1.0f)) * innovation_var));
+			float gate_limit = sqrtf((sq(math::max(_params.heading_innov_gate, 1.0f)) * _heading_innov_var));
 			innovation = math::constrain(innovation, -gate_limit, gate_limit);
 		}
 
@@ -645,7 +658,7 @@ void Ekf::fuseHeading()
 	float HP[_k_num_states] = {};
 
 	for (unsigned column = 0; column < _k_num_states; column++) {
-		for (unsigned row = 0; row < 3; row++) {
+		for (unsigned row = 1; row <= 2; row++) {
 			HP[column] += H_YAW[row] * P[row][column];
 		}
 	}

--- a/matlab/generated/Inertial Nav EKF/Simple Magnetometer Fusion.txt
+++ b/matlab/generated/Inertial Nav EKF/Simple Magnetometer Fusion.txt
@@ -1,32 +1,57 @@
 /* 
-Autocode for fusion of a yaw error measurement where the innovation is given by: 
+Observation jacobian for fusion of the horizontal components of magnetometer measurements.
 
-innovation = atan2f(magMeasEarthFrameEast,magMeasEarthFrameNorth) - declinationAngle;
+innovation = atan2(magE/magN) - declination, where magN and magE are the North and East components obtained
+by rotating the measured magnetometer readings from body into earth axes.
 
-magMeasEarthFrameEast and magMeasEarthFrameNorth are obtained by rotating the magnetometer measurements from body frame to eath frame.
-declinationAngle is the estimated declination as that location
+This method of fusion reduces roll and pitch errors due to external field disturbances and is suitable for initial alignment and ground / indoor use
 
-Protection against /0 and covariance matrix errors will need to be added.
+Divide by zero protection hs been added
 */
 
-// intermediate variables
+// calculate intermediate variables for observation jacobian
 float t2 = q0*q0;
 float t3 = q1*q1;
 float t4 = q2*q2;
 float t5 = q3*q3;
-float t6 = t2+t3-t4-t5;
-float t7 = q0*q3*2.0f;
-float t8 = q1*q2*2.0f;
-float t9 = t7+t8;
-float t10 = 1.0f/(t6*t6);
-float t11 = t9*t9;
-float t12 = t10*t11;
-float t13 = t12+1.0f;
-float t14 = 1.0f/t13;
-float t15 = 1.0f/t6;
+float t6 = q0*q3*2.0f;
+float t8 = t2-t3+t4-t5;
+float t9 = q0*q1*2.0f;
+float t10 = q2*q3*2.0f;
+float t11 = t9-t10;
+float t14 = q1*q2*2.0f;
+float t21 = magY*t8;
+float t22 = t6+t14;
+float t23 = magX*t22;
+float t24 = magZ*t11;
+float t7 = t21+t23-t24;
+float t12 = t2+t3-t4-t5;
+float t13 = magX*t12;
+float t15 = q0*q2*2.0f;
+float t16 = q1*q3*2.0f;
+float t17 = t15+t16;
+float t18 = magZ*t17;
+float t19 = t6-t14;
+float t25 = magY*t19;
+float t20 = t13+t18-t25;
+if (fabsf(t20) < 1e-6f) {
+    return;
+}
+float t26 = 1.0f/(t20*t20);
+float t27 = t7*t7;
+float t28 = t26*t27;
+float t29 = t28+1.0;
+if (fabsf(t29) < 1e-12f) {
+    return;
+}
+float t30 = 1.0f/t29;
+if (fabsf(t20) < 1e-12f) {
+    return;
+}
+float t31 = 1.0f/t20;
 
-// Calculate the observation jacobian for the innovation derivative wrt the attitude error states only
-// Use the reduced order to optimise the calculation of the Kalman gain matrix and covariance update
-float H_MAG[3];
-H_YAW[1] = t14*(t15*(q0*q1*2.0f-q2*q3*2.0f)+t9*t10*(q0*q2*2.0f+q1*q3*2.0f));
-H_YAW[2] = t14*(t15*(t2-t3+t4-t5)+t9*t10*(t7-t8));
+// calculate observation jacobian
+float H_DECL[3] = {};
+H_DECL[0] = -t30*(t31*(magZ*t8+magY*t11)+t7*t26*(magY*t17+magZ*t19));
+H_DECL[1] = t30*(t31*(magX*t11+magZ*t22)-t7*t26*(magZ*t12-magX*t17));
+H_DECL[2] = t30*(t31*(magX*t8-magY*t22)+t7*t26*(magY*t12+magX*t19));

--- a/matlab/generated/Inertial Nav EKF/Yaw Angle Fusion.txt
+++ b/matlab/generated/Inertial Nav EKF/Yaw Angle Fusion.txt
@@ -1,0 +1,27 @@
+/* 
+Autocode for fusion of an Euler yaw measurement.
+
+Protection against /0 and covariance matrix errors will need to be added.
+*/
+
+// intermediate variables
+float t2 = q0*q0;
+float t3 = q1*q1;
+float t4 = q2*q2;
+float t5 = q3*q3;
+float t6 = t2+t3-t4-t5;
+float t7 = q0*q3*2.0f;
+float t8 = q1*q2*2.0f;
+float t9 = t7+t8;
+float t10 = 1.0f/(t6*t6);
+float t11 = t9*t9;
+float t12 = t10*t11;
+float t13 = t12+1.0f;
+float t14 = 1.0f/t13;
+float t15 = 1.0f/t6;
+
+// Calculate the observation jacobian for the innovation derivative wrt the attitude error states only
+// Use the reduced order to optimise the calculation of the Kalman gain matrix and covariance update
+float H_MAG[3];
+H_YAW[1] = t14*(t15*(q0*q1*2.0f-q2*q3*2.0f)+t9*t10*(q0*q2*2.0f+q1*q3*2.0f));
+H_YAW[2] = t14*(t15*(t2-t3+t4-t5)+t9*t10*(t7-t8));


### PR DESCRIPTION
This fixes a bug introduced when the heading observation jacobian and Kalman gain calculations were updated to not use magnetic field measurements directly, but the patch updating the innovation calculation had  been omitted. 

There has been further optimisation of the direct heading fusion calculations and an error in the innovation calculation for that method has ben fixed.

During testing it was noted that the direct heading angle fusion was not suitable for tail-sitter type vehicles or for other applications with arbitrary startup orientations due to poor accuracy around +- 90 degrees pitch. As a result a revised magnetometer fusion method has been developed and implemented which uses the azimuth angle of the projected magnetic field onto the horizontal as the observation. This avoids the singularity regions, but also retains the robustness to external field disturbances of the direct heading fusion. This new method has been labelled as mag-2D fusion in the code to differentiate it from the direct heading fusion 

If EKF_MAG_TYPE = 0 is used, the new method will be used for startup and on the ground, and the EKF will switch over to 3-axis fusion for flight. This is the default behaviour.

This new method can forced on by setting EKF_MAG_TYPE = 3.

The previous direct heading fusion method has been retained for future use with external pose measurement (eg Vicon) and can be forced on by setting EKF_MAG_CAL = 1 as per previous behaviour.

The new method has been bench tested with EKF_MAG_TYPE = 0,1,2,3,4 . It has been indoor flight tested with EKF_MAG_TYPE = 0,3 to compare the new fusion option with 3-Axis fusion in the flight environment. The flights involved continuous yaw manoeuvres both CW and CCW to fuly exercise the compass fusion. The results and flight performance were equivalent, however during manual piloting it was noticed that the copter's tilt level was more consistent with  EKF_MAG_TYPE = 3.  

Test Results - EKF_MAG_TYPE = 0 (using mag-2D fusion on ground and mag-3D fusion in-flight)
![delangz bias 3](https://cloud.githubusercontent.com/assets/3596952/13199592/ee469e4e-d87d-11e5-8dda-4e42413e4c95.png)

synthetic position innovations
![pos innov 0](https://cloud.githubusercontent.com/assets/3596952/13199560/10aa06d4-d87d-11e5-87d0-59988af4637c.png)

Z gyro bias
![delangz bias 0](https://cloud.githubusercontent.com/assets/3596952/13199567/30ec2bd4-d87d-11e5-904b-20290afa7b00.png)

Z gyro scale factor
![delangz scale 0](https://cloud.githubusercontent.com/assets/3596952/13199569/3cb622f8-d87d-11e5-9aa6-074f10941a73.png)

Test Results - EKF_MAG_TYPE = 3 (using mag-2D fusion on ground and in flight)

synthetic position innovations
![pos innov 3](https://cloud.githubusercontent.com/assets/3596952/13199591/dd9d3e18-d87d-11e5-852e-872ef3f60005.png)

Z gyro bias
![delangz bias 3](https://cloud.githubusercontent.com/assets/3596952/13199593/f9727310-d87d-11e5-9ba4-e3cdbe2451b0.png)

Z gyro scale factor
![delangz scale 3](https://cloud.githubusercontent.com/assets/3596952/13199595/fde241a0-d87d-11e5-96eb-b45b0fac9d4e.png)
