### PR TITLE
initialize ECL_L1 variables

### DIFF
--- a/l1/ecl_l1_pos_controller.h
+++ b/l1/ecl_l1_pos_controller.h
@@ -70,9 +70,15 @@
 class __EXPORT ECL_L1_Pos_Controller
 {
 public:
-	ECL_L1_Pos_Controller() {
-		_L1_period = 25;
-		_L1_damping = 0.75f;
+	ECL_L1_Pos_Controller() :
+		_L1_distance(20.0),
+		_L1_period(25.0),
+		_L1_damping(0.75),
+		_L1_ratio(5.0),
+		_K_L1(2.0),
+		_heading_omega(1.0),
+		_roll_lim_rad(math::radians(10.0))
+	{
 	}
 
 	/**


### PR DESCRIPTION
This is a possible fix for https://github.com/PX4/Firmware/issues/3902, but should be good regardless.