### PR TITLE
EKF: Improve height reset behaviour

### DIFF
--- a/EKF/RingBuffer.h
+++ b/EKF/RingBuffer.h
@@ -160,6 +160,30 @@ public:
 		return _buffer[index];
 	}
 
+	// return data at the specified index
+	data_type get_from_index(unsigned index)
+	{
+		if (index >= _size) {
+			index = _size-1;
+		}
+		return _buffer[index];
+	}
+
+	// push data to the specified index
+	void push_to_index(unsigned index, data_type sample)
+	{
+		if (index >= _size) {
+			index = _size-1;
+		}
+		_buffer[index] = sample;
+	}
+
+	// return the length of the buffer
+	unsigned get_length()
+	{
+		return _size;
+	}
+
 private:
 	data_type *_buffer;
 	unsigned _head, _tail, _size;

--- a/EKF/common.h
+++ b/EKF/common.h
@@ -267,7 +267,7 @@ struct parameters {
 		baro_innov_gate = 5.0f;
 		posNE_innov_gate = 5.0f;
 		vel_innov_gate = 5.0f;
-		hgt_reset_lim = 5.0f;
+		hgt_reset_lim = 0.0f;
 
 		// magnetometer fusion
 		mag_heading_noise = 3.0e-1f;

--- a/EKF/control.cpp
+++ b/EKF/control.cpp
@@ -156,6 +156,10 @@ void Ekf::controlFusionModes()
 				// Reset states to the last GPS measurement
 				resetPosition();
 				resetVelocity();
+
+				// Reset the timeout counters
+				_time_last_pos_fuse = _time_last_imu;
+				_time_last_vel_fuse = _time_last_imu;
 			}
 		}
 	}
@@ -241,6 +245,9 @@ void Ekf::controlFusionModes()
 
 		// Reset vertical position and velocity states to the last measurement
 		resetHeight();
+
+		// Reset the timout timer
+		_time_last_hgt_fuse = _time_last_imu;
 	}
 
 	// handle the case when we are relying on optical flow fusion and lose it

--- a/EKF/ekf.cpp
+++ b/EKF/ekf.cpp
@@ -488,6 +488,13 @@ bool Ekf::initialiseFilter(void)
 		// initialise the terrain estimator
 		initHagl();
 
+		// reset the essential fusion timeout counters
+		_time_last_hgt_fuse = _time_last_imu;
+		_time_last_pos_fuse = _time_last_imu;
+		_time_last_vel_fuse = _time_last_imu;
+		_time_last_hagl_fuse = _time_last_imu;
+		_time_last_of_fuse = _time_last_imu;
+
 		return true;
 	}
 }

--- a/EKF/ekf.cpp
+++ b/EKF/ekf.cpp
@@ -89,7 +89,8 @@ Ekf::Ekf():
 	_vert_pos_reset_delta(0.0f),
 	_time_vert_pos_reset(0),
 	_vert_vel_reset_delta(0.0f),
-	_time_vert_vel_reset(0)
+	_time_vert_vel_reset(0),
+	_time_bad_vert_accel(0)
 {
 	_state = {};
 	_last_known_posNE.setZero();

--- a/EKF/ekf.cpp
+++ b/EKF/ekf.cpp
@@ -85,7 +85,11 @@ Ekf::Ekf():
 	_baro_hgt_faulty(false),
 	_gps_hgt_faulty(false),
 	_rng_hgt_faulty(false),
-	_baro_hgt_offset(0.0f)
+	_baro_hgt_offset(0.0f),
+	_vert_pos_reset_delta(0.0f),
+	_time_vert_pos_reset(0),
+	_vert_vel_reset_delta(0.0f),
+	_time_vert_vel_reset(0)
 {
 	_state = {};
 	_last_known_posNE.setZero();

--- a/EKF/ekf.h
+++ b/EKF/ekf.h
@@ -126,6 +126,9 @@ public:
 	// get GPS check status
 	void get_gps_check_status(uint16_t *_gps_check_fail_status);
 
+	// return the amount the local vertical position changed in the last height reset and the time of the reset
+	void get_vert_pos_reset(float *delta, uint64_t *time_us) {*delta = _vert_pos_reset_delta; *time_us = _time_vert_pos_reset;}
+
 private:
 
 	static const uint8_t _k_num_states = 24;

--- a/EKF/ekf.h
+++ b/EKF/ekf.h
@@ -240,6 +240,9 @@ private:
 	float _vert_vel_reset_delta;	// increase in vertical position velocity at the last reset(m)
 	uint64_t _time_vert_vel_reset;	// last system time in usec that the vertical velocity state was reset
 
+	// imu fault status
+	uint64_t _time_bad_vert_accel;	// last time a bad vertical accel was detected (usec)
+
 	// update the real time complementary filter states. This includes the prediction
 	// and the correction step
 	void calculateOutputStates();

--- a/EKF/ekf.h
+++ b/EKF/ekf.h
@@ -232,6 +232,10 @@ private:
 	int _primary_hgt_source;	// priary source of height data set at initialisation
 
 	float _baro_hgt_offset;		// number of metres the baro height origin is above the local NED origin (m)
+	float _vert_pos_reset_delta;	// increase in vertical position state at the last reset(m)
+	uint64_t _time_vert_pos_reset;	// last system time in usec that the vertical position state was reset
+	float _vert_vel_reset_delta;	// increase in vertical position velocity at the last reset(m)
+	uint64_t _time_vert_vel_reset;	// last system time in usec that the vertical velocity state was reset
 
 	// update the real time complementary filter states. This includes the prediction
 	// and the correction step

--- a/EKF/ekf.h
+++ b/EKF/ekf.h
@@ -172,7 +172,7 @@ private:
 	float _mag_innov_var[3];	// earth magnetic field innovation variance
 
 	float _airspeed_innov;		// airspeed measurement innovation
-	float _airspeed_innov_var;  // airspeed measurement innovation variance
+	float _airspeed_innov_var;	// airspeed measurement innovation variance
 
 	float _heading_innov;		// heading measurement innovation
 	float _heading_innov_var;	// heading measurement innovation variance
@@ -211,12 +211,12 @@ private:
 
 	// Variables used to initialise the filter states
 	uint32_t _hgt_counter;		// number of height samples taken
-	float _hgt_filt_state;		// filtered height measurement
+	float _rng_filt_state;		// filtered height measurement
 	uint32_t _mag_counter;		// number of magnetometer samples taken
 	uint64_t _time_last_mag;	// measurement time of last magnetomter sample
 	Vector3f _mag_filt_state;	// filtered magnetometer measurement
 	Vector3f _delVel_sum;		// summed delta velocity
-	float _hgt_sensor_offset;	// height that needs to be subtracted from the primary height sensor so that it reads zero height at the origin (m)
+	float _hgt_sensor_offset;	// value subtracted from the height measurement to maintain consistency after switching height sensors (m)
 
 	gps_check_fail_status_u _gps_check_fail_status;
 
@@ -234,7 +234,7 @@ private:
 	bool _rng_hgt_faulty;		// true if valid rnage finder height data is unavailable for use
 	int _primary_hgt_source;	// priary source of height data set at initialisation
 
-	float _baro_hgt_offset;		// number of metres the baro height origin is above the local NED origin (m)
+	float _baro_hgt_offset;		// baro height reading at the local NED origin (m)
 	float _vert_pos_reset_delta;	// increase in vertical position state at the last reset(m)
 	uint64_t _time_vert_pos_reset;	// last system time in usec that the vertical position state was reset
 	float _vert_vel_reset_delta;	// increase in vertical position velocity at the last reset(m)

--- a/EKF/ekf.h
+++ b/EKF/ekf.h
@@ -216,7 +216,7 @@ private:
 	uint64_t _time_last_mag;	// measurement time of last magnetomter sample
 	Vector3f _mag_filt_state;	// filtered magnetometer measurement
 	Vector3f _delVel_sum;		// summed delta velocity
-	float _hgt_sensor_offset;	// value subtracted from the height measurement to maintain consistency after switching height sensors (m)
+	float _hgt_sensor_offset;	// set as necessary if desired to maintain the same height after a height reset (m)
 
 	gps_check_fail_status_u _gps_check_fail_status;
 

--- a/EKF/estimator_interface.h
+++ b/EKF/estimator_interface.h
@@ -220,6 +220,9 @@ public:
 	// get GPS check status
 	virtual void get_gps_check_status(uint16_t *val) = 0;
 
+	// return the amount the local vertical position changed in the last height reset and the time of the reset
+	virtual void get_vert_pos_reset(float *delta, uint64_t *time_us) = 0;
+
 protected:
 
 	parameters _params;		// filter parameters


### PR DESCRIPTION
Addresses #96 and #91 

Has been flown in SITL for normal operation and bench tested for a GPS height timeout

Height reset recovery from each of the three modes (Baro, GPS and range finder) needs to by tested. I have tried using SITL, but it does not support adding offsets to sensor outputs.