### PR TITLE
EKF:  Improve output observer position and velocity tracking

### DIFF
--- a/EKF/common.h
+++ b/EKF/common.h
@@ -229,6 +229,10 @@ struct parameters {
 	Vector3f rng_pos_body;	// xyz position of range sensor in body frame (m)
 	Vector3f flow_pos_body;	// xyz position of range sensor focal point in body frame (m)
 
+	// output complementary filter tuning
+	float vel_Tau;	// velocity state correction time constant (1/sec)
+	float pos_Tau;	// postion state correction time constant (1/sec)
+
 	// Initialize parameter values.  Initialization must be accomplished in the constructor to allow C99 compiler compatibility.
 	parameters()
 	{
@@ -307,6 +311,10 @@ struct parameters {
 		gps_pos_body = {};
 		rng_pos_body = {};
 		flow_pos_body = {};
+
+		// output complementary filter tuning time constants
+		vel_Tau = 0.5f;
+		pos_Tau = 0.25f;
 	}
 };
 

--- a/EKF/ekf.h
+++ b/EKF/ekf.h
@@ -192,8 +192,6 @@ private:
 
 	// complementary filter states
 	Vector3f _delta_angle_corr;	// delta angle correction vector
-	Vector3f _delta_vel_corr;	// delta velocity correction vector
-	Vector3f _vel_corr;		// velocity correction vector
 	imuSample _imu_down_sampled;	// down sampled imu data (sensor rate -> filter update rate)
 	Quaternion _q_down_sampled;	// down sampled quaternion (tracking delta angles between ekf update steps)
 


### PR DESCRIPTION
Enables smaller output complementary filer time constants to be used for position and velocity states in response to https://github.com/PX4/ecl/issues/125. 

Replace the delayed time feedback mechanism used by the translational states with a direct feedback method.
Time constants for velocity and position convergence can be separately adjusted with tunable parameters.
The method is more computationally more expensive because it requires modification of the output buffer history but is acceptable because updating the buffer only requires 6 FLOP per buffer index for a total of 30*6 = 180 FLOP per output update. EKF2 processing utilistion on a Pixracer board has going up from 15.1 to 15.7 % as a result of this change. These changes may not be necessary if the issues associated with the snapdragon board and range finder sensor data quality can be resolved.
The method was not applied to the attitude states because the quaternion operations required at each buffer index would have been computationally prohibitive.

The change was tested on a problem replay log with inconsistent range finder and IMU data: 

**Vertical Tracking Before Change**
![posd before](https://cloud.githubusercontent.com/assets/3596952/15265335/ce9592e2-19c0-11e6-834a-a5afc15cb8b4.png)
![veld before](https://cloud.githubusercontent.com/assets/3596952/15265336/d13d6fd8-19c0-11e6-9af1-66e840851d30.png)

**Vertical Tracking After Change**
![posd after](https://cloud.githubusercontent.com/assets/3596952/15265408/2518d862-19c2-11e6-8a83-a26e01446e5d.png)
![veld after](https://cloud.githubusercontent.com/assets/3596952/15265433/64de8dd4-19c2-11e6-8a60-520d701e7d26.png)
