### PR TITLE
EKF: Reduce effect of magnetic field disturbances on roll and pitch

### DIFF
--- a/EKF/common.h
+++ b/EKF/common.h
@@ -183,7 +183,7 @@ struct parameters {
 		posNE_innov_gate = 3.0f;
 		vel_innov_gate = 3.0f;
 
-		mag_heading_noise = 1.7e-1f;
+		mag_heading_noise = 5.0e-1f;
 		mag_noise = 5.0e-2f;
 		mag_declination_deg = 0.0f;
 		heading_innov_gate = 3.0f;

--- a/EKF/control.cpp
+++ b/EKF/control.cpp
@@ -105,9 +105,9 @@ void Ekf::controlFusionModes()
 	// or the more accurate 3-axis fusion
 	if (_params.mag_fusion_type == MAG_FUSE_TYPE_AUTO) {
 		if (!_control_status.flags.armed) {
-			// always use 2D mag fusion for initial startup
-			_control_status.flags.mag_hdg = false;
-			_control_status.flags.mag_2D = true;
+			// use heading fusion for initial startup
+			_control_status.flags.mag_hdg = true;
+			_control_status.flags.mag_2D = false;
 			_control_status.flags.mag_3D = false;
 
 		} else {
@@ -123,24 +123,17 @@ void Ekf::controlFusionModes()
 				_control_status.flags.mag_3D = true;
 
 			} else {
-				// always use 2D mag fusion when on the ground
-				_control_status.flags.mag_hdg = false;
-				_control_status.flags.mag_2D = true;
+				// use heading fusion when on the ground
+				_control_status.flags.mag_hdg = true;
+				_control_status.flags.mag_2D = false;
 				_control_status.flags.mag_3D = false;
 			}
 		}
 
 	} else if (_params.mag_fusion_type == MAG_FUSE_TYPE_HEADING) {
-		// always use yaw fusion unless tilt is over 45 deg, otherwise use 2D fusion
-		if (_R_prev(2, 2) > 0.7071f) {
-			_control_status.flags.mag_hdg = true;
-			_control_status.flags.mag_2D = false;
-
-		} else {
-			_control_status.flags.mag_hdg = false;
-			_control_status.flags.mag_2D = true;
-		}
-
+		// always use heading fusion
+		_control_status.flags.mag_hdg = true;
+		_control_status.flags.mag_2D = false;
 		_control_status.flags.mag_3D = false;
 
 	} else if (_params.mag_fusion_type == MAG_FUSE_TYPE_2D) {

--- a/EKF/control.cpp
+++ b/EKF/control.cpp
@@ -112,12 +112,12 @@ void Ekf::controlFusionModes()
 
 		} else {
 			if (_control_status.flags.in_air) {
-				// if transitioning from a non-3D fusion mode, we need to initialise the yaw angle and field states
+				// if transitioning into 3-axis fusion mode, we need to initialise the yaw angle and field states
 				if (!_control_status.flags.mag_3D) {
 					_control_status.flags.yaw_align = resetMagHeading(_mag_sample_delayed.mag);
 				}
 
-				// always use 3D mag fusion when airborne
+				// use 3D mag fusion when airborne
 				_control_status.flags.mag_hdg = false;
 				_control_status.flags.mag_2D = false;
 				_control_status.flags.mag_3D = true;
@@ -143,7 +143,7 @@ void Ekf::controlFusionModes()
 		_control_status.flags.mag_3D = false;
 
 	} else if (_params.mag_fusion_type == MAG_FUSE_TYPE_3D) {
-		// if transitioning from a non-3D fusion mode, we need to initialise the yaw angle and field states
+		// if transitioning into 3-axis fusion mode, we need to initialise the yaw angle and field states
 		if (!_control_status.flags.mag_3D) {
 			_control_status.flags.yaw_align = resetMagHeading(_mag_sample_delayed.mag);
 		}

--- a/EKF/ekf.cpp
+++ b/EKF/ekf.cpp
@@ -115,11 +115,11 @@ bool Ekf::init(uint64_t timestamp)
 	_output_new.vel.setZero();
 	_output_new.pos.setZero();
 	_output_new.quat_nominal = matrix::Quaternion<float>();
-    
+
 	_delta_angle_corr.setZero();
 	_delta_vel_corr.setZero();
 	_vel_corr.setZero();
-    
+
 	_imu_down_sampled.delta_ang.setZero();
 	_imu_down_sampled.delta_vel.setZero();
 	_imu_down_sampled.delta_ang_dt = 0.0f;
@@ -180,6 +180,7 @@ bool Ekf::update()
 			fuseMag2D();
 
 		} else if (_control_status.flags.mag_hdg && _control_status.flags.yaw_align) {
+			// fusion of a Euler yaw angle from either a 321 or 312 rotation sequence
 			fuseHeading();
 
 		} else {

--- a/EKF/ekf.h
+++ b/EKF/ekf.h
@@ -187,7 +187,7 @@ private:
 	// ekf sequential fusion of magnetometer measurements
 	void fuseMag();
 
-	// fuse heading measurement (currently uses estimate from magnetometer)
+	// fuse the first euler angle from either a 321 or 312 rotation sequence as the observation (currently measures yaw using the magnetometer)
 	void fuseHeading();
 
 	// fuse projecton of magnetometer onto horizontal plane

--- a/EKF/mag_fusion.cpp
+++ b/EKF/mag_fusion.cpp
@@ -510,7 +510,15 @@ void Ekf::fuseHeading()
 		float t7 = q0 * q3 * 2.0f;
 		float t8 = q1 * q2 * 2.0f;
 		float t9 = t7 + t8;
-		float t10 = 1.0f / (t6 * t6);
+		float t10 = sq(t6);
+
+		if (t10 > 1e-6f) {
+			t10 = 1.0f / t10;
+
+		} else {
+			return;
+		}
+
 		float t11 = t9 * t9;
 		float t12 = t10 * t11;
 		float t13 = t12 + 1.0f;
@@ -523,14 +531,7 @@ void Ekf::fuseHeading()
 			return;
 		}
 
-		float t15;
-
-		if (fabsf(t6) > 1e-6f) {
-			t15 = 1.0f / t6;
-
-		} else {
-			return;
-		}
+		float t15 = 1.0f / t6;
 
 		H_YAW[0] = 0.0f;
 		H_YAW[1] = t14 * (t15 * (q0 * q1 * 2.0f - q2 * q3 * 2.0f) + t9 * t10 * (q0 * q2 * 2.0f + q1 * q3 * 2.0f));
@@ -557,7 +558,15 @@ void Ekf::fuseHeading()
 		float t7 = q0 * q3 * 2.0f;
 		float t10 = q1 * q2 * 2.0f;
 		float t8 = t7 - t10;
-		float t9 = 1.0f / (t6 * t6);
+		float t9 = sq(t6);
+
+		if (t9 > 1e-6f) {
+			t9 = 1.0f / t9;
+
+		} else {
+			return;
+		}
+
 		float t11 = t8 * t8;
 		float t12 = t9 * t11;
 		float t13 = t12 + 1.0f;
@@ -570,14 +579,7 @@ void Ekf::fuseHeading()
 			return;
 		}
 
-		float t15;
-
-		if (fabsf(t6) > 1e-6f) {
-			t15 = 1.0f / t6;
-
-		} else {
-			return;
-		}
+		float t15 = 1.0f / t6;
 
 		H_YAW[0] = -t14 * (t15 * (q0 * q2 * 2.0f + q1 * q3 * 2.0f) - t8 * t9 * (q0 * q1 * 2.0f - q2 * q3 * 2.0f));
 		H_YAW[1] = 0.0f;

--- a/matlab/generated/Inertial Nav EKF/Yaw Angle Fusion.txt
+++ b/matlab/generated/Inertial Nav EKF/Yaw Angle Fusion.txt
@@ -1,10 +1,8 @@
 /* 
-Autocode for fusion of an Euler yaw measurement.
-
-Protection against /0 and covariance matrix errors will need to be added.
+Code fragments for fusion of an Euler yaw measurement from a 321 sequence.
 */
 
-// intermediate variables
+// calculate observation jacobians
 float t2 = q0*q0;
 float t3 = q1*q1;
 float t4 = q2*q2;
@@ -19,9 +17,29 @@ float t12 = t10*t11;
 float t13 = t12+1.0f;
 float t14 = 1.0f/t13;
 float t15 = 1.0f/t6;
-
-// Calculate the observation jacobian for the innovation derivative wrt the attitude error states only
-// Use the reduced order to optimise the calculation of the Kalman gain matrix and covariance update
-float H_MAG[3];
+H_YAW[0] = 0.0f;
 H_YAW[1] = t14*(t15*(q0*q1*2.0f-q2*q3*2.0f)+t9*t10*(q0*q2*2.0f+q1*q3*2.0f));
 H_YAW[2] = t14*(t15*(t2-t3+t4-t5)+t9*t10*(t7-t8));
+
+/*
+Code fragments for fusion of an Euler yaw measurement from a 312 sequence.
+*/
+
+// calculate observation jacobian
+float t2 = q0*q0;
+float t3 = q1*q1;
+float t4 = q2*q2;
+float t5 = q3*q3;
+float t6 = t2-t3+t4-t5;
+float t7 = q0*q3*2.0f;
+float t10 = q1*q2*2.0f;
+float t8 = t7-t10;
+float t9 = 1.0f/(t6*t6);
+float t11 = t8*t8;
+float t12 = t9*t11;
+float t13 = t12+1.0f;
+float t14 = 1.0f/t13;
+float t15 = 1.0f/t6;
+H_YAW[0] = -t14*(t15*(q0*q2*2.0f+q1*q3*2.0f)-t8*t9*(q0*q1*2.0f-q2*q3*2.0f));
+H_YAW[1] = 0.0f;
+H_YAW[2] = t14*(t15*(t2+t3-t4-t5)+t8*t9*(t7+t10));


### PR DESCRIPTION
**Information**

Replaces #67 

The previous default method of fusing magnetometer data when on the ground used the azimuth angle of the projection of the measured field onto the horizontal. Unfortunately this method did not decouple the observation from the roll and pitch angle in the filter observation equations with the result that magnetic field interference could create large errors in the estimated roll and pitch.

The alternative provided as an option was fusion of the Euler yaw angle obtained from a separate magnetic compass calculation which had much smaller levels of roll and pitch error due to magnetic field disturbances. However this could not be used as a default method because it suffered from singularities at +-90 deg pitch.

The solution was to enable fusion of magnetic heading using either a 321 and 312 Euler yaw observation and automatically chooses the best option to eliminate problems associated with use of an Euler angle observation when the second angle in the rotation set is near +-90 degrees.

This has enabled the simple yaw fusion method to be the default method for on-ground operation, which significantly reduces the effect of magnetic field disturbances on the roll and pitch angle.

The 3-axis fusion remains as the default method for up and away flight.

The required 312 Euler to DCM and DCM to Euler conversions were not available in the library so have been inlined. They will need to be added to the ECL math library.

** Test Results**

The susceptibility to magnetic interference was tested on the bench with the board stationary and a magnetised steel rod used to create large levels of magnetic interference. The 2D fusion as can be seen next suffers from large level of coupling between magnetic field disturbance and roll and pitch errors:

![mag_2d](https://cloud.githubusercontent.com/assets/3596952/13418427/6fa1ca34-dfc9-11e5-8439-43a826518f35.png)

The new heading fusion method reduced the disturbances by an order of magnitude:

![mag_hdg](https://cloud.githubusercontent.com/assets/3596952/13418454/936aa21a-dfc9-11e5-98ca-956aa4b194ac.png)