### PR TITLE
activate airspeed fusion

### DIFF
--- a/EKF/airspeed_fusion.cpp
+++ b/EKF/airspeed_fusion.cpp
@@ -89,7 +89,9 @@ void Ekf::fuseAirspeed()
 		float _airspeed_innov_var_temp = (R_TAS + SH_TAS[2] * (P[3][3] * SH_TAS[2] + P[4][3] * SH_TAS[1] - P[22][3] * SH_TAS[2] - P[23][3] * SH_TAS[1] + P[5][3] * vd *SH_TAS[0]) + SH_TAS[1] * (P[3][4] * SH_TAS[2] + P[4][4] * SH_TAS[1] - P[22][4] * SH_TAS[2] - P[23][4] * SH_TAS[1] + P[5][4] * vd *SH_TAS[0]) - SH_TAS[2] * (P[3][22] * SH_TAS[2] + P[4][22] * SH_TAS[1] - P[22][22] * SH_TAS[2] - P[23][22] * SH_TAS[1] + P[5][22] * vd *SH_TAS[0]) - SH_TAS[1] * (P[3][23] * SH_TAS[2] + P[4][23] * SH_TAS[1] - P[22][23] * SH_TAS[2] - P[23][23] * SH_TAS[1] + P[5][23] * vd *SH_TAS[0]) + vd *SH_TAS[0] * (P[3][5] * SH_TAS[2] + P[4][5] * SH_TAS[1] - P[22][5] * SH_TAS[2] - P[23][5] * SH_TAS[1] + P[5][5] * vd *SH_TAS[0]));
 		if (_airspeed_innov_var_temp >= R_TAS) { // Check for badly conditioned calculation
             SK_TAS[0] = 1.0f / _airspeed_innov_var_temp;
+            _fault_status.bad_airspeed = false;
         } else { // Reset the estimator
+        	_fault_status.bad_airspeed = true;
             initialiseCovariance();
             return;
         }

--- a/EKF/airspeed_fusion.cpp
+++ b/EKF/airspeed_fusion.cpp
@@ -184,5 +184,4 @@ void Ekf::fuseAirspeed()
 		makeSymmetrical(); 
 		limitCov();
 	}
-	// Do we want to force and limit the covariance matrx even if v_tas_pred < X ?
 }

--- a/EKF/airspeed_fusion.cpp
+++ b/EKF/airspeed_fusion.cpp
@@ -134,7 +134,7 @@ void Ekf::fuseAirspeed()
 
 
 		// calculate measurement innovation
-		_airspeed_innov = v_tas_pred - _airspeed_sample_delayed.airspeed; // This is TAS, maybe we should indicate that in some way
+		_airspeed_innov = v_tas_pred - _airspeed_sample_delayed.true_airspeed; // This is TAS, maybe we should indicate that in some way
 
 		// Calculate the innovation variance
 		_airspeed_innov_var = 1.0f / SK_TAS[0];

--- a/EKF/airspeed_fusion.cpp
+++ b/EKF/airspeed_fusion.cpp
@@ -70,7 +70,7 @@ void Ekf::fuseAirspeed()
 	v_tas_pred = sqrtf((ve - vwe) * (ve - vwe) + (vn - vwn) * (vn - vwn) + vd * vd);
 
 	// Perform fusion of True Airspeed measurement
-	if (v_tas_pred > 3.0f) {
+	if (v_tas_pred > 1.0f) {
 		// Calculate the observation jacobian
 		// intermediate variable from algebraic optimisation
 		SH_TAS[0] = 1 / (sqrt(sq(ve - vwe) + sq(vn - vwn) + sq(vd)));

--- a/EKF/airspeed_fusion.cpp
+++ b/EKF/airspeed_fusion.cpp
@@ -73,7 +73,7 @@ void Ekf::fuseAirspeed()
 	if (v_tas_pred > 1.0f) {
 		// Calculate the observation jacobian
 		// intermediate variable from algebraic optimisation
-		SH_TAS[0] = 1 / (sqrt(sq(ve - vwe) + sq(vn - vwn) + sq(vd)));
+		SH_TAS[0] = 1 / v_tas_pred;
 		SH_TAS[1] = (SH_TAS[0] * (2 * ve - 2 * vwe)) / 2.0f;
 		SH_TAS[2] = (SH_TAS[0] * (2 * vn - 2 * vwn)) / 2.0f;
 

--- a/EKF/common.h
+++ b/EKF/common.h
@@ -112,7 +112,7 @@ struct rangeSample {
 };
 
 struct airspeedSample {
-	float       airspeed;	// true airspeed measurement in m/s
+	float       true_airspeed;	// true airspeed measurement in m/s
 	uint64_t    time_us;	// timestamp in microseconds
 };
 

--- a/EKF/ekf.cpp
+++ b/EKF/ekf.cpp
@@ -307,7 +307,7 @@ bool Ekf::update()
 		}
 
 		// Fuse airspeed if the data has fallen behind the fusion time horizon, we are airborne and the measured airspeed is above a defined threshold, now hardcoded to 5 m/s
-		if (_airspeed_buffer.pop_first_older_than(_imu_sample_delayed.time_us, &_airspeed_sample_delayed) && _in_air && _airspeed_sample_delayed.airspeed > 5.0f) {
+		if (_airspeed_buffer.pop_first_older_than(_imu_sample_delayed.time_us, &_airspeed_sample_delayed) && _in_air && _airspeed_sample_delayed.true_airspeed > 5.0f) {
 			fuseAirspeed();
 		}
 	}

--- a/EKF/ekf.cpp
+++ b/EKF/ekf.cpp
@@ -306,8 +306,8 @@ bool Ekf::update()
 			_fuse_flow = false;
 		}
 
-		// TODO This is just to get the logic inside but we will only start fusion once we tested this again
-		if (_airspeed_buffer.pop_first_older_than(_imu_sample_delayed.time_us, &_airspeed_sample_delayed) && false) {
+		// Fuse airspeed if the data has fallen behind the fusion time horizon, we are airborne and the measured airspeed is above a defined threshold, now hardcoded to 5 m/s
+		if (_airspeed_buffer.pop_first_older_than(_imu_sample_delayed.time_us, &_airspeed_sample_delayed) && _in_air && _airspeed_sample_delayed.airspeed > 5.0f) {
 			fuseAirspeed();
 		}
 	}

--- a/EKF/ekf.cpp
+++ b/EKF/ekf.cpp
@@ -42,6 +42,8 @@
 #include "ekf.h"
 #include "mathlib.h"
 
+#define MIN_AIRSPEED_MEAS 5.0f // We don't want to fuse airspeed if the measured airspeed is below this value, since the sensor is not accurate
+
 Ekf::Ekf():
 	_filter_initialised(false),
 	_earth_rate_initialised(false),
@@ -306,8 +308,8 @@ bool Ekf::update()
 			_fuse_flow = false;
 		}
 
-		// Fuse airspeed if the data has fallen behind the fusion time horizon, we are airborne and the measured airspeed is above a defined threshold, now hardcoded to 5 m/s
-		if (_airspeed_buffer.pop_first_older_than(_imu_sample_delayed.time_us, &_airspeed_sample_delayed) && _in_air && _airspeed_sample_delayed.true_airspeed > 5.0f) {
+		// Fuse airspeed if the data has fallen behind the fusion time horizon, we are airborne and the measured airspeed is above a defined threshold
+		if (_airspeed_buffer.pop_first_older_than(_imu_sample_delayed.time_us, &_airspeed_sample_delayed) && _in_air && _airspeed_sample_delayed.true_airspeed > MIN_AIRSPEED_MEAS) {
 			fuseAirspeed();
 		}
 	}

--- a/EKF/estimator_interface.cpp
+++ b/EKF/estimator_interface.cpp
@@ -208,7 +208,7 @@ void EstimatorInterface::setAirspeedData(uint64_t time_usec, float *data)
 
 	if (time_usec - _time_last_airspeed > 80000) {
 		airspeedSample airspeed_sample_new;
-		airspeed_sample_new.airspeed = *data;
+		airspeed_sample_new.true_airspeed = *data;
 		airspeed_sample_new.time_us = time_usec - _params.airspeed_delay_ms * 1000;
 		airspeed_sample_new.time_us -= FILTER_UPDATE_PERRIOD_MS * 1000 / 2; //typo PeRRiod
 		_time_last_airspeed = time_usec;


### PR DESCRIPTION
Fuse airspeed if the data has fallen behind the fusion time horizon, we are airborne and the measured airspeed is above a defined threshold, now hardcoded to 5 m/s