### PR TITLE
EKF: Improve Output Predictor Tracking

### DIFF
--- a/EKF/common.h
+++ b/EKF/common.h
@@ -348,7 +348,7 @@ struct parameters {
 		ev_pos_body = {};
 
 		// output complementary filter tuning time constants
-		vel_Tau = 0.5f;
+		vel_Tau = 0.25f;
 		pos_Tau = 0.25f;
 
 	}

--- a/EKF/ekf.cpp
+++ b/EKF/ekf.cpp
@@ -130,6 +130,8 @@ Ekf::Ekf():
 	_last_known_posNE.setZero();
 	_imu_down_sampled = {};
 	_q_down_sampled.setZero();
+	_vel_err_integ.setZero();
+	_pos_err_integ.setZero();
 	_mag_filt_state = {};
 	_delVel_sum = {};
 	_flow_gyro_bias = {};
@@ -631,19 +633,15 @@ void Ekf::calculateOutputStates()
 
 		// calculate a position correction that will be applied to the output state history
 		float pos_gain = _dt_ekf_avg / math::constrain(_params.pos_Tau, _dt_ekf_avg, 10.0f);
-		Vector3f pos_delta = (_state.pos - _output_sample_delayed.pos) * pos_gain;
+		Vector3f pos_err = (_state.pos - _output_sample_delayed.pos);
+		_pos_err_integ += pos_err;
+		Vector3f pos_correction = pos_err * pos_gain + _pos_err_integ * sq(pos_gain) * 0.1f;
 
 		// calculate a velocity correction that will be applied to the output state history
-		Vector3f vel_delta;
-		if (_params.pos_Tau <= 0.0f) {
-			// this method will cause the velocity to be kinematically consistent with
-			// the position corretions rather than tracking the EKF states
-			vel_delta = pos_delta * (1.0f / time_delay);
-		} else {
-			// this method makes the velocity track the EKF states with the specified time constant
-			float vel_gain = _dt_ekf_avg / math::constrain(_params.vel_Tau, _dt_ekf_avg, 10.0f);
-			vel_delta = (_state.vel - _output_sample_delayed.vel) * vel_gain;
-		}
+		float vel_gain = _dt_ekf_avg / math::constrain(_params.vel_Tau, _dt_ekf_avg, 10.0f);
+		Vector3f vel_err = (_state.vel - _output_sample_delayed.vel);
+		_vel_err_integ += vel_err;
+		Vector3f vel_correction = vel_err * vel_gain + _vel_err_integ * sq(pos_gain) * 0.1f;
 
 		// loop through the output filter state history and apply the corrections to the velocity and position states
 		// this method is too expensive to use for the attitude states due to the quaternion operations required
@@ -655,10 +653,10 @@ void Ekf::calculateOutputStates()
 			output_states = _output_buffer.get_from_index(index);
 
 			// a constant  velocity correction is applied
-			output_states.vel += vel_delta;
+			output_states.vel += vel_correction;
 
 			// a constant position correction is applied
-			output_states.pos += pos_delta;
+			output_states.pos += pos_correction;
 
 			// push the updated data to the buffer
 			_output_buffer.push_to_index(index,output_states);

--- a/EKF/ekf.h
+++ b/EKF/ekf.h
@@ -117,6 +117,10 @@ public:
 
 	void get_pos_var(Vector3f &pos_var);
 
+	// return an array containing the output predictor angular, velocity and position tracking
+	// error magnitudes (rad), (m/s), (m)
+	void get_output_tracking_error(float error[3]);
+
 	// return true if the global position estimate is valid
 	bool global_position_is_valid();
 
@@ -246,6 +250,7 @@ private:
 	Quaternion _q_down_sampled;	// down sampled quaternion (tracking delta angles between ekf update steps)
 	Vector3f _vel_err_integ;	// integral of velocity tracking error
 	Vector3f _pos_err_integ;	// integral of position tracking error
+	float _output_tracking_error[3];// contains the magnitude of the angle, velocity and position track errors (rad, m/s, m)
 
 	// variables used for the GPS quality checks
 	float _gpsDriftVelN;		// GPS north position derivative (m/s)

--- a/EKF/ekf.h
+++ b/EKF/ekf.h
@@ -240,10 +240,12 @@ private:
 
 	float _mag_declination;		// magnetic declination used by reset and fusion functions (rad)
 
-	// complementary filter states
+	// output predictor states
 	Vector3f _delta_angle_corr;	// delta angle correction vector
 	imuSample _imu_down_sampled;	// down sampled imu data (sensor rate -> filter update rate)
 	Quaternion _q_down_sampled;	// down sampled quaternion (tracking delta angles between ekf update steps)
+	Vector3f _vel_err_integ;	// integral of velocity tracking error
+	Vector3f _pos_err_integ;	// integral of position tracking error
 
 	// variables used for the GPS quality checks
 	float _gpsDriftVelN;		// GPS north position derivative (m/s)

--- a/EKF/ekf_helper.cpp
+++ b/EKF/ekf_helper.cpp
@@ -674,6 +674,13 @@ void Ekf::get_ekf_origin(uint64_t *origin_time, map_projection_reference_s *orig
 	memcpy(origin_alt, &_gps_alt_ref, sizeof(float));
 }
 
+// return an array containing the output predictor angular, velocity and position tracking
+// error magnitudes (rad), (m/s), (m)
+void Ekf::get_output_tracking_error(float error[3])
+{
+	memcpy(error, _output_tracking_error, 3 * sizeof(float));
+}
+
 // get the 1-sigma horizontal and vertical position uncertainty of the ekf WGS-84 position
 void Ekf::get_ekf_accuracy(float *ekf_eph, float *ekf_epv, bool *dead_reckoning)
 {

--- a/EKF/estimator_interface.h
+++ b/EKF/estimator_interface.h
@@ -88,8 +88,10 @@ public:
 
 	virtual void get_covariances(float *covariances) = 0;
 
-	// get the ekf WGS-84 origin position and height and the system time it was last set
+	// gets the variances for the NED velocity states
 	virtual void get_vel_var(Vector3f &vel_var) = 0;
+
+	// gets the variances for the NED position states
 	virtual void get_pos_var(Vector3f &pos_var) = 0;
 
 	// gets the innovation variance of the flow measurement
@@ -103,6 +105,10 @@ public:
 
 	// gets the innovation of the HAGL measurement
 	virtual void get_hagl_innov(float *flow_innov_var) = 0;
+
+	// return an array containing the output predictor angular, velocity and position tracking
+	// error magnitudes (rad), (m/s), (m)
+	virtual void get_output_tracking_error(float error[3]) = 0;
 
 	// get the ekf WGS-84 origin positoin and height and the system time it was last set
 	virtual void get_ekf_origin(uint64_t *origin_time, map_projection_reference_s *origin_pos, float *origin_alt) = 0;


### PR DESCRIPTION
**DESCRIPTION**

Add integral action to the output predictor position and velocity tracking to reduce the effect of acceleration aliasing and bias errors.
Publish the tracking errors to assist with diagnostics and tuning.
Retune the time constant used to track the velocity states.

**TEST DATA**

Plot of attitude (EST4.e1), velocity (EST4.e2) and position (EST4.e3) tracking error magnitude from a flight test with a Pixracer board. Units are rad, m/s and m respectively.

![screen shot 2016-08-15 at 10 53 50 am](https://cloud.githubusercontent.com/assets/3596952/17653295/9392ffea-62d6-11e6-8ca7-cededaea9d12.png)

A corresponding PR has been raised on PX4/Firmware to enable data logging: https://github.com/PX4/Firmware/pull/5318

Back to back comparison tracking data using the tracking loops before and after the change applied to a replay log with high vibration levels (wingwing flight vehicle with pixracer board). There is some reduction in e2 (velocity) and e3 (position) state tracking error levels.

BEFORE
![before](https://cloud.githubusercontent.com/assets/3596952/19053357/5f6d79be-8a06-11e6-8adf-ab20b30b94bb.png)

AFTER
![after](https://cloud.githubusercontent.com/assets/3596952/19053386/71b72fa2-8a06-11e6-93c7-e3bf869ec571.png)

