### PR TITLE
EKF2 provide alternative output velocity prediction

### DIFF
--- a/EKF/RingBuffer.h
+++ b/EKF/RingBuffer.h
@@ -161,7 +161,7 @@ public:
 	}
 
 	// return data at the specified index
-	data_type get_from_index(unsigned index)
+	inline data_type get_from_index(unsigned index)
 	{
 		if (index >= _size) {
 			index = _size-1;
@@ -170,7 +170,7 @@ public:
 	}
 
 	// push data to the specified index
-	void push_to_index(unsigned index, data_type sample)
+	inline void push_to_index(unsigned index, data_type sample)
 	{
 		if (index >= _size) {
 			index = _size-1;


### PR DESCRIPTION
This PR introduces an optional method of predicting the velocity forward from the fusion to the output time horizon. It is activated by setting EKF2_TAU_VEL to a negative value. This causes the state history for the output predictor states to be corrected using the position difference instead of the velocity difference. The end result is a velocity that more closely matches the first derivative of the position. This may help in situations where control loops rely on kinematic consistency between position and velocity.

Tested with https://github.com/PX4/Firmware/tree/pr-ekf2OutputPredictor and EKF2_TAU_VEL = -1

Flight test log here: http://logs.uaventure.com/view/C5gVya4qXoKuHXPXEY5AxJ

Plots of the vertical position and velocity for the EKF and predictor:

![vertical comparison](https://cloud.githubusercontent.com/assets/3596952/15457296/719ad6ae-20ca-11e6-862d-f94f956664a7.png)

![vertical comparison zoomed 1](https://cloud.githubusercontent.com/assets/3596952/15457298/76ec13fc-20ca-11e6-9e6c-df2163a2a02a.png)