### PR TITLE
activate tas fusion, off by default

### DIFF
--- a/EKF/ekf.cpp
+++ b/EKF/ekf.cpp
@@ -365,9 +365,8 @@ bool Ekf::update()
 			_fuse_flow = false;
 		}
 
-		// TODO This is just to get the logic inside but we will only start fusion once we tested this again
-		//if (_airspeed_buffer.pop_first_older_than(_imu_sample_delayed.time_us, &_airspeed_sample_delayed)) {
-		if (false) {
+		// If we are using airspeed measurements and data has fallen behind the fusion time horizon then fuse it
+		if (_airspeed_buffer.pop_first_older_than(_imu_sample_delayed.time_us, &_airspeed_sample_delayed)) {
 			fuseAirspeed();
 		}
 	}


### PR DESCRIPTION
This makes it possible to activate airspeed fusion by setting a parameter, it is however off by default for the moment.
Goes together with https://github.com/PX4/Firmware/pull/4755