### PR TITLE
EKF: Fix vulnerability in height reset

### DIFF
--- a/EKF/control.cpp
+++ b/EKF/control.cpp
@@ -184,9 +184,7 @@ void Ekf::controlFusionModes()
 				_control_status.flags.rng_hgt = false;
 				// adjust the height offset so we can use the GPS
 				_hgt_sensor_offset = _state.pos(2) + gps_init.hgt - _gps_alt_ref;
-				if (!baro_hgt_available) {
-					printf("EKF baro hgt timeout - switching to gps\n");
-				}
+				printf("EKF baro hgt timeout - switching to gps\n");
 			}
 		}
 


### PR DESCRIPTION
Addresses https://github.com/PX4/ecl/issues/91

If bad inertial data causes a large vertical velocity, resetting the height without also resetting the vertical velocity is ineffective, because the bad velocity will pull the height away from the measurement resulting in repeating height resets.

This PR adds code to reset the vertical velocity to the GPS if available, following a vertical position reset.
The variances for the vertical position and velocity states are also reset using known sensor error characteristics.