### PR TITLE
EKF2: Reduce effect of magnetic disturbances on tilt

### DIFF
--- a/EKF/common.h
+++ b/EKF/common.h
@@ -183,7 +183,7 @@ struct parameters {
 		posNE_innov_gate = 3.0f;
 		vel_innov_gate = 3.0f;
 
-		mag_heading_noise = 1.7e-1f;
+		mag_heading_noise = 5.0e-1f;
 		mag_noise = 5.0e-2f;
 		mag_declination_deg = 0.0f;
 		heading_innov_gate = 3.0f;

--- a/EKF/control.cpp
+++ b/EKF/control.cpp
@@ -106,8 +106,8 @@ void Ekf::controlFusionModes()
 	if (_params.mag_fusion_type == MAG_FUSE_TYPE_AUTO) {
 		if (!_control_status.flags.armed) {
 			// always use 2D mag fusion for initial startup
-			_control_status.flags.mag_hdg = false;
-			_control_status.flags.mag_2D = true;
+			_control_status.flags.mag_hdg = true;
+			_control_status.flags.mag_2D = false;
 			_control_status.flags.mag_3D = false;
 
 		} else {
@@ -123,9 +123,9 @@ void Ekf::controlFusionModes()
 				_control_status.flags.mag_3D = true;
 
 			} else {
-				// always use 2D mag fusion when on the ground
-				_control_status.flags.mag_hdg = false;
-				_control_status.flags.mag_2D = true;
+				// always use heading mag fusion when on the ground
+				_control_status.flags.mag_hdg = true;
+				_control_status.flags.mag_2D = false;
 				_control_status.flags.mag_3D = false;
 			}
 		}

--- a/EKF/control.cpp
+++ b/EKF/control.cpp
@@ -131,16 +131,9 @@ void Ekf::controlFusionModes()
 		}
 
 	} else if (_params.mag_fusion_type == MAG_FUSE_TYPE_HEADING) {
-		// always use yaw fusion unless tilt is over 45 deg, otherwise use 2D fusion
-		if (_R_prev(2, 2) > 0.7071f) {
-			_control_status.flags.mag_hdg = true;
-			_control_status.flags.mag_2D = false;
-
-		} else {
-			_control_status.flags.mag_hdg = false;
-			_control_status.flags.mag_2D = true;
-		}
-
+		// always use yaw fusion
+		_control_status.flags.mag_hdg = true;
+		_control_status.flags.mag_2D = false;
 		_control_status.flags.mag_3D = false;
 
 	} else if (_params.mag_fusion_type == MAG_FUSE_TYPE_2D) {

--- a/EKF/ekf.cpp
+++ b/EKF/ekf.cpp
@@ -115,11 +115,11 @@ bool Ekf::init(uint64_t timestamp)
 	_output_new.vel.setZero();
 	_output_new.pos.setZero();
 	_output_new.quat_nominal = matrix::Quaternion<float>();
-    
+
 	_delta_angle_corr.setZero();
 	_delta_vel_corr.setZero();
 	_vel_corr.setZero();
-    
+
 	_imu_down_sampled.delta_ang.setZero();
 	_imu_down_sampled.delta_vel.setZero();
 	_imu_down_sampled.delta_ang_dt = 0.0f;
@@ -180,7 +180,14 @@ bool Ekf::update()
 			fuseMag2D();
 
 		} else if (_control_status.flags.mag_hdg && _control_status.flags.yaw_align) {
-			fuseHeading();
+			// fusion of a Euler yaw angle from either a 321 or 312 rotation sequence
+			// choose the sequence furhtest from it's associate singularity
+			if (fabsf(_R_prev(0, 2)) < fabsf(_R_prev(1, 2))) {
+				fuseHeading321();
+
+			} else {
+				fuseHeading312();
+			}
 
 		} else {
 			// do no fusion at all

--- a/EKF/ekf.h
+++ b/EKF/ekf.h
@@ -187,8 +187,11 @@ private:
 	// ekf sequential fusion of magnetometer measurements
 	void fuseMag();
 
-	// fuse heading measurement (currently uses estimate from magnetometer)
-	void fuseHeading();
+	// fuse the first euler angle from a 321 rotation sequence as the observation (currently measures yaw using the magnetometer)
+	void fuseHeading321();
+
+	// fuse the first euler angle from a 312 rotation sequence as the observation (currently measures yaw using the magnetoemter
+	void fuseHeading312();
 
 	// fuse projecton of magnetometer onto horizontal plane
 	void fuseMag2D();

--- a/EKF/mag_fusion.cpp
+++ b/EKF/mag_fusion.cpp
@@ -1030,11 +1030,27 @@ void Ekf::fuseHeading312()
 	float t7 = q0 * q3 * 2.0f;
 	float t10 = q1 * q2 * 2.0f;
 	float t8 = t7 - t10;
-	float t9 = 1.0f / (t6 * t6);
+	float t9;
+
+	if (fabsf(t6) > 1e-3f) {
+		t9 = 1.0f / (t6 * t6);
+
+	} else {
+		return;
+	}
+
 	float t11 = t8 * t8;
 	float t12 = t9 * t11;
 	float t13 = t12 + 1.0f;
-	float t14 = 1.0f / t13;
+	float t14;
+
+	if (fabsf(t13) > 1e-6f) {
+		t14 = 1.0f / t13;
+
+	} else {
+		return;
+	}
+
 	float t15 = 1.0f / t6;
 	float t16 = q0 * q2 * 2.0f;
 	float t17 = q1 * q3 * 2.0f;

--- a/EKF/mag_fusion.cpp
+++ b/EKF/mag_fusion.cpp
@@ -1135,9 +1135,9 @@ void Ekf::fuseHeading312()
 	// Calculate the 312 sequence euler angles that rotate from earth to body frame
 	// See http://www.atacolorado.com/eulersequences.doc
 	Vector3f euler312;
-	euler312(1) = asinf(_R_prev(1, 2)); // second rotation (roll)
-	euler312(1) = atan2f(-_R_prev(0, 2) , _R_prev(2, 2)); // third rotation (pitch)
 	euler312(0) = atan2f(-_R_prev(1, 0) , _R_prev(1, 1)); // first rotation (yaw)
+	euler312(1) = asinf(_R_prev(1, 2)); // second rotation (roll)
+	euler312(2) = atan2f(-_R_prev(0, 2) , _R_prev(2, 2)); // third rotation (pitch)
 
 	float predicted_hdg = euler312(0); // we will need the predicted heading to calculate the innovation
 

--- a/matlab/generated/Inertial Nav EKF/Yaw Angle Fusion.txt
+++ b/matlab/generated/Inertial Nav EKF/Yaw Angle Fusion.txt
@@ -1,27 +1,173 @@
 /* 
-Autocode for fusion of an Euler yaw measurement.
-
-Protection against /0 and covariance matrix errors will need to be added.
+Code fragments for fusion of an Euler yaw measurement from a 321 sequence.
 */
 
-// intermediate variables
-float t2 = q0*q0;
-float t3 = q1*q1;
-float t4 = q2*q2;
-float t5 = q3*q3;
-float t6 = t2+t3-t4-t5;
-float t7 = q0*q3*2.0f;
-float t8 = q1*q2*2.0f;
-float t9 = t7+t8;
-float t10 = 1.0f/(t6*t6);
-float t11 = t9*t9;
-float t12 = t10*t11;
-float t13 = t12+1.0f;
-float t14 = 1.0f/t13;
-float t15 = 1.0f/t6;
+// calculate intermediate variables for observation jacobians
+float t2 = q0 * q0;
+float t3 = q1 * q1;
+float t4 = q2 * q2;
+float t5 = q3 * q3;
+float t6 = t2 + t3 - t4 - t5;
+float t7 = q0 * q3 * 2.0f;
+float t8 = q1 * q2 * 2.0f;
+float t9 = t7 + t8;
+float t10 = 1.0f / (t6 * t6);
+float t11 = t9 * t9;
+float t12 = t10 * t11;
+float t13 = t12 + 1.0f;
+float t14 = 1.0f / t13;
+float t15 = 1.0f / t6;
 
-// Calculate the observation jacobian for the innovation derivative wrt the attitude error states only
-// Use the reduced order to optimise the calculation of the Kalman gain matrix and covariance update
-float H_MAG[3];
-H_YAW[1] = t14*(t15*(q0*q1*2.0f-q2*q3*2.0f)+t9*t10*(q0*q2*2.0f+q1*q3*2.0f));
-H_YAW[2] = t14*(t15*(t2-t3+t4-t5)+t9*t10*(t7-t8));
+float H_YAW[3] = {};
+H_YAW[1] = t14 * (t15 * (q0 * q1 * 2.0f - q2 * q3 * 2.0f) + t9 * t10 * (q0 * q2 * 2.0f + q1 * q3 * 2.0f));
+H_YAW[2] = t14 * (t15 * (t2 - t3 + t4 - t5) + t9 * t10 * (t7 - t8));
+
+
+// calculate intermediate expressions for Kalman gains
+float t16 = q0 * q1 * 2.0f;
+float t29 = q2 * q3 * 2.0f;
+float t17 = t16 - t29;
+float t18 = t15 * t17;
+float t19 = q0 * q2 * 2.0f;
+float t20 = q1 * q3 * 2.0f;
+float t21 = t19 + t20;
+float t22 = t9 * t10 * t21;
+float t23 = t18 + t22;
+float t40 = t14 * t23;
+float t24 = t2 - t3 + t4 - t5;
+float t25 = t15 * t24;
+float t26 = t7 - t8;
+float t27 = t9 * t10 * t26;
+float t28 = t25 + t27;
+float t41 = t14 * t28;
+float t30 = P[1][1] * t40;
+float t31 = P[1][2] * t40;
+float t32 = P[2][2] * t41;
+float t33 = t31 + t32;
+float t34 = t41 * t33;
+float t35 = P[2][1] * t41;
+float t36 = t30 + t35;
+float t37 = t40 * t36;
+float t38 = R_YAW + t34 + t37; // Innovation variance
+float t39 = 1.0f / t38;
+
+// calculate Kalman gains
+float Kfusion[24] = {};
+Kfusion[0] = t39 * (P[0][1] * t40 + P[0][2] * t41);
+Kfusion[1] = t39 * (t30 + P[1][2] * t41);
+Kfusion[2] = t39 * (t32 + P[2][1] * t40);
+Kfusion[3] = t39 * (P[3][1] * t40 + P[3][2] * t41);
+Kfusion[4] = t39 * (P[4][1] * t40 + P[4][2] * t41);
+Kfusion[5] = t39 * (P[5][1] * t40 + P[5][2] * t41);
+Kfusion[6] = t39 * (P[6][1] * t40 + P[6][2] * t41);
+Kfusion[7] = t39 * (P[7][1] * t40 + P[7][2] * t41);
+Kfusion[8] = t39 * (P[8][1] * t40 + P[8][2] * t41);
+Kfusion[9] = t39 * (P[9][1] * t40 + P[9][2] * t41);
+Kfusion[10] = t39 * (P[10][1] * t40 + P[10][2] * t41);
+Kfusion[11] = t39 * (P[11][1] * t40 + P[11][2] * t41);
+Kfusion[12] = t39 * (P[12][1] * t40 + P[12][2] * t41);
+Kfusion[13] = t39 * (P[13][1] * t40 + P[13][2] * t41);
+Kfusion[14] = t39 * (P[14][1] * t40 + P[14][2] * t41);
+Kfusion[15] = t39 * (P[15][1] * t40 + P[15][2] * t41);
+Kfusion[16] = t39*(P[16][1]*t40+P[16][2]*t41);
+Kfusion[17] = t39*(P[17][1]*t40+P[17][2]*t41);
+Kfusion[18] = t39*(P[18][1]*t40+P[18][2]*t41);
+Kfusion[19] = t39*(P[19][1]*t40+P[19][2]*t41);
+Kfusion[20] = t39*(P[20][1]*t40+P[20][2]*t41);
+Kfusion[21] = t39*(P[21][1]*t40+P[21][2]*t41);
+Kfusion[22] = t39 * (P[22][1] * t40 + P[22][2] * t41);
+Kfusion[23] = t39 * (P[23][1] * t40 + P[23][2] * t41);
+
+/*
+Code fragments for fusion of an Euler yaw measurement from a 312 sequence.
+*/
+
+// calculate intermediate variables
+float t2 = q0 * q0;
+float t3 = q1 * q1;
+float t4 = q2 * q2;
+float t5 = q3 * q3;
+float t6 = t2 - t3 + t4 - t5;
+float t7 = q0 * q3 * 2.0f;
+float t10 = q1 * q2 * 2.0f;
+float t8 = t7 - t10;
+float t9 = 1.0f / (t6 * t6);
+float t11 = t8 * t8;
+float t12 = t9 * t11;
+float t13 = t12 + 1.0f;
+float t14 = 1.0f / t13;
+float t15 = 1.0f / t6;
+float t16 = q0 * q2 * 2.0f;
+float t17 = q1 * q3 * 2.0f;
+float t18 = t16 + t17;
+float t19 = t15 * t18;
+float t20 = q0 * q1 * 2.0f;
+float t28 = q2 * q3 * 2.0f;
+float t21 = t20 - t28;
+float t29 = t8 * t9 * t21;
+float t22 = t19 - t29;
+float t23 = t2 + t3 - t4 - t5;
+float t24 = t15 * t23;
+float t25 = t7 + t10;
+float t26 = t8 * t9 * t25;
+float t27 = t24 + t26;
+float t30 = P[0][0] * t14 * t22;
+float t31 = P[0][2] * t14 * t22;
+float t37 = P[2][2] * t14 * t27;
+float t32 = t31 - t37;
+float t39 = P[2][0] * t14 * t27;
+float t33 = t30 - t39;
+float t34 = t14 * t22 * t33;
+float t38 = t14 * t27 * t32;
+float t35 = R_YAW + t34 - t38;
+float t36 = 1.0f / t35;
+float t40 = q0;
+float t41 = q1;
+float t42 = q2;
+float t43 = q3;
+float t44 = t40 * t40;
+float t45 = t41 * t41;
+float t46 = t42 * t42;
+float t47 = t43 * t43;
+float t48 = t44 - t45 + t46 - t47;
+float t49 = t40 * t43 * 2.0f;
+float t53 = t41 * t42 * 2.0f;
+float t50 = t49 - t53;
+float t51 = 1.0f / (t48 * t48);
+float t52 = 1.0f / t48;
+float t54 = t50 * t50;
+float t55 = t51 * t54;
+float t56 = t55 + 1.0f;
+float t57 = 1.0f / t56;
+
+// calculate Kalman gains
+float Kfusion[24] = {};
+Kfusion[0] = -t36 * (t30 - P[0][2] * t14 * t27);
+Kfusion[1] = -t36 * (P[1][0] * t14 * t22 - P[1][2] * t14 * t27);
+Kfusion[2] = t36 * (t37 - P[2][0] * t14 * t22);
+Kfusion[3] = -t36 * (P[3][0] * t14 * t22 - P[3][2] * t14 * t27);
+Kfusion[4] = -t36 * (P[4][0] * t14 * t22 - P[4][2] * t14 * t27);
+Kfusion[5] = -t36 * (P[5][0] * t14 * t22 - P[5][2] * t14 * t27);
+Kfusion[6] = -t36 * (P[6][0] * t14 * t22 - P[6][2] * t14 * t27);
+Kfusion[7] = -t36 * (P[7][0] * t14 * t22 - P[7][2] * t14 * t27);
+Kfusion[8] = -t36 * (P[8][0] * t14 * t22 - P[8][2] * t14 * t27);
+Kfusion[9] = -t36 * (P[9][0] * t14 * t22 - P[9][2] * t14 * t27);
+Kfusion[10] = -t36 * (P[10][0] * t14 * t22 - P[10][2] * t14 * t27);
+Kfusion[11] = -t36 * (P[11][0] * t14 * t22 - P[11][2] * t14 * t27);
+Kfusion[12] = -t36 * (P[12][0] * t14 * t22 - P[12][2] * t14 * t27);
+Kfusion[13] = -t36 * (P[13][0] * t14 * t22 - P[13][2] * t14 * t27);
+Kfusion[14] = -t36 * (P[14][0] * t14 * t22 - P[14][2] * t14 * t27);
+Kfusion[15] = -t36 * (P[15][0] * t14 * t22 - P[15][2] * t14 * t27);
+Kfusion[16] = -t36*(P[16][0]*t14*t22-P[16][2]*t14*t27);
+Kfusion[17] = -t36*(P[17][0]*t14*t22-P[17][2]*t14*t27);
+Kfusion[18] = -t36*(P[18][0]*t14*t22-P[18][2]*t14*t27);
+Kfusion[19] = -t36*(P[19][0]*t14*t22-P[19][2]*t14*t27);
+Kfusion[20] = -t36*(P[20][0]*t14*t22-P[20][2]*t14*t27);
+Kfusion[21] = -t36*(P[21][0]*t14*t22-P[21][2]*t14*t27);
+Kfusion[22] = -t36 * (P[22][0] * t14 * t22 - P[22][2] * t14 * t27);
+Kfusion[23] = -t36 * (P[23][0] * t14 * t22 - P[23][2] * t14 * t27);
+
+// calculate observation jacobian
+float H_YAW[3] = {};
+H_YAW[0] = -t57 * (t52 * (t40 * t42 * 2.0f + t41 * t43 * 2.0f) - t50 * t51 * (t40 * t41 * 2.0f - t42 * t43 * 2.0f));
+H_YAW[2] = t57 * (t52 * (t44 + t45 - t46 - t47) + t50 * t51 * (t49 + t53));

--- a/matlab/scripts/Inertial Nav EKF/GenerateNavFilterEquations.m
+++ b/matlab/scripts/Inertial Nav EKF/GenerateNavFilterEquations.m
@@ -289,7 +289,7 @@ K_MAGS = (Psimple*transpose(H_MAGS))/(H_MAGS*Psimple*transpose(H_MAGS) + R_DECL)
 %[K_MAGS,SK_MAGS]=OptimiseAlgebra(K_MAGS,'SK_MAGS');
 ccode(K_MAGS,'file','calcK_MAGS.c');
 
-%% derive equations for fusion of yaw measurements
+%% derive equations for fusion of 321 sequence yaw measurement
 
 % rotate X body axis into earth axes
 yawVec = Tbn*[1;0;0];
@@ -305,6 +305,18 @@ ccode(H_YAW,'file','calcH_YAW.c');
 K_YAW = (P*transpose(H_YAW))/(H_YAW*P*transpose(H_YAW) + R_YAW);
 %K_MAGS = simplify(K_MAGS);
 ccode(K_YAW,'file','calcK_YAW.c');
+
+%% derive equations for fusion of 312 sequence yaw measurement
+
+Tnb = transpose(Tbn);
+% Calculate the yaw angle of the projection
+angMeas = atan(-Tnb(2,1)/Tnb(2,2));
+H_YAW2 = jacobian(angMeas,stateVector); % measurement Jacobian
+H_YAW2 = subs(H_YAW2, {'rotErrX', 'rotErrY', 'rotErrZ'}, {0,0,0});
+%ccode(H_YAW2,'file','calcH_YAW2.c');
+% Calculate Kalman gain vector
+K_YAW2 = (P*transpose(H_YAW2))/(H_YAW2*P*transpose(H_YAW2) + R_YAW);
+ccode([K_YAW2;H_YAW2'],'file','calcYAW2.c');
 
 %% derive equations for fusion of synthetic deviation measurement
 % used to keep correct heading when operating without absolute position or


### PR DESCRIPTION
Thes changes add a method to fuse in magnetic heading using both a 321 and 312 Euler yaw observation and automatically chooses the best option to eliminate problems associated with use of an Euler angle observation when the second angle in the rotation set is near +-90 degrees.

This has enabled the simple yaw fusion method to be the default method for on-ground operation, which significantly reduces the effect of magnetic field disturbances on the roll and pitch angle.

The 3-axis fusion remains as the default method for up and away flight.

TODO - the required 312 Euler to DCM and DCM to Euler conversions were not available in the library so have been inlined. They will need to be added to the ECL math library.