### PR TITLE
EKF: Add option to use GPS for height and improve height fall-back behaviour

### DIFF
--- a/EKF/common.h
+++ b/EKF/common.h
@@ -90,6 +90,9 @@ struct gpsSample {
 	Vector2f    pos;	// NE earth frame gps horizontal position measurement in m
 	float       hgt;	// gps height measurement in m
 	Vector3f    vel;	// NED earth frame gps velocity measurement in m/s
+	float	    hacc;	// 1-std horizontal position error m
+	float	    vacc;	// 1-std vertical position error m
+	float       sacc;	// 1-std speed error m/s
 	uint64_t    time_us;	// timestamp in microseconds
 };
 
@@ -142,6 +145,11 @@ struct flowSample {
 #define MAG_FUSE_TYPE_3D        2   // Magnetometer 3-axis fusion will always be used. This is more accurate, but more affected by localised earth field distortions
 #define MAG_FUSE_TYPE_2D        3   // A 2D fusion that uses the horizontal projection of the magnetic fields measurement will alays be used. This is less accurate, but less affected by earth field distortions.
 
+// Maximum sensor intervals in usec
+#define GPS_MAX_INTERVAL	5e5
+#define BARO_MAX_INTERVAL	2e5
+#define RNG_MAX_INTERVAL	2e5
+
 struct parameters {
 	// measurement source control
 	int fusion_mode;		// bitmasked integer that selects which of the GPS and optical flow aiding sources will be used
@@ -176,6 +184,7 @@ struct parameters {
 	float baro_innov_gate;		// barometric height innovation consistency gate size (STD)
 	float posNE_innov_gate;		// GPS horizontal position innovation consistency gate size (STD)
 	float vel_innov_gate;		// GPS velocity innovation consistency gate size (STD)
+	float hgt_reset_lim;		// The maximum 1-sigma uncertainty in height that can be tolerated before the height state is reset (m)
 
 	// magnetometer fusion
 	float mag_heading_noise;	// measurement noise used for simple heading fusion (rad)
@@ -245,6 +254,7 @@ struct parameters {
 		baro_innov_gate = 3.0f;
 		posNE_innov_gate = 3.0f;
 		vel_innov_gate = 3.0f;
+		hgt_reset_lim = 5.0f;
 
 		// magnetometer fusion
 		mag_heading_noise = 1.7e-1f;
@@ -341,4 +351,5 @@ union filter_control_status_u {
 	} flags;
 	uint16_t value;
 };
+
 }

--- a/EKF/ekf.cpp
+++ b/EKF/ekf.cpp
@@ -434,9 +434,6 @@ bool Ekf::initialiseFilter(void)
 			_baro_hgt_offset = 0.0f;
 		}
 
-		// set the velocity to the GPS measurement (by definition, the initial position and height is at the origin)
-		resetVelocity();
-
 		// initialise the state covariance matrix
 		initialiseCovariance();
 

--- a/EKF/ekf.cpp
+++ b/EKF/ekf.cpp
@@ -84,8 +84,6 @@ Ekf::Ekf():
 	_rng_hgt_faulty(false),
 	_baro_hgt_offset(0.0f)
 {
-	_control_status = {};
-	_control_status_prev = {};
 	_state = {};
 	_last_known_posNE.setZero();
 	_earth_rate_NED.setZero();
@@ -155,6 +153,9 @@ bool Ekf::init(uint64_t timestamp)
 
 	_filter_initialised = false;
 	_terrain_initialised = false;
+
+	_control_status.value = 0;
+	_control_status_prev.value = 0;
 
 	return ret;
 }

--- a/EKF/ekf.cpp
+++ b/EKF/ekf.cpp
@@ -307,6 +307,11 @@ bool Ekf::update()
 	// the output observer always runs
 	calculateOutputStates();
 
+	// check for NaN on attitude states
+	if (isnan(_state.quat_nominal(0)) || isnan(_output_new.quat_nominal(0))) {
+		return false;
+	}
+
 	// We don't have valid data to output until tilt and yaw alignment is complete
 	if (_control_status.flags.tilt_align && _control_status.flags.yaw_align) {
 		return true;

--- a/EKF/ekf.cpp
+++ b/EKF/ekf.cpp
@@ -71,15 +71,17 @@ Ekf::Ekf():
 	_last_gps_origin_time_us(0),
 	_gps_alt_ref(0.0f),
 	_hgt_counter(0),
-	_time_last_hgt(0),
-	_hgt_sum(0.0f),
+	_hgt_filt_state(0.0f),
 	_mag_counter(0),
 	_time_last_mag(0),
-	_hgt_at_alignment(0.0f),
+	_hgt_sensor_offset(0.0f),
 	_terrain_vpos(0.0f),
 	_hagl_innov(0.0f),
 	_hagl_innov_var(0.0f),
 	_time_last_hagl_fuse(0),
+	_baro_hgt_faulty(false),
+	_gps_hgt_faulty(false),
+	_rng_hgt_faulty(false),
 	_baro_hgt_offset(0.0f)
 {
 	_control_status = {};
@@ -100,7 +102,7 @@ Ekf::Ekf():
 	_last_known_posNE.setZero();
 	_imu_down_sampled = {};
 	_q_down_sampled.setZero();
-	_mag_sum = {};
+	_mag_filt_state = {};
 	_delVel_sum = {};
 	_flow_gyro_bias = {};
 	_imu_del_ang_of = {};
@@ -160,13 +162,13 @@ bool Ekf::init(uint64_t timestamp)
 bool Ekf::update()
 {
 
-		if (!_filter_initialised) {
-			_filter_initialised = initialiseFilter();
+	if (!_filter_initialised) {
+		_filter_initialised = initialiseFilter();
 
-			if (!_filter_initialised) {
-				return false;
-			}
+		if (!_filter_initialised) {
+			return false;
 		}
+	}
 
 	// Only run the filter if IMU data in the buffer has been updated
 	if (_imu_updated) {
@@ -221,22 +223,16 @@ bool Ekf::update()
 				_fuse_height = true;
 			}
 
-		} else if ((_time_last_imu - _time_last_hgt_fuse) > 5e5 && _control_status.flags.rng_hgt) {
+		} else if ((_time_last_imu - _time_last_hgt_fuse) > 2 * RNG_MAX_INTERVAL && _control_status.flags.rng_hgt) {
 			// If we are supposed to be using range finder data as the primary height sensor, have missed or rejected measurements
 			// and are on the ground, then synthesise a measurement at the expected on ground value
 			if (!_in_air) {
 				_range_sample_delayed.rng = _params.rng_gnd_clearance;
 				_range_sample_delayed.time_us = _imu_sample_delayed.time_us;
 
-			} else {
-				// if this happens in the air, fuse the baro measurement to constrain drift
-				// use the baro for this update only
-				_control_status.flags.baro_hgt = true;
-				_control_status.flags.rng_hgt = false;
 			}
 
 			_fuse_height = true;
-
 		}
 
 		// determine if baro data has fallen behind the fuson time horizon and fuse it in the main filter if enabled
@@ -246,16 +242,25 @@ bool Ekf::update()
 
 			} else {
 				// calculate a filtered offset between the baro origin and local NED origin if we are not using the baro  as a height reference
-				float offset_error = _baro_sample_delayed.hgt + _state.pos(2) - _baro_hgt_offset;
+				float offset_error =  _state.pos(2) + _baro_sample_delayed.hgt - _hgt_sensor_offset - _baro_hgt_offset;
 				_baro_hgt_offset += 0.02f * math::constrain(offset_error, -5.0f, 5.0f);
 			}
 		}
 
 		// If we are using GPS aiding and data has fallen behind the fusion time horizon then fuse it
-		if (_gps_buffer.pop_first_older_than(_imu_sample_delayed.time_us, &_gps_sample_delayed) && _control_status.flags.gps) {
-			_fuse_pos = true;
-			_fuse_vert_vel = true;
-			_fuse_hor_vel = true;
+		if (_gps_buffer.pop_first_older_than(_imu_sample_delayed.time_us, &_gps_sample_delayed)) {
+			// Only use GPS data for position and velocity aiding if enabled
+			if (_control_status.flags.gps) {
+				_fuse_pos = true;
+				_fuse_vert_vel = true;
+				_fuse_hor_vel = true;
+			}
+
+			// only use gps height observation in the main filter if specifically enabled
+			if (_control_status.flags.gps_hgt) {
+				_fuse_height = true;
+			}
+
 		}
 
 		// If we are using optical flow aiding and data has fallen behind the fusion time horizon, then fuse it
@@ -320,30 +325,44 @@ bool Ekf::initialiseFilter(void)
 	_delVel_sum += imu_init.delta_vel;
 
 	// Sum the magnetometer measurements
-	magSample mag_init = _mag_buffer.get_newest();
-
-	if (mag_init.time_us != 0) {
-		_mag_counter ++;
-		_mag_sum += mag_init.mag;
-	}
-
-	if (_params.vdist_sensor_type == VDIST_SENSOR_RANGE) {
-		rangeSample range_init = _range_buffer.get_newest();
-
-		if (range_init.time_us != _time_last_hgt) {
-			_hgt_counter ++;
-			_hgt_sum += range_init.rng;
-			_time_last_hgt = range_init.time_us;
+	if (_mag_buffer.pop_first_older_than(_imu_sample_delayed.time_us, &_mag_sample_delayed)) {
+		if (_mag_counter == 0) {
+			_mag_filt_state = _mag_sample_delayed.mag;
 		}
 
-	} else if (_params.vdist_sensor_type == VDIST_SENSOR_BARO) {
-		// initialize vertical position with newest baro measurement
-		baroSample baro_init = _baro_buffer.get_newest();
+		_mag_counter ++;
+		_mag_filt_state = _mag_filt_state * 0.9f + _mag_sample_delayed.mag * 0.1f;
+	}
 
-		if (baro_init.time_us != _time_last_hgt) {
+	// set the default height source from the adjustable parameter
+	if (_hgt_counter == 0) {
+		_primary_hgt_source = _params.vdist_sensor_type;
+	}
+
+	if (_primary_hgt_source == VDIST_SENSOR_RANGE) {
+		if (_range_buffer.pop_first_older_than(_imu_sample_delayed.time_us, &_range_sample_delayed)) {
+			if (_hgt_counter == 0) {
+				_control_status.flags.baro_hgt = false;
+				_control_status.flags.gps_hgt = false;
+				_control_status.flags.rng_hgt = true;
+				_hgt_filt_state = _range_sample_delayed.rng;
+			}
+
 			_hgt_counter ++;
-			_hgt_sum += baro_init.hgt;
-			_time_last_hgt = baro_init.time_us;
+			_hgt_filt_state = 0.9f * _hgt_filt_state + 0.1f * _range_sample_delayed.rng;
+		}
+
+	} else if (_primary_hgt_source == VDIST_SENSOR_BARO || _primary_hgt_source == VDIST_SENSOR_GPS) {
+		if (_baro_buffer.pop_first_older_than(_imu_sample_delayed.time_us, &_baro_sample_delayed)) {
+			if (_hgt_counter == 0) {
+				_control_status.flags.baro_hgt = true;
+				_control_status.flags.gps_hgt = false;
+				_control_status.flags.rng_hgt = false;
+				_hgt_filt_state = _baro_sample_delayed.hgt;
+			}
+
+			_hgt_counter ++;
+			_hgt_filt_state = 0.9f * _hgt_filt_state + 0.1f * _baro_sample_delayed.hgt;
 		}
 
 	} else {
@@ -351,10 +370,14 @@ bool Ekf::initialiseFilter(void)
 	}
 
 	// check to see if we have enough measurements and return false if not
-	if (_hgt_counter < 10 || _mag_counter < 10) {
+	if (_hgt_counter <= 10 || _mag_counter <= 10) {
 		return false;
 
 	} else {
+		// reset variables that are shared with post alignment GPS checks
+		_gps_drift_velD = 0.0f;
+		_gps_alt_ref = 0.0f;
+
 		// Zero all of the states
 		_state.ang_error.setZero();
 		_state.vel.setZero();
@@ -388,19 +411,20 @@ bool Ekf::initialiseFilter(void)
 		_tilt_err_length_filt = 1.0f;
 
 		// calculate the averaged magnetometer reading
-		Vector3f mag_init = _mag_sum * (1.0f / (float(_mag_counter)));
+		Vector3f mag_init = _mag_filt_state;
 
 		// calculate the initial magnetic field and yaw alignment
 		resetMagHeading(mag_init);
 
 		// calculate the averaged height reading to calulate the height of the origin
-		_hgt_at_alignment = _hgt_sum / (float)_hgt_counter;
+		_hgt_sensor_offset = _hgt_filt_state;
 
 		// if we are not using the baro height as the primary source, then calculate an offset relative to the origin
 		// so it can be used as a backup
-		if (_params.vdist_sensor_type != VDIST_SENSOR_BARO) {
+		if (!_control_status.flags.baro_hgt) {
 			baroSample baro_newest = _baro_buffer.get_newest();
-			_baro_hgt_offset = baro_newest.hgt - _hgt_at_alignment;
+			_baro_hgt_offset = baro_newest.hgt - _hgt_sensor_offset;
+
 		} else {
 			_baro_hgt_offset = 0.0f;
 		}

--- a/EKF/ekf.h
+++ b/EKF/ekf.h
@@ -98,12 +98,6 @@ public:
 	bool collect_gps(uint64_t time_usec, struct gps_message *gps);
 	bool collect_imu(imuSample &imu);
 
-	// this is the current status of the filter control modes
-	filter_control_status_u _control_status;
-
-	// this is the previous status of the filter control modes - used to detect mode transitions
-	filter_control_status_u _control_status_prev;
-
 	// get the ekf WGS-84 origin position and height and the system time it was last set
 	void get_ekf_origin(uint64_t *origin_time, map_projection_reference_s *origin_pos, float *origin_alt);
 
@@ -197,14 +191,13 @@ private:
 	float _gps_alt_ref;		// WGS-84 height (m)
 
 	// Variables used to initialise the filter states
-	uint8_t _hgt_counter;		// number of height samples averaged
-	uint64_t _time_last_hgt;	// measurement time of last height sample
-	float _hgt_sum;			// summed height measurement
-	uint8_t _mag_counter;		// number of magnetometer samples averaged
+	uint32_t _hgt_counter;		// number of height samples taken
+	float _hgt_filt_state;		// filtered height measurement
+	uint32_t _mag_counter;		// number of magnetometer samples taken
 	uint64_t _time_last_mag;	// measurement time of last magnetomter sample
-	Vector3f _mag_sum;		// summed magnetometer measurement
+	Vector3f _mag_filt_state;	// filtered magnetometer measurement
 	Vector3f _delVel_sum;		// summed delta velocity
-	float _hgt_at_alignment;	// baro offset relative to alignment position
+	float _hgt_sensor_offset;	// height that needs to be subtracted from the primary height sensor so that it reads zero height at the origin (m)
 
 	gps_check_fail_status_u _gps_check_fail_status;
 
@@ -215,6 +208,12 @@ private:
 	float _hagl_innov_var;		// innovation variance for the last height above terrain measurement (m^2)
 	uint64_t _time_last_hagl_fuse;	// last system time in usec that the hagl measurement failed it's checks
 	bool _terrain_initialised;	// true when the terrain estimator has been intialised
+
+	// height sensor fault status
+	bool _baro_hgt_faulty;		// true if valid baro data is unavailable for use
+	bool _gps_hgt_faulty;		// true if valid gps height data is unavailable for use
+	bool _rng_hgt_faulty;		// true if valid rnage finder height data is unavailable for use
+	int _primary_hgt_source;	// priary source of height data set at initialisation
 
 	float _baro_hgt_offset;		// number of metres the baro height origin is above the local NED origin (m)
 

--- a/EKF/estimator_interface.cpp
+++ b/EKF/estimator_interface.cpp
@@ -299,6 +299,29 @@ bool EstimatorInterface::initialise_interface(uint64_t timestamp)
 		return false;
 	}
 
+	// zero the data in the observation buffers
+	for (int index=0; index < OBS_BUFFER_LENGTH; index++) {
+		gpsSample gps_sample_init = {};
+		_gps_buffer.push(gps_sample_init);
+		magSample mag_sample_init = {};
+		_mag_buffer.push(mag_sample_init);
+		baroSample baro_sample_init = {};
+		_baro_buffer.push(baro_sample_init);
+		rangeSample range_sample_init = {};
+		_range_buffer.push(range_sample_init);
+		airspeedSample airspeed_sample_init = {};
+		_airspeed_buffer.push(airspeed_sample_init);
+		flowSample flow_sample_init = {};
+		_flow_buffer.push(flow_sample_init);
+	}
+
+	// zero the data in the imu data and output observer state buffers
+	for (int index=0; index < IMU_BUFFER_LENGTH; index++) {
+		imuSample imu_sample_init = {};
+		_imu_buffer.push(imu_sample_init);
+		outputSample output_sample_init = {};
+		_output_buffer.push(output_sample_init);
+	}
 
 	_dt_imu_avg = 0.0f;
 

--- a/EKF/estimator_interface.h
+++ b/EKF/estimator_interface.h
@@ -222,8 +222,6 @@ protected:
 
 	bool _NED_origin_initialised = false;
 	bool _gps_speed_valid = false;
-	float _gps_speed_accuracy = 0.0f; // GPS receiver reported 1-sigma speed accuracy (m/s)
-	float _gps_hpos_accuracy = 0.0f; // GPS receiver reported 1-sigma horizontal accuracy (m)
 	float _gps_origin_eph = 0.0f; // horizontal position uncertainty of the GPS origin
 	float _gps_origin_epv = 0.0f; // vertical position uncertainty of the GPS origin
 	struct map_projection_reference_s _pos_ref = {};    // Contains WGS-84 position latitude and longitude (radians)
@@ -262,4 +260,11 @@ protected:
 
 	float _mag_declination_gps;         // magnetic declination returned by the geo library using the last valid GPS position (rad)
 	float _mag_declination_to_save_deg; // magnetic declination to save to EKF2_MAG_DECL (deg)
+
+	// this is the current status of the filter control modes
+	filter_control_status_u _control_status;
+
+	// this is the previous status of the filter control modes - used to detect mode transitions
+	filter_control_status_u _control_status_prev;
+
 };

--- a/EKF/gps_checks.cpp
+++ b/EKF/gps_checks.cpp
@@ -59,7 +59,7 @@ bool Ekf::collect_gps(uint64_t time_usec, struct gps_message *gps)
 	if (!_NED_origin_initialised) {
 		// we have good GPS data so can now set the origin's WGS-84 position
 		if (gps_is_good(gps) && !_NED_origin_initialised) {
-			printf("gps is good -  setting EKF origin\n");
+			printf("EKF gps is good - setting origin\n");
 			// Set the origin's WGS-84 position to the last gps fix
 			double lat = gps->lat / 1.0e7;
 			double lon = gps->lon / 1.0e7;
@@ -81,6 +81,16 @@ bool Ekf::collect_gps(uint64_t time_usec, struct gps_message *gps)
 			// save the horizontal and vertical position uncertainty of the origin
 			_gps_origin_eph = gps->eph;
 			_gps_origin_epv = gps->epv;
+
+			// if the user has selected GPS as the primary height source, switch across to using it
+			if (_primary_hgt_source == VDIST_SENSOR_GPS) {
+				printf("EKF switching to GPS height\n");
+				_control_status.flags.baro_hgt = false;
+				_control_status.flags.gps_hgt = true;
+				_control_status.flags.rng_hgt = false;
+				// zero the sensor offset
+				_hgt_sensor_offset = 0.0f;
+			}
 		}
 	}
 

--- a/EKF/gps_checks.cpp
+++ b/EKF/gps_checks.cpp
@@ -143,7 +143,7 @@ bool Ekf::gps_is_good(struct gps_message *gps)
 
 	} else {
 		map_projection_init_timestamped(&_pos_ref, lat, lon, _time_last_imu);
-		_gps_alt_ref = gps->alt * 1e-3f;
+		_gps_alt_ref = 1e-3f * (float)gps->alt;
 	}
 
 	// Calculate time lapsed since last update, limit to prevent numerical errors and calculate the lowpass filter coefficient
@@ -176,10 +176,10 @@ bool Ekf::gps_is_good(struct gps_message *gps)
 
 	// Calculate the vertical drift velocity and limit to 10x the threshold
 	vel_limit = 10.0f * _params.req_vdrift;
-	float velD = fminf(fmaxf((_gps_alt_ref - gps->alt * 1e-3f) / dt, -vel_limit), vel_limit);
+	float velD = fminf(fmaxf((_gps_alt_ref - 1e-3f * (float)gps->alt) / dt, -vel_limit), vel_limit);
 
 	// Save the current height as the reference for next time
-	_gps_alt_ref = gps->alt * 1e-3f;
+	_gps_alt_ref = 1e-3f * (float)gps->alt;
 
 	// Apply a low pass filter to the vertical velocity
 	_gps_drift_velD = velD * filter_coef + _gps_drift_velD * (1.0f - filter_coef);

--- a/EKF/mag_fusion.cpp
+++ b/EKF/mag_fusion.cpp
@@ -1007,7 +1007,6 @@ void Ekf::fuseMag2D()
 		// we allow to use it when on the ground because the large innovation could be caused
 		// by interference or a large initial gyro bias
 		if (_control_status.flags.in_air) {
-			printf("return 5\n");
 			return;
 
 		} else {


### PR DESCRIPTION
- Add GPS accuracy data to GPS buffer so that the accuracy and measurement information used by various processes is from the same point in time.
- Define maximum measurement intervals for different sensor types so that timeouts can be detected using consistent thresholds
- Use a combined time and height uncertainty criteria to determine if the height state needs to be reset
- Maintain a filtered baro height correction so that the baro data can be used as a fall-back if either range or GPS height fusion fails
- Use  low pass filtered data during alignment instead of averaged data to reduce the effect of time delays and allow for longer averaging periods when using range finder data.
- Implement a consistent fall-back behaviour following a height fusion timeout.

**Flight Test Results**

http://logs.uaventure.com/view/7Cc2Jtrrarxc7RKCqfFX4Y

A flight test was conducted indoors with EKF2_HGT_MODE = 1 to use GPs altitude. The board used was a pixracer. The rc.logging file was modified to that data logging started in power-up. Three flights were performed. Flight 1 started before the GPS origin was set, so the origin was set and the switch to GPS height use occurred in-flight.
The copter was landed and disarmed and the GPs connector was disconnected which caused it to revert to Baro height and static mode for position aiding. Flight 2 was performed without the GPs connected, the copter was landed, disarmed and the GPS connector reattached.  This caused the EKF to switch back to GPs aiding for position and velocity, but remain with Baro aiding as per the design intent.

Innovation Plots

There were two large glitches in baro measurements shortly after power-up - the cause of these glitches is not known and they have not been observed in other logs. The switch to GPS height and back again was smooth

![pos d innov](https://cloud.githubusercontent.com/assets/3596952/13809332/6c2c585a-ebbe-11e5-9de4-cc274dd876d8.png)
![vel d innov](https://cloud.githubusercontent.com/assets/3596952/13809336/6ec03370-ebbe-11e5-99fe-8808fba03f75.png)
![pos ne innov](https://cloud.githubusercontent.com/assets/3596952/13809347/76c75616-ebbe-11e5-8bcf-14b569c5c54b.png)
![vel ne innov](https://cloud.githubusercontent.com/assets/3596952/13809349/79a9db56-ebbe-11e5-9c17-0e36c395c124.png)

Local and Global Height

![height](https://cloud.githubusercontent.com/assets/3596952/13809355/81cda556-ebbe-11e5-8ae5-58455d498980.png)

NE Position - note the divergence in position after GPs loss which continues until the filter times-out and switches to a non-GPs mode. Note the reset back to the correct position when GPs is re-acquired.

![pos ne](https://cloud.githubusercontent.com/assets/3596952/13809509/3a038e38-ebbf-11e5-92fe-4e1230de663f.png)

NE Position 1-Sigma Uncertainty - note the growth in estimated error which matches the actual error growth

![pos ne uncertainty](https://cloud.githubusercontent.com/assets/3596952/13809525/47cc55c2-ebbf-11e5-936d-da486ae1995f.png)