### PR TITLE
Save memory

### DIFF
--- a/EKF/airspeed_fusion.cpp
+++ b/EKF/airspeed_fusion.cpp
@@ -161,6 +161,7 @@ void Ekf::fuseAirspeed()
 			KH[row][23] = Kfusion[row] * H_TAS[23];
 		}
 
+		float KHP[_k_num_states][_k_num_states];
 		for (unsigned row = 0; row < _k_num_states; row++) {
 			for (unsigned column = 0; column < _k_num_states; column++) {
 				float tmp = KH[row][4] * P[4][column];

--- a/EKF/ekf.h
+++ b/EKF/ekf.h
@@ -239,7 +239,6 @@ private:
 
 	float P[_k_num_states][_k_num_states];	// state covariance matrix
 	float KH[_k_num_states][_k_num_states]; // intermediate variable for the covariance update
-	float KHP[_k_num_states][_k_num_states]; // intermediate variable for the covariance update
 
 	float _vel_pos_innov[6];	// innovations: 0-2 vel,  3-5 pos
 	float _vel_pos_innov_var[6];	// innovation variances: 0-2 vel, 3-5 pos

--- a/EKF/mag_fusion.cpp
+++ b/EKF/mag_fusion.cpp
@@ -320,6 +320,7 @@ void Ekf::fuseMag()
 
 		}
 
+		float KHP[_k_num_states][_k_num_states];
 		for (unsigned row = 0; row < _k_num_states; row++) {
 			for (unsigned column = 0; column < _k_num_states; column++) {
 				float tmp = KH[row][0] * P[0][column];
@@ -643,6 +644,7 @@ void Ekf::fuseHeading()
 		}
 	}
 
+	float KHP[_k_num_states][_k_num_states];
 	for (unsigned row = 0; row < _k_num_states; row++) {
 		for (unsigned column = 0; column < _k_num_states; column++) {
 			float tmp = KH[row][0] * P[0][column];
@@ -779,6 +781,7 @@ void Ekf::fuseDeclination()
 		}
 	}
 
+	float KHP[_k_num_states][_k_num_states];
 	for (unsigned row = 0; row < _k_num_states; row++) {
 		for (unsigned column = 0; column < _k_num_states; column++) {
 			float tmp = KH[row][16] * P[16][column];

--- a/EKF/optflow_fusion.cpp
+++ b/EKF/optflow_fusion.cpp
@@ -439,6 +439,7 @@ void Ekf::fuseOptFlow()
 			}
 		}
 
+		float KHP[_k_num_states][_k_num_states];
 		for (unsigned row = 0; row < _k_num_states; row++) {
 			for (unsigned column = 0; column < _k_num_states; column++) {
 				float tmp = KH[row][0] * P[0][column];

--- a/EKF/vel_pos_fusion.cpp
+++ b/EKF/vel_pos_fusion.cpp
@@ -239,6 +239,7 @@ void Ekf::fuseVelPosHeight()
 		}
 
 		// update covarinace matrix via Pnew = (I - KH)P
+		float KHP[_k_num_states][_k_num_states];
 		for (unsigned row = 0; row < _k_num_states; row++) {
 			for (unsigned column = 0; column < _k_num_states; column++) {
 				KHP[row][column] = Kfusion[row] * P[state_index][column];

--- a/validation/data_validator.cpp
+++ b/validation/data_validator.cpp
@@ -44,8 +44,8 @@
 
 DataValidator::DataValidator(DataValidator *prev_sibling) :
 	_error_mask(ERROR_FLAG_NO_ERROR),
-	_time_last(0),
 	_timeout_interval(20000),
+	_time_last(0),
 	_event_count(0),
 	_error_count(0),
 	_error_density(0),

--- a/validation/data_validator.h
+++ b/validation/data_validator.h
@@ -136,7 +136,14 @@ public:
 	 *
 	 * @param timeout_interval_us The timeout interval in microseconds
 	 */
-	void			set_timeout(uint64_t timeout_interval_us) { _timeout_interval = timeout_interval_us; }
+	void			set_timeout(uint32_t timeout_interval_us) { _timeout_interval = timeout_interval_us; }
+
+	/**
+	 * Get the timeout value
+	 *
+	 * @return The timeout interval in microseconds
+	 */
+	uint32_t			get_timeout() const { return _timeout_interval; }
 	
 	/**
 	 * Data validator error states 
@@ -150,8 +157,8 @@ public:
 
 private:
 	uint32_t _error_mask;			/**< sensor error state */
+	uint32_t _timeout_interval;		/**< interval in which the datastream times out in us */
 	uint64_t _time_last;			/**< last timestamp */
-	uint64_t _timeout_interval;		/**< interval in which the datastream times out in us */
 	uint64_t _event_count;			/**< total data counter */
 	uint64_t _error_count;			/**< error count */
 	int _error_density;			/**< ratio between successful reads and errors */
@@ -169,6 +176,6 @@ private:
 	static const constexpr unsigned VALUE_EQUAL_COUNT_MAX = 100;	/**< if the sensor value is the same (accumulated also between axes) this many times, flag it */
 
 	/* we don't want this class to be copied */
-	DataValidator(const DataValidator&);
-	DataValidator operator=(const DataValidator&);
+	DataValidator(const DataValidator&) = delete;
+	DataValidator operator=(const DataValidator&) = delete;
 };

--- a/validation/data_validator_group.cpp
+++ b/validation/data_validator_group.cpp
@@ -60,6 +60,12 @@ DataValidatorGroup::DataValidatorGroup(unsigned siblings) :
 
 DataValidatorGroup::~DataValidatorGroup()
 {
+	while (_first) {
+		DataValidator* next = _first->sibling();
+		delete (_first);
+		_first = next;
+	}
+}
 
 }
 

--- a/validation/data_validator_group.cpp
+++ b/validation/data_validator_group.cpp
@@ -41,7 +41,6 @@
 
 #include "data_validator_group.h"
 #include <ecl/ecl.h>
-#include <cassert>
 
 DataValidatorGroup::DataValidatorGroup(unsigned siblings) :
 	_first(nullptr),
@@ -50,7 +49,6 @@ DataValidatorGroup::DataValidatorGroup(unsigned siblings) :
 	_first_failover_time(0),
 	_toggle_count(0)
 {
-	assert(siblings > 0);
 	DataValidator *next = _first;
 
 	for (unsigned i = 0; i < siblings; i++) {

--- a/validation/data_validator_group.cpp
+++ b/validation/data_validator_group.cpp
@@ -64,7 +64,7 @@ DataValidatorGroup::~DataValidatorGroup()
 }
 
 void
-DataValidatorGroup::set_timeout(uint64_t timeout_interval_us)
+DataValidatorGroup::set_timeout(uint32_t timeout_interval_us)
 {
 	DataValidator *next = _first;
 

--- a/validation/data_validator_group.cpp
+++ b/validation/data_validator_group.cpp
@@ -41,6 +41,7 @@
 
 #include "data_validator_group.h"
 #include <ecl/ecl.h>
+#include <cassert>
 
 DataValidatorGroup::DataValidatorGroup(unsigned siblings) :
 	_first(nullptr),
@@ -49,6 +50,7 @@ DataValidatorGroup::DataValidatorGroup(unsigned siblings) :
 	_first_failover_time(0),
 	_toggle_count(0)
 {
+	assert(siblings > 0);
 	DataValidator *next = _first;
 
 	for (unsigned i = 0; i < siblings; i++) {
@@ -56,6 +58,7 @@ DataValidatorGroup::DataValidatorGroup(unsigned siblings) :
 	}
 
 	_first = next;
+	_timeout_interval_us = _first->get_timeout();
 }
 
 DataValidatorGroup::~DataValidatorGroup()
@@ -67,6 +70,15 @@ DataValidatorGroup::~DataValidatorGroup()
 	}
 }
 
+DataValidator *DataValidatorGroup::add_new_validator()
+{
+	DataValidator *validator = new DataValidator(_first);
+	if (!validator) {
+		return nullptr;
+	}
+	_first = validator;
+	_first->set_timeout(_timeout_interval_us);
+	return _first;
 }
 
 void
@@ -78,6 +90,7 @@ DataValidatorGroup::set_timeout(uint32_t timeout_interval_us)
 		next->set_timeout(timeout_interval_us);
 		next = next->sibling();
 	}
+	_timeout_interval_us = timeout_interval_us;
 }
 
 void

--- a/validation/data_validator_group.h
+++ b/validation/data_validator_group.h
@@ -49,6 +49,12 @@ public:
 	virtual ~DataValidatorGroup();
 
 	/**
+	 * Create a new Validator (with index equal to the number of currently existing validators)
+	 * @return the newly created DataValidator or nullptr on error
+	 */
+	DataValidator *add_new_validator();
+
+	/**
 	 * Put an item into the validator group.
 	 *
 	 * @param index		Sensor index
@@ -117,6 +123,7 @@ public:
 
 private:
 	DataValidator *_first;		/**< sibling in the group */
+	uint32_t _timeout_interval_us; /**< currently set timeout */
 	int _curr_best;		/**< currently best index */
 	int _prev_best;		/**< the previous best index */
 	uint64_t _first_failover_time;	/**< timestamp where the first failover occured or zero if none occured */

--- a/validation/data_validator_group.h
+++ b/validation/data_validator_group.h
@@ -45,6 +45,9 @@
 
 class __EXPORT DataValidatorGroup {
 public:
+	/**
+	 * @param siblings initial number of DataValidator's. Must be > 0.
+	 */
 	DataValidatorGroup(unsigned siblings);
 	virtual ~DataValidatorGroup();
 

--- a/validation/data_validator_group.h
+++ b/validation/data_validator_group.h
@@ -113,7 +113,7 @@ public:
 	 *
 	 * @param timeout_interval_us The timeout interval in microseconds
 	 */
-	void			set_timeout(uint64_t timeout_interval_us);
+	void			set_timeout(uint32_t timeout_interval_us);
 
 private:
 	DataValidator *_first;		/**< sibling in the group */


### PR DESCRIPTION
Save memory by moving the KHP matrix to the stack and using a smaller timeout data type in DataValidator.

@priseborough @tumbili can you please review?