### PR TITLE
Attitude reset after heading reset

### DIFF
--- a/EKF/ekf_helper.cpp
+++ b/EKF/ekf_helper.cpp
@@ -113,9 +113,9 @@ bool Ekf::resetMagHeading(Vector3f &mag_init)
 	Vector3f mag_ef_zeroyaw = R_to_earth_zeroyaw * mag_init;
 	euler_init(2) = _mag_declination - atan2f(mag_ef_zeroyaw(1), mag_ef_zeroyaw(0));
 
-	// calculate initial quaternion states
+	// calculate initial quaternion states for the ekf
+	// we don't change the output attitude to avoid jumps
 	_state.quat_nominal = Quaternion(euler_init);
-	_output_new.quat_nominal = _state.quat_nominal;
 
 	// reset the angle error variances because the yaw angle could have changed by a significant amount
 	// by setting them to zero we avoid 'kicks' in angle when 3-D fusion starts and the imu process noise


### PR DESCRIPTION
When doing a test flight in the lab with the Pixracer using latest ecl master the quad suddenly twitched some seconds after it was in the air. The log showed that the attitude jumped considerable (see picture below). This jump occurred when the heading reset happened (switch from heading fusion to 3D mag fusion). I believe that the problem was that we were setting the output attitude equal to the yaw corrected ekf attitude which is of course delayed and thus now necessarily a good choice.