### PR TITLE
ekf reset: more granular reset / timeout strategy for gps fusion

### DIFF
--- a/EKF/common.h
+++ b/EKF/common.h
@@ -261,6 +261,9 @@ struct parameters {
 	float vel_Tau;	// velocity state correction time constant (1/sec)
 	float pos_Tau;	// postion state correction time constant (1/sec)
 
+	unsigned no_gps_timeout_max;	// maximum time we allow dead reckoning while both gps position and velocity measurements are being
+									// rejected
+
 	// Initialize parameter values.  Initialization must be accomplished in the constructor to allow C99 compiler compatibility.
 	parameters()
 	{
@@ -350,6 +353,8 @@ struct parameters {
 		// output complementary filter tuning time constants
 		vel_Tau = 0.25f;
 		pos_Tau = 0.25f;
+
+		no_gps_timeout_max = 7e6;	// maximum seven seconds of dead reckoning time for gps
 
 	}
 };

--- a/EKF/control.cpp
+++ b/EKF/control.cpp
@@ -363,23 +363,24 @@ void Ekf::controlGpsFusion()
 					_last_known_posNE(1) = _state.pos(1);
 					_state.vel.setZero();
 					ECL_WARN("EKF GPS fusion timout - stopping GPS aiding");
-			}
+			} else {
 
-			// We are relying on GPS aiding to constrain attitude drift so after 7 seconds without aiding we need to do something
-			bool do_reset = (_time_last_imu - _time_last_pos_fuse > _params.no_gps_timeout_max) && (_time_last_imu - _time_last_vel_fuse > _params.no_gps_timeout_max);
+				// We are relying on GPS aiding to constrain attitude drift so after 7 seconds without aiding we need to do something
+				bool do_reset = (_time_last_imu - _time_last_pos_fuse > _params.no_gps_timeout_max) && (_time_last_imu - _time_last_vel_fuse > _params.no_gps_timeout_max);
 
-			// Our position measurments have been rejected for more than 14 seconds
-			do_reset |= _time_last_imu - _time_last_pos_fuse > 2 * _params.no_gps_timeout_max;
+				// Our position measurments have been rejected for more than 14 seconds
+				do_reset |= _time_last_imu - _time_last_pos_fuse > 2 * _params.no_gps_timeout_max;
 
-			if (do_reset) {
-				// Reset states to the last GPS measurement
-				resetPosition();
-				resetVelocity();
-				ECL_WARN("EKF GPS fusion timout - resetting to GPS");
+				if (do_reset) {
+					// Reset states to the last GPS measurement
+					resetPosition();
+					resetVelocity();
+					ECL_WARN("EKF GPS fusion timout - resetting to GPS");
 
-				// Reset the timeout counters
-				_time_last_pos_fuse = _time_last_imu;
-				_time_last_vel_fuse = _time_last_imu;
+					// Reset the timeout counters
+					_time_last_pos_fuse = _time_last_imu;
+					_time_last_vel_fuse = _time_last_imu;
+				}
 			}
 
 		}


### PR DESCRIPTION
- if both gps position and velocity measurements are rejected for 7 seconds
do a reset
- if only gps position measurements are rejected then wait for 14 seconds
as we still have velocity measurements to constrain the drift in position
- introduced ecl internal parameter for the timeout

Signed-off-by: Roman <bapstroman@gmail.com>