### PR TITLE
Tiny PR: added getter function for wind states

### DIFF
--- a/EKF/airspeed_fusion.cpp
+++ b/EKF/airspeed_fusion.cpp
@@ -202,3 +202,9 @@ void Ekf::fuseAirspeed()
 		}
 	}
 }
+
+void Ekf::get_wind_velocity(float *wind)
+{
+	wind[0] = _state.wind_vel(0);
+	wind[1] = _state.wind_vel(1);
+}

--- a/EKF/ekf.h
+++ b/EKF/ekf.h
@@ -97,6 +97,9 @@ public:
 	// get the state vector at the delayed time horizon
 	void get_state_delayed(float *state);
 
+	// get the wind velocity in m/s
+	void get_wind_velocity(float *wind);
+
 	// get the diagonal elements of the covariance matrix
 	void get_covariances(float *covariances);
 

--- a/EKF/estimator_interface.h
+++ b/EKF/estimator_interface.h
@@ -84,6 +84,8 @@ public:
 
 	virtual void get_state_delayed(float *state) = 0;
 
+	virtual void get_wind_velocity(float *wind) = 0;
+
 	virtual void get_covariances(float *covariances) = 0;
 
 	// get the ekf WGS-84 origin position and height and the system time it was last set


### PR DESCRIPTION
Small interface to wind states, so we can call them from ekf2_main in a clean way.
(we use this for publishing estimated airspeed to controllers)