### PR TITLE
ekf: initialize _terrain_var

### DIFF
--- a/EKF/ekf.cpp
+++ b/EKF/ekf.cpp
@@ -94,6 +94,7 @@ Ekf::Ekf():
 	_time_last_mag(0),
 	_hgt_sensor_offset(0.0f),
 	_terrain_vpos(0.0f),
+	_terrain_var(1.e4f),
 	_hagl_innov(0.0f),
 	_hagl_innov_var(0.0f),
 	_time_last_hagl_fuse(0),


### PR DESCRIPTION
This fixes an access to an uninitialized value.

in PX4 Firmware: Ekf::get_terrain_vert_pos depends on it. This is the valgrind output:
```
==15439== Thread 14 ekf2:
==15439== Conditional jump or move depends on uninitialised value(s)
==15439==    at 0x5610087: sqrtf (in /usr/lib64/libm-2.22.so)
==15439==    by 0x4D1AF0: Ekf::get_terrain_vert_pos(float*) (terrain_estimator.cpp:135)
==15439==    by 0x46641F: Ekf2::task_main() (ekf2_main.cpp:655)
==15439==    by 0x42BF3D: entry_adapter(void*) (px4_posix_tasks.cpp:103)
==15439==    by 0x4E3C609: start_thread (in /usr/lib64/libpthread-2.22.so)
==15439==    by 0x5BF7A4C: clone (in /usr/lib64/libc-2.22.so)
```