### PR TITLE
EKF: external vision bug fixes

### DIFF
--- a/EKF/common.h
+++ b/EKF/common.h
@@ -231,9 +231,7 @@ struct parameters {
 	float rng_gnd_clearance;	// minimum valid value for range when on ground (m)
 
 	// vision position fusion
-	float ev_noise;		// observation noise for vision sensor estimates (m)
 	float ev_innov_gate;		// vision estimator fusion innovation consistency gate size (STD)
-	float ev_gnd_clearance;	// minimum valid value for vision based height estimate when on ground (m)
 
 	// optical flow fusion
 	float flow_noise;		// observation noise for optical flow LOS rate measurements (rad/sec)

--- a/EKF/common.h
+++ b/EKF/common.h
@@ -422,6 +422,7 @@ union filter_control_status_u {
 		uint16_t gps_hgt     : 1; // 11 - true when range finder height is being fused as a primary height reference
 		uint16_t ev_pos      : 1; // 12 - true when local position data from external vision is being fused
 		uint16_t ev_yaw      : 1; // 13 - true when yaw data from external vision measurements is being fused
+		uint16_t ev_hgt      : 1; // 14 - true when height data from external vision measurements is being fused
 	} flags;
 	uint16_t value;
 };

--- a/EKF/ekf.cpp
+++ b/EKF/ekf.cpp
@@ -423,11 +423,7 @@ bool Ekf::initialiseFilter(void)
 
 	// set the default height source from the adjustable parameter
 	if (_hgt_counter == 0) {
-		if (_params.fusion_mode & MASK_USE_EVPOS) {
-			_primary_hgt_source = VDIST_SENSOR_EV;
-		} else {
-			_primary_hgt_source = _params.vdist_sensor_type;
-		}
+		_primary_hgt_source = _params.vdist_sensor_type;
 	}
 
 	if (_primary_hgt_source == VDIST_SENSOR_RANGE) {
@@ -447,7 +443,7 @@ bool Ekf::initialiseFilter(void)
 		}
 
 	} else if (_primary_hgt_source == VDIST_SENSOR_BARO || _primary_hgt_source == VDIST_SENSOR_GPS || _primary_hgt_source == VDIST_SENSOR_EV) {
-		// if the user parameter specifies use of GPS for height we use baro height initially and switch to GPS
+		// if the user parameter specifies use of GPS or external vision (EV) for height we use baro height initially and switch to GPS or EV
 		// later when it passes checks.
 		if (_baro_buffer.pop_first_older_than(_imu_sample_delayed.time_us, &_baro_sample_delayed)) {
 			if (_hgt_counter == 0 && _baro_sample_delayed.time_us != 0) {

--- a/EKF/ekf_helper.cpp
+++ b/EKF/ekf_helper.cpp
@@ -204,7 +204,7 @@ void Ekf::resetHeight()
 			// TODO: reset to last known gps based estimate
 		}
 
-	} else if (_control_status.flags.ev_pos) {
+	} else if (_control_status.flags.ev_hgt) {
 		// initialize vertical position with newest measurement
 		extVisionSample ev_newest = _ext_vision_buffer.get_newest();
 

--- a/EKF/ekf_helper.cpp
+++ b/EKF/ekf_helper.cpp
@@ -208,12 +208,15 @@ void Ekf::resetHeight()
 		// initialize vertical position with newest measurement
 		extVisionSample ev_newest = _ext_vision_buffer.get_newest();
 
-		if (_time_last_imu - ev_newest.time_us < 2 * EV_MAX_INTERVAL) {
+		// use the most recent data if it's time offset from the fusion time horizon is smaller
+		int32_t dt_newest = ev_newest.time_us - _imu_sample_delayed.time_us;
+		int32_t dt_delayed = _ev_sample_delayed.time_us - _imu_sample_delayed.time_us;
+		if (abs(dt_newest) < abs(dt_delayed)) {
 			_state.pos(2) = ev_newest.posNED(2);
-
 		} else {
-			// TODO: reset to last known baro based estimate
+			_state.pos(2) = _ev_sample_delayed.posNED(2);
 		}
+
 	}
 
 	// reset the vertical velocity covariance values

--- a/EKF/vel_pos_fusion.cpp
+++ b/EKF/vel_pos_fusion.cpp
@@ -159,7 +159,7 @@ void Ekf::fuseVelPosHeight()
 			R[5] = fmaxf(_ev_sample_delayed.posErr, 0.01f);
 			R[5] = R[5] * R[5];
 			// innovation gate size
-			gate_size[5] = fmaxf(_params.baro_innov_gate, 1.0f);
+			gate_size[5] = fmaxf(_params.ev_innov_gate, 1.0f);
 		}
 
 	}

--- a/EKF/vel_pos_fusion.cpp
+++ b/EKF/vel_pos_fusion.cpp
@@ -165,7 +165,7 @@ void Ekf::fuseVelPosHeight()
 			R[5] = R[5] * R[5];
 			// innovation gate size
 			gate_size[5] = fmaxf(_params.range_innov_gate, 1.0f);
-		} else if (_control_status.flags.ev_pos) {
+		} else if (_control_status.flags.ev_hgt) {
 			fuse_map[5] = true;
 			// calculate the innovation assuming the external vision observaton is in local NED frame
 			_vel_pos_innov[5] = _state.pos(2) - _ev_sample_delayed.posNED(2);


### PR DESCRIPTION
Addresses: #141 and #151. Note turning accel bias learning off via the EKF2_AID_MASK parameter may still be beneficial depending on tuning for external vision operation with accurate sensing.

Required for https://github.com/PX4/Firmware/pull/4647

Replayed log fusing external vision data here (experimental data courtesy of @pickledgator from #141)

http://logs.uaventure.com/view/eZryf2znyV9stqokLeWkwj

Replayed log fusing external vision and range finder data here (experimental data courtesy of @pickledgator from #141)

http://logs.uaventure.com/view/aGBegC39R5Rdx33GazzuvF

EKF plots from second log

![posd innov](https://cloud.githubusercontent.com/assets/3596952/15597858/cda51bda-2417-11e6-8766-1f9570292c9d.png)
![posne innov](https://cloud.githubusercontent.com/assets/3596952/15597860/cdf8061a-2417-11e6-8937-08b1a98a190a.png)
![yaw innov](https://cloud.githubusercontent.com/assets/3596952/15597862/cdfe52f4-2417-11e6-8b88-abff0dc2500f.png)
![posned](https://cloud.githubusercontent.com/assets/3596952/15597861/cdfb67e2-2417-11e6-951e-15726351b5b9.png)
![vert tracking](https://cloud.githubusercontent.com/assets/3596952/15597859/cdf53d9a-2417-11e6-9c39-686121f6622b.png)

log from normal quad flight with GPS here:

http://logs.uaventure.com/view/a5JUpD5uXC9thJV9kD6KRK