### PR TITLE
EV testing

### DIFF
--- a/EKF/ekf.cpp
+++ b/EKF/ekf.cpp
@@ -332,7 +332,7 @@ bool Ekf::update()
 
 		// if we aren't doing any aiding, fake GPS measurements at the last known position to constrain drift
 		// Coincide fake measurements with baro data for efficiency with a minimum fusion rate of 5Hz
-		if (!_control_status.flags.gps && !_control_status.flags.opt_flow
+		if (!_control_status.flags.gps && !_control_status.flags.opt_flow && !_control_status.flags.ev_pos
 		    && ((_time_last_imu - _time_last_fake_gps > 2e5) || _fuse_height)) {
 			_fuse_pos = true;
 			_time_last_fake_gps = _time_last_imu;

--- a/EKF/estimator_interface.cpp
+++ b/EKF/estimator_interface.cpp
@@ -393,5 +393,7 @@ void EstimatorInterface::unallocate_buffers()
 bool EstimatorInterface::local_position_is_valid()
 {
 	// return true if the position estimate is valid
-	return (((_time_last_imu - _time_last_optflow) < 5e6) && _control_status.flags.opt_flow) || global_position_is_valid();
+	return (((_time_last_imu - _time_last_optflow) < 5e6) && _control_status.flags.opt_flow) || 
+		(((_time_last_imu - _time_last_ext_vision) < 5e6) && _control_status.flags.ev_pos) || 
+		global_position_is_valid();
 }


### PR DESCRIPTION
added ev_pos flag check to valid_lpos check.
need to disable fake gps when ev_pos is valid, not just optical flow.