### PR TITLE
EKF: Fix Bug Causing Roll/pitch Disturbances On Mag Fusion Mode Switch

### DIFF
--- a/EKF/common.h
+++ b/EKF/common.h
@@ -155,8 +155,8 @@ struct parameters {
 	float req_gdop;         // maximum acceptable geometric dilution of precision
 	float req_hdrift;       // maximum acceptable horizontal drift speed
 	float req_vdrift;       // maximum acceptable vertical drift speed
-	
-    // Initialize parameter values.  Initialization must be accomplished in the constructor to allow C99 compiler compatibility.
+
+	// Initialize parameter values.  Initialization must be accomplished in the constructor to allow C99 compiler compatibility.
 	parameters()
 	{
 		mag_delay_ms = 0.0f;

--- a/EKF/control.cpp
+++ b/EKF/control.cpp
@@ -112,6 +112,11 @@ void Ekf::controlFusionModes()
 
 		} else {
 			if (_control_status.flags.in_air) {
+				// if transitioning from a non-3D fusion mode, we need to initialise the yaw angle and field states
+				if (!_control_status.flags.mag_3D) {
+					_control_status.flags.yaw_align = resetMagHeading(_mag_sample_delayed.mag);
+				}
+
 				// always use 3D mag fusion when airborne
 				_control_status.flags.mag_hdg = false;
 				_control_status.flags.mag_2D = false;
@@ -145,6 +150,11 @@ void Ekf::controlFusionModes()
 		_control_status.flags.mag_3D = false;
 
 	} else if (_params.mag_fusion_type == MAG_FUSE_TYPE_3D) {
+		// if transitioning from a non-3D fusion mode, we need to initialise the yaw angle and field states
+		if (!_control_status.flags.mag_3D) {
+			_control_status.flags.yaw_align = resetMagHeading(_mag_sample_delayed.mag);
+		}
+
 		// always use 3-axis mag fusion
 		_control_status.flags.mag_hdg = false;
 		_control_status.flags.mag_2D = false;

--- a/EKF/control.cpp
+++ b/EKF/control.cpp
@@ -57,8 +57,10 @@ void Ekf::controlFusionModes()
 	if (!_control_status.flags.gps) {
 		if (_control_status.flags.tilt_align && (_time_last_imu - _time_last_gps) < 5e5 && _NED_origin_initialised
 		    && (_time_last_imu - _last_gps_fail_us > 5e6)) {
-			// Reset the yaw and magnetic field states
-			_control_status.flags.yaw_align = resetMagHeading(_mag_sample_delayed.mag);
+			// If the heading is not aligned, reset the yaw and magnetic field states
+			if (!_control_status.flags.yaw_align) {
+				_control_status.flags.yaw_align = resetMagHeading(_mag_sample_delayed.mag);
+			}
 
 			// If the heading is valid, reset the positon and velocity and start using gps aiding
 			if (_control_status.flags.yaw_align) {

--- a/EKF/ekf_helper.cpp
+++ b/EKF/ekf_helper.cpp
@@ -117,6 +117,12 @@ bool Ekf::resetMagHeading(Vector3f &mag_init)
 	_state.quat_nominal = Quaternion(euler_init);
 	_output_new.quat_nominal = _state.quat_nominal;
 
+	// reset the angle error variances because the yaw angle could have changed by a significant amount
+	// by setting them to zero we avoid 'kicks' in angle when 3-D fusion starts and the imu process noise
+	// will grow them again.
+	zeroRows(P, 0, 2);
+	zeroCols(P, 0, 2);
+
 	// calculate initial earth magnetic field states
 	matrix::Dcm<float> R_to_earth(euler_init);
 	_state.mag_I = R_to_earth * mag_init;

--- a/EKF/estimator_interface.cpp
+++ b/EKF/estimator_interface.cpp
@@ -68,9 +68,9 @@ EstimatorInterface::EstimatorInterface():
 	_mag_declination_gps(0.0f),
 	_mag_declination_to_save_deg(0.0f)
 {
-    _pos_ref = {};
-    memset(_mag_test_ratio, 0, sizeof(_mag_test_ratio));
-    memset(_vel_pos_test_ratio, 0, sizeof(_vel_pos_test_ratio));
+	_pos_ref = {};
+	memset(_mag_test_ratio, 0, sizeof(_mag_test_ratio));
+	memset(_vel_pos_test_ratio, 0, sizeof(_vel_pos_test_ratio));
 }
 
 EstimatorInterface::~EstimatorInterface()
@@ -202,7 +202,7 @@ void EstimatorInterface::setAirspeedData(uint64_t time_usec, float *data)
 	if (time_usec > _time_last_airspeed) {
 		airspeedSample airspeed_sample_new;
 		airspeed_sample_new.airspeed = *data;
-		airspeed_sample_new.time_us = time_usec -_params.airspeed_delay_ms * 1000;
+		airspeed_sample_new.time_us = time_usec - _params.airspeed_delay_ms * 1000;
 		airspeed_sample_new.time_us -= FILTER_UPDATE_PERRIOD_MS * 1000 / 2;
 		_time_last_airspeed = time_usec;
 

--- a/EKF/geo.cpp
+++ b/EKF/geo.cpp
@@ -211,13 +211,13 @@ uint64_t map_projection_timestamp(const struct map_projection_reference_s *ref)
 }
 
 int map_projection_global_init(double lat_0, double lon_0,
-					uint64_t timestamp) //lat_0, lon_0 are expected to be in correct format: -> 47.1234567 and not 471234567
+			       uint64_t timestamp) //lat_0, lon_0 are expected to be in correct format: -> 47.1234567 and not 471234567
 {
 	return map_projection_init_timestamped(&mp_ref, lat_0, lon_0, timestamp);
 }
 
 int map_projection_init_timestamped(struct map_projection_reference_s *ref, double lat_0, double lon_0,
-		uint64_t timestamp) //lat_0, lon_0 are expected to be in correct format: -> 47.1234567 and not 471234567
+				    uint64_t timestamp) //lat_0, lon_0 are expected to be in correct format: -> 47.1234567 and not 471234567
 {
 
 	ref->lat_rad = lat_0 * M_DEG_TO_RAD;
@@ -237,7 +237,7 @@ int map_projection_global_reference(double *ref_lat_rad, double *ref_lon_rad)
 }
 
 int map_projection_reference(const struct map_projection_reference_s *ref, double *ref_lat_rad,
-				      double *ref_lon_rad)
+			     double *ref_lon_rad)
 {
 	if (!map_projection_initialized(ref)) {
 		return -1;
@@ -256,7 +256,7 @@ int map_projection_global_project(double lat, double lon, float *x, float *y)
 }
 
 int map_projection_project(const struct map_projection_reference_s *ref, double lat, double lon, float *x,
-				    float *y)
+			   float *y)
 {
 	if (!map_projection_initialized(ref)) {
 		return -1;
@@ -293,7 +293,7 @@ int map_projection_global_reproject(float x, float y, double *lat, double *lon)
 }
 
 int map_projection_reproject(const struct map_projection_reference_s *ref, float x, float y, double *lat,
-				      double *lon)
+			     double *lon)
 {
 	if (!map_projection_initialized(ref)) {
 		return -1;
@@ -419,7 +419,7 @@ float get_distance_to_next_waypoint(double lat_now, double lon_now, double lat_n
 }
 
 void create_waypoint_from_line_and_dist(double lat_A, double lon_A, double lat_B, double lon_B, float dist,
-		double *lat_target, double *lon_target)
+					double *lat_target, double *lon_target)
 {
 	if (fabsf(dist) < FLT_EPSILON) {
 		*lat_target = lat_A;
@@ -437,7 +437,7 @@ void create_waypoint_from_line_and_dist(double lat_A, double lon_A, double lat_B
 }
 
 void waypoint_from_heading_and_distance(double lat_start, double lon_start, float bearing, float dist,
-		double *lat_target, double *lon_target)
+					double *lat_target, double *lon_target)
 {
 	bearing = _wrap_2pi(bearing);
 	double radius_ratio = (double)(fabs(dist) / CONSTANTS_RADIUS_OF_EARTH);
@@ -472,7 +472,7 @@ float get_bearing_to_next_waypoint(double lat_now, double lon_now, double lat_ne
 }
 
 void get_vector_to_next_waypoint(double lat_now, double lon_now, double lat_next, double lon_next, float *v_n,
-		float *v_e)
+				 float *v_e)
 {
 	double lat_now_rad = lat_now * M_DEG_TO_RAD;
 	double lon_now_rad = lon_now * M_DEG_TO_RAD;
@@ -488,7 +488,7 @@ void get_vector_to_next_waypoint(double lat_now, double lon_now, double lat_next
 }
 
 void get_vector_to_next_waypoint_fast(double lat_now, double lon_now, double lat_next, double lon_next,
-		float *v_n, float *v_e)
+				      float *v_n, float *v_e)
 {
 	double lat_now_rad = lat_now * M_DEG_TO_RAD;
 	double lon_now_rad = lon_now * M_DEG_TO_RAD;
@@ -504,7 +504,7 @@ void get_vector_to_next_waypoint_fast(double lat_now, double lon_now, double lat
 }
 
 void add_vector_to_global_position(double lat_now, double lon_now, float v_n, float v_e, double *lat_res,
-		double *lon_res)
+				   double *lon_res)
 {
 	double lat_now_rad = lat_now * M_DEG_TO_RAD;
 	double lon_now_rad = lon_now * M_DEG_TO_RAD;
@@ -516,7 +516,7 @@ void add_vector_to_global_position(double lat_now, double lon_now, float v_n, fl
 // Additional functions - @author Doug Weibel <douglas.weibel@colorado.edu>
 
 int get_distance_to_line(struct crosstrack_error_s *crosstrack_error, double lat_now, double lon_now,
-				  double lat_start, double lon_start, double lat_end, double lon_end)
+			 double lat_start, double lon_start, double lat_end, double lon_end)
 {
 // This function returns the distance to the nearest point on the track line.  Distance is positive if current
 // position is right of the track and negative if left of the track as seen from a point on the track line
@@ -568,8 +568,8 @@ int get_distance_to_line(struct crosstrack_error_s *crosstrack_error, double lat
 
 
 int get_distance_to_arc(struct crosstrack_error_s *crosstrack_error, double lat_now, double lon_now,
-				 double lat_center, double lon_center,
-				 float radius, float arc_start_bearing, float arc_sweep)
+			double lat_center, double lon_center,
+			float radius, float arc_start_bearing, float arc_sweep)
 {
 	// This function returns the distance to the nearest point on the track arc.  Distance is positive if current
 	// position is right of the arc and negative if left of the arc as seen from the closest point on the arc and

--- a/EKF/geo.h
+++ b/EKF/geo.h
@@ -57,7 +57,7 @@
 #define M_PI_2_F  1.57079632679489661923f
 #define M_RAD_TO_DEG 0.01745329251994329576f
 #define M_DEG_TO_RAD 57.29577951308232087679f
-#define OK 0 
+#define OK 0
 #define ERROR -1
 // XXX remove
 struct crosstrack_error_s {
@@ -116,7 +116,7 @@ int map_projection_global_reference(double *ref_lat_rad, double *ref_lon_rad);
  * @return 0 if map_projection_init was called before, -1 else
  */
 int map_projection_reference(const struct map_projection_reference_s *ref, double *ref_lat_rad,
-				      double *ref_lon_rad);
+			     double *ref_lon_rad);
 
 
 /**
@@ -128,7 +128,7 @@ int map_projection_reference(const struct map_projection_reference_s *ref, doubl
  * @param lon in degrees (8.1234567°, not 81234567°)
  */
 int map_projection_init_timestamped(struct map_projection_reference_s *ref,
-		double lat_0, double lon_0, uint64_t timestamp);
+				    double lat_0, double lon_0, uint64_t timestamp);
 
 /**
  * Initializes the map transformation given by the argument and sets the timestamp to now.
@@ -161,7 +161,7 @@ int map_projection_global_project(double lat, double lon, float *x, float *y);
 * @return 0 if map_projection_init was called before, -1 else
 */
 int map_projection_project(const struct map_projection_reference_s *ref, double lat, double lon, float *x,
-				    float *y);
+			   float *y);
 
 /**
  * Transforms a point in the local azimuthal equidistant plane to the
@@ -186,7 +186,7 @@ int map_projection_global_reproject(float x, float y, double *lat, double *lon);
  * @return 0 if map_projection_init was called before, -1 else
  */
 int map_projection_reproject(const struct map_projection_reference_s *ref, float x, float y, double *lat,
-				      double *lon);
+			     double *lon);
 
 /**
  * Get reference position of the global map projection
@@ -243,7 +243,7 @@ float get_distance_to_next_waypoint(double lat_now, double lon_now, double lat_n
  * @param lon_target longitude of target waypoint C in degrees (47.1234567°, not 471234567°)
  */
 void create_waypoint_from_line_and_dist(double lat_A, double lon_A, double lat_B, double lon_B, float dist,
-		double *lat_target, double *lon_target);
+					double *lat_target, double *lon_target);
 
 /**
  * Creates a waypoint from given waypoint, distance and bearing
@@ -257,7 +257,7 @@ void create_waypoint_from_line_and_dist(double lat_A, double lon_A, double lat_B
  * @param lon_target longitude of target waypoint in degrees (47.1234567°, not 471234567°)
  */
 void waypoint_from_heading_and_distance(double lat_start, double lon_start, float bearing, float dist,
-		double *lat_target, double *lon_target);
+					double *lat_target, double *lon_target);
 
 /**
  * Returns the bearing to the next waypoint in radians.
@@ -270,20 +270,20 @@ void waypoint_from_heading_and_distance(double lat_start, double lon_start, floa
 float get_bearing_to_next_waypoint(double lat_now, double lon_now, double lat_next, double lon_next);
 
 void get_vector_to_next_waypoint(double lat_now, double lon_now, double lat_next, double lon_next, float *v_n,
-		float *v_e);
+				 float *v_e);
 
 void get_vector_to_next_waypoint_fast(double lat_now, double lon_now, double lat_next, double lon_next,
-		float *v_n, float *v_e);
+				      float *v_n, float *v_e);
 
 void add_vector_to_global_position(double lat_now, double lon_now, float v_n, float v_e, double *lat_res,
-		double *lon_res);
+				   double *lon_res);
 
 int get_distance_to_line(struct crosstrack_error_s *crosstrack_error, double lat_now, double lon_now,
-				  double lat_start, double lon_start, double lat_end, double lon_end);
+			 double lat_start, double lon_start, double lat_end, double lon_end);
 
 int get_distance_to_arc(struct crosstrack_error_s *crosstrack_error, double lat_now, double lon_now,
-				 double lat_center, double lon_center,
-				 float radius, float arc_start_bearing, float arc_sweep);
+			double lat_center, double lon_center,
+			float radius, float arc_start_bearing, float arc_sweep);
 
 /*
  * Calculate distance in global frame

--- a/EKF/mathlib.h
+++ b/EKF/mathlib.h
@@ -45,13 +45,14 @@
 #include <algorithm>
 #define M_PI_F 3.14159265358979323846f
 
-namespace math {
-	using namespace Eigen;
-	using namespace std;
+namespace math
+{
+using namespace Eigen;
+using namespace std;
 
-	float constrain(float &val, float min, float max);
-	float radians(float degrees);
-	float degrees(float radians);
+float constrain(float &val, float min, float max);
+float radians(float degrees);
+float degrees(float radians);
 }
 #else
 #include <mathlib/mathlib.h>


### PR DESCRIPTION
The magnetic field states and yaw angles were being reset on transition into GPS mode, not 3D fusion mode. 

This could cause large magnetometer innovations and upsets in roll and pitch when 3D fusion commenced if the vehicle was subject to significant field disturbances on the ground when it started using GPS.

This PR ensures that the mag field states and yaw are always reset when entering 3D fusion mode, and that the angle error covariances are zeroed to prevent unwanted angle disturbances when commencing 3D fusion.

The following flight test data shows an in-air transition into 3D fusion. Note that the angle error variances quickly recover within seconds of the reset due to the imu process noise.

![mag x innov](https://cloud.githubusercontent.com/assets/3596952/13281506/5b323d12-db38-11e5-9f47-51f73ceba478.png)
![mag z innov](https://cloud.githubusercontent.com/assets/3596952/13281508/5b7dfaea-db38-11e5-93f2-737a905ba7f1.png)
![mag y innov](https://cloud.githubusercontent.com/assets/3596952/13281509/5b7fac0a-db38-11e5-9a44-36225bee008c.png)
![yaw innov](https://cloud.githubusercontent.com/assets/3596952/13281512/61085d5c-db38-11e5-8851-c3caa3ad2673.png)
![angle error sigma](https://cloud.githubusercontent.com/assets/3596952/13281513/66fa9978-db38-11e5-84c1-31396351ec6f.png)
![roll pitch](https://cloud.githubusercontent.com/assets/3596952/13281531/84e2390a-db38-11e5-828c-bba4c0bd5781.png)
![mag bias](https://cloud.githubusercontent.com/assets/3596952/13281601/d8940b3c-db38-11e5-94f8-c587cc49f93d.png)
