### PR TITLE
EKF: Improve Position Accuracy Reporting

### DIFF
--- a/EKF/ekf.h
+++ b/EKF/ekf.h
@@ -95,6 +95,9 @@ public:
 	// get the ekf WGS-84 origin position and height and the system time it was last set
 	void get_ekf_origin(uint64_t *origin_time, map_projection_reference_s *origin_pos, float *origin_alt);
 
+	// get the 1-sigma horizontal and vertical position uncertainty of the ekf WGS-84 position
+	void get_ekf_accuracy(float *ekf_eph, float *ekf_epv, bool *dead_reckoning);
+
 private:
 
 	static const uint8_t _k_num_states = 24;

--- a/EKF/estimator_interface.cpp
+++ b/EKF/estimator_interface.cpp
@@ -160,6 +160,7 @@ void EstimatorInterface::setGpsData(uint64_t time_usec, struct gps_message *gps)
 
 		_gps_speed_valid = gps->vel_ned_valid;
 		_gps_speed_accuracy = gps->sacc;
+		_gps_hpos_accuracy = gps->eph;
 
 		float lpos_x = 0.0f;
 		float lpos_y = 0.0f;

--- a/EKF/estimator_interface.h
+++ b/EKF/estimator_interface.h
@@ -197,6 +197,7 @@ protected:
 	bool _gps_speed_valid;
 	float _gps_speed_accuracy;                  // GPS receiver reported speed accuracy (m/s)
 	struct map_projection_reference_s _pos_ref; // Contains WGS-84 position latitude and longitude (radians)
+	float _gps_hpos_accuracy = 0.0f; // GPS receiver reported 1-sigma horizontal accuracy (m)
 
 	bool _mag_healthy;              // computed by mag innovation test
 	float _yaw_test_ratio;          // yaw innovation consistency check ratio

--- a/EKF/estimator_interface.h
+++ b/EKF/estimator_interface.h
@@ -83,6 +83,9 @@ public:
 	// get the ekf WGS-84 origin position and height and the system time it was last set
 	virtual void get_ekf_origin(uint64_t *origin_time, map_projection_reference_s *origin_pos, float *origin_alt) = 0;
 
+	// get the 1-sigma horizontal and vertical position uncertainty of the ekf WGS-84 position
+	virtual void get_ekf_accuracy(float *ekf_eph, float *ekf_epv, bool *dead_reckoning) = 0;
+
 	// ask estimator for sensor data collection decision and do any preprocessing if required, returns true if not defined
 	virtual bool collect_gps(uint64_t time_usec, struct gps_message *gps) { return true; }
 
@@ -198,6 +201,8 @@ protected:
 	float _gps_speed_accuracy;                  // GPS receiver reported speed accuracy (m/s)
 	struct map_projection_reference_s _pos_ref; // Contains WGS-84 position latitude and longitude (radians)
 	float _gps_hpos_accuracy = 0.0f; // GPS receiver reported 1-sigma horizontal accuracy (m)
+	float _gps_origin_eph = 0.0f; // horizontal position uncertainty of the GPS origin
+	float _gps_origin_epv = 0.0f; // vertical position uncertainty of the GPS origin
 
 	bool _mag_healthy;              // computed by mag innovation test
 	float _yaw_test_ratio;          // yaw innovation consistency check ratio

--- a/EKF/gps_checks.cpp
+++ b/EKF/gps_checks.cpp
@@ -70,6 +70,9 @@ bool Ekf::collect_gps(uint64_t time_usec, struct gps_message *gps)
 			_last_gps_origin_time_us = _time_last_imu;
 			// set the magnetic declination returned by the geo library using the current GPS position
 			_mag_declination_gps = math::radians(get_mag_declination(lat, lon));
+			// save the horizontal and vertical position uncertainty of the origin
+			_gps_origin_eph = gps->eph;
+			_gps_origin_epv = gps->epv;
 		}
 	}
 

--- a/EKF/vel_pos_fusion.cpp
+++ b/EKF/vel_pos_fusion.cpp
@@ -40,6 +40,7 @@
  */
 
 #include "ekf.h"
+#include "mathlib.h"
 
 void Ekf::fuseVelPosHeight()
 {
@@ -90,7 +91,10 @@ void Ekf::fuseVelPosHeight()
 			R[3] = fmaxf(_params.pos_noaid_noise, 0.5f);
 
 		} else {
-			R[3] = fmaxf(_params.gps_pos_noise, 0.01f);
+			float lower_limit = fmaxf(_params.gps_pos_noise, 0.01f);
+			float upper_limit = fmaxf(_params.pos_noaid_noise, lower_limit);
+			R[3] = math::constrain(_gps_hpos_accuracy, lower_limit, upper_limit);
+
 		}
 
 		R[3] = R[3] * R[3];


### PR DESCRIPTION
Use GPS reported accuracy to set position observation noise, but bound the noise to safe limits set by the parameters. This reduces the effect of noisy GPS on filter estimates

Publish the filter absolute position uncertainty in the horizontal and vertical directions and indicate if the filter is dead reckoning. This reporting takes account of uncertainty in the EKF origin. This information can be combined with GPS error reporting outside of the filter to make better decisions based on control loop accuracy requirements.

It has been flight tested in an indoor environment with noisy GPS. http://logs.uaventure.com/view/y93HLUxKJtzsPwpzZYrZMP
Test result show that the innovation variance is adjusting to the variations in GPS accuracy

![pos innov](https://cloud.githubusercontent.com/assets/3596952/13306007/f8e5f7e4-dbb3-11e5-8d68-d5eae728bb74.png)

![pos innov var](https://cloud.githubusercontent.com/assets/3596952/13306139/263e1810-dbb5-11e5-808c-d5740be41b40.png)

![vel innov](https://cloud.githubusercontent.com/assets/3596952/13306005/f88e6a60-dbb3-11e5-9562-f5ecdfebdf90.png)

![pos uncertainty](https://cloud.githubusercontent.com/assets/3596952/13306009/fa209b8c-dbb3-11e5-8940-d2c9c7531e40.png)


