### PR TITLE
EKF: Add IMU vibration calculation and reporting

### DIFF
--- a/EKF/ekf.h
+++ b/EKF/ekf.h
@@ -121,6 +121,14 @@ public:
 	// error magnitudes (rad), (m/s), (m)
 	void get_output_tracking_error(float error[3]);
 
+	/*
+	Returns  following IMU vibration metrics in the following array locations
+	0 : Gyro delta angle coning metric = filtered length of (delta_angle x prev_delta_angle)
+	1 : Gyro high frequency vibe = filtered length of (delta_angle - prev_delta_angle)
+	2 : Accel high frequency vibe = filtered length of (delta_velocity - prev_delta_velocity)
+	*/
+	void get_imu_vibe_metrics(float vibe[3]);
+
 	// return true if the global position estimate is valid
 	bool global_position_is_valid();
 

--- a/EKF/ekf_helper.cpp
+++ b/EKF/ekf_helper.cpp
@@ -696,6 +696,17 @@ void Ekf::get_output_tracking_error(float error[3])
 	memcpy(error, _output_tracking_error, 3 * sizeof(float));
 }
 
+/*
+Returns  following IMU vibration metrics in the following array locations
+0 : Gyro delta angle coning metric = filtered length of (delta_angle x prev_delta_angle)
+1 : Gyro high frequency vibe = filtered length of (delta_angle - prev_delta_angle)
+2 : Accel high frequency vibe = filtered length of (delta_velocity - prev_delta_velocity)
+*/
+void Ekf::get_imu_vibe_metrics(float vibe[3])
+{
+	memcpy(vibe, _vibe_metrics, 3 * sizeof(float));
+}
+
 // get the 1-sigma horizontal and vertical position uncertainty of the ekf WGS-84 position
 void Ekf::get_ekf_accuracy(float *ekf_eph, float *ekf_epv, bool *dead_reckoning)
 {

--- a/EKF/estimator_interface.h
+++ b/EKF/estimator_interface.h
@@ -111,6 +111,14 @@ public:
 	// error magnitudes (rad), (m/s), (m)
 	virtual void get_output_tracking_error(float error[3]) = 0;
 
+	/*
+	Returns  following IMU vibration metrics in the following array locations
+	0 : Gyro delta angle coning metric = filtered length of (delta_angle x prev_delta_angle)
+	1 : Gyro high frequency vibe = filtered length of (delta_angle - prev_delta_angle)
+	2 : Accel high frequency vibe = filtered length of (delta_velocity - prev_delta_velocity)
+	*/
+	virtual void get_imu_vibe_metrics(float vibe[3]) = 0;
+
 	// get the ekf WGS-84 origin positoin and height and the system time it was last set
 	virtual void get_ekf_origin(uint64_t *origin_time, map_projection_reference_s *origin_pos, float *origin_alt) = 0;
 
@@ -298,6 +306,14 @@ protected:
 	float _tas_test_ratio;		// tas innovation consistency check ratio
 	float _terr_test_ratio;		// height above terrain measurement innovation consistency check ratio
 	innovation_fault_status_u _innov_check_fail_status;
+
+	// IMU vibration monitoring
+	Vector3f _delta_ang_prev;	// delta angle from the previous IMU measurement
+	Vector3f _delta_vel_prev;	// delta velocity from the previous IMU measurement
+	float _vibe_metrics[3];		// IMU vibration metrics
+					// [0] Level of coning vibration in the IMU delta angles (rad^2)
+					// [1] high frequency vibraton level in the IMU delta angle data (rad)
+					// [2] high frequency vibration level in the IMU delta velocity data (m/s)
 
 	// data buffer instances
 	RingBuffer<imuSample> _imu_buffer;


### PR DESCRIPTION
Add calculation and reporting of IMU delta angle and velocity coning and high frequency vibration.

These will need to be published on the estimator_status uORB message which is currently un-used.

This has been flight tested and the messages checked using this branch: https://github.com/PX4/Firmware/pull/5682

<img width="1229" alt="screen shot 2016-10-18 at 5 31 10 pm" src="https://cloud.githubusercontent.com/assets/3596952/19466725/b1fafec4-9558-11e6-80c4-fc1dd720f000.png">