### PR TITLE
Change state reset information interface

### DIFF
--- a/EKF/ekf.h
+++ b/EKF/ekf.h
@@ -134,15 +134,21 @@ public:
 	void get_velD_reset(float *delta, uint8_t *counter) {*delta = _state_reset_status.velD_change; *counter = _state_reset_status.velD_counter;}
 
 	// return the amount the local horizontal position changed in the last reset and the number of reset events
-	void get_posNE_reset(Vector2f *delta, uint8_t *counter) {*delta = _state_reset_status.posNE_change; *counter = _state_reset_status.posNE_counter;}
+	void get_posNE_reset(float delta[2], uint8_t *counter){
+		memcpy(delta, &_state_reset_status.posNE_change._data[0], sizeof(_state_reset_status.posNE_change._data));
+		*counter = _state_reset_status.posNE_counter;
+	}
 
 	// return the amount the local horizontal velocity changed in the last reset and the number of reset events
-	void get_velNE_reset(Vector2f *delta, uint8_t *counter) {*delta = _state_reset_status.velNE_change; *counter = _state_reset_status.velNE_counter;}
+	void get_velNE_reset(float delta[2], uint8_t *counter) {
+		memcpy(delta, &_state_reset_status.velNE_change._data[0], sizeof(_state_reset_status.velNE_change._data));
+		*counter = _state_reset_status.velNE_counter;
+	}
 
 	// return the amount the quaternion has changed in the last reset and the number of reset events
-	void get_quat_reset(Quaternion *delta, uint8_t *counter)
+	void get_quat_reset(float delta_quat[4], uint8_t *counter)
 	{
-		*delta = _state_reset_status.quat_change;
+		memcpy(delta_quat, &_state_reset_status.quat_change._data[0], sizeof(_state_reset_status.quat_change._data));
 		*counter = _state_reset_status.quat_counter;
 	}
 

--- a/EKF/estimator_interface.h
+++ b/EKF/estimator_interface.h
@@ -224,13 +224,13 @@ public:
 	virtual void get_velD_reset(float *delta, uint8_t *counter) = 0;
 
 	// return the amount the local horizontal position changed in the last reset and the number of reset events
-	virtual void get_posNE_reset(Vector2f *delta, uint8_t *counter) = 0;
+	virtual void get_posNE_reset(float delta[2], uint8_t *counter) = 0;
 
 	// return the amount the local horizontal velocity changed in the last reset and the number of reset events
-	virtual void get_velNE_reset(Vector2f *delta, uint8_t *counter) = 0;
+	virtual void get_velNE_reset(float delta[2], uint8_t *counter) = 0;
 
 	// return the amount the quaternion has changed in the last reset and the number of reset events
-	virtual void get_quat_reset(Quaternion *delta, uint8_t *counter) = 0;
+	virtual void get_quat_reset(float delta_quat[4], uint8_t *counter) = 0;
 
 	// get EKF innovation consistency check status
 	virtual void get_innovation_test_status(uint16_t *val)


### PR DESCRIPTION
@priseborough I changed the reset interface slightly so that there are no vector dependencies. Also this allows us to copy the reset data directly into the topic structs. 