### PR TITLE
ekf_helper.cpp: remove unused includes

### DIFF
--- a/EKF/ekf_helper.cpp
+++ b/EKF/ekf_helper.cpp
@@ -40,11 +40,6 @@
  */
 
 #include "ekf.h"
-#ifdef __PX4_POSIX
-#include <iostream>
-#include <fstream>
-#endif
-#include <iomanip>
 #include "mathlib.h"
 
 // Reset the velocity states. If we have a recent and valid


### PR DESCRIPTION
This fixes a compile error with GCC 5.2.0 and cross-compilation:
/usr/arm-none-eabi/include/c++/5.2.0/arm-none-eabi/armv7e-m/fpu/bits/error_constants.h:122:27: error: 'ENOTSUP' was not declared in this scope
       not_supported =     ENOTSUP,

The problem was that the #include <iomanip> was taken from the host system,
which conflicts with includes from NuttX (NuttX has only basic C++ STL
support)