### PR TITLE
EKF: Fix bad behaviour when aligning from inverted

### DIFF
--- a/EKF/ekf.cpp
+++ b/EKF/ekf.cpp
@@ -243,7 +243,7 @@ bool Ekf::initialiseFilter(void)
 		if (_delVel_sum.norm() > 0.001f) {
 			_delVel_sum.normalize();
 			pitch = asinf(_delVel_sum(0));
-			roll = -asinf(_delVel_sum(1) / cosf(pitch));
+			roll = -atan2f(_delVel_sum(2), _delVel_sum(1));
 
 		} else {
 			return false;


### PR DESCRIPTION
The  previous code did not work when inverted and would /0 when pitch = +-90 deg