### PR TITLE
Remove optimization flags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,15 +30,12 @@
 # POSSIBILITY OF SUCH DAMAGE.
 #
 ############################################################################
-set(MODULE_CFLAGS )
-if(${OS} STREQUAL "nuttx")
-	list(APPEND MODULE_CFLAGS -Wframe-larger-than=6000)
-endif()
 
 px4_add_module(
 	MODULE lib__ecl
 	STACK_MAIN 6000
-	COMPILE_FLAGS ${MODULE_CFLAGS}
+	STACK_MAX 6000
+	COMPILE_FLAGS
 	SRCS
 		attitude_fw/ecl_controller.cpp
 		attitude_fw/ecl_pitch_controller.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,7 +38,7 @@ endif()
 px4_add_module(
 	MODULE lib__ecl
 	STACK_MAIN 6000
-	COMPILE_FLAGS ${MODULE_CFLAGS} -Os
+	COMPILE_FLAGS ${MODULE_CFLAGS}
 	SRCS
 		attitude_fw/ecl_controller.cpp
 		attitude_fw/ecl_pitch_controller.cpp
@@ -62,4 +62,4 @@ px4_add_module(
 	DEPENDS
 		platforms__common
 	)
-# vim: set noet ft=cmake fenc=utf-8 ff=unix : 
+# vim: set noet ft=cmake fenc=utf-8 ff=unix :

--- a/EKF/ekf_helper.cpp
+++ b/EKF/ekf_helper.cpp
@@ -130,6 +130,7 @@ bool Ekf::resetPosition()
 	_state_reset_status.posNE_change = posNE_change;
 	_state_reset_status.posNE_counter++;
 
+	return true;
 }
 
 // Reset height state using the last height measurement

--- a/EKF/tests/base/CMakeLists.txt
+++ b/EKF/tests/base/CMakeLists.txt
@@ -35,10 +35,9 @@ px4_add_module(
 	MAIN base
 	STACK_MAIN 4096
 	COMPILE_FLAGS
-		-Os
 	SRCS
 		base.cpp
 	DEPENDS
 		platforms__common
 	)
-# vim: set noet ft=cmake fenc=utf-8 ff=unix : 
+# vim: set noet ft=cmake fenc=utf-8 ff=unix :

--- a/EKF/tests/ringbuffer/CMakeLists.txt
+++ b/EKF/tests/ringbuffer/CMakeLists.txt
@@ -35,10 +35,9 @@ px4_add_module(
 	MAIN ringbuffer
 	STACK_MAIN 4096
 	COMPILE_FLAGS
-		-Os
 	SRCS
 		ringbuffer.cpp
 	DEPENDS
 		platforms__common
 	)
-# vim: set noet ft=cmake fenc=utf-8 ff=unix : 
+# vim: set noet ft=cmake fenc=utf-8 ff=unix :


### PR DESCRIPTION
This removes the optimization flag (optimize for size) out of the module because it should be taken care of on a platform level rather than a module level.