### PR TITLE
Move __STDC_FORMAT_MACROS to build system

### DIFF
--- a/EKF/RingBuffer.h
+++ b/EKF/RingBuffer.h
@@ -37,7 +37,6 @@
  * Template RingBuffer.
  */
 
-#define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 #include <cstdio>
 #include <cstring>

--- a/EKF/estimator_interface.cpp
+++ b/EKF/estimator_interface.cpp
@@ -40,7 +40,6 @@
  * @author Siddharth B Purohit <siddharthbharatpurohit@gmail.com>
  */
 
-#define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 #include <math.h>
 #include "../ecl.h"


### PR DESCRIPTION
__STDC_FORMAT_MACROS changes the behavior of inttypes.h to allow
defining format macros for printf-like functions. It needs to be defined
before any include is done, otherwise due to include chains and header
guards it may not take effect.

Instead of defining it everywhere it is used, let the PX4 build system
to deal with it.
