### PR TITLE
EKF:  Reduce RAM usage and output predictor errors

### DIFF
--- a/EKF/common.h
+++ b/EKF/common.h
@@ -173,6 +173,7 @@ struct parameters {
 	// measurement source control
 	int fusion_mode;		// bitmasked integer that selects which of the GPS and optical flow aiding sources will be used
 	int vdist_sensor_type;		// selects the primary source for height data
+	int sensor_interval_min_ms;	// minimum time of arrival difference between non IMU sensor updates. Sets the size of the observation buffers.
 
 	// measurement time delays
 	float mag_delay_ms;		// magnetometer measurement delay relative to the IMU (msec)
@@ -275,6 +276,7 @@ struct parameters {
 		// measurement source control
 		fusion_mode = MASK_USE_GPS;
 		vdist_sensor_type = VDIST_SENSOR_BARO;
+		sensor_interval_min_ms = 20;
 
 		// measurement time delays
 		mag_delay_ms = 0.0f;

--- a/EKF/ekf.cpp
+++ b/EKF/ekf.cpp
@@ -259,10 +259,10 @@ bool Ekf::initialiseFilter(void)
 			// increment the sample count and apply a LPF to the measurement
 			_mag_counter ++;
 			// don't start using data until we can be certain all bad initial data has been flushed
-			if (_mag_counter == OBS_BUFFER_LENGTH+1) {
+			if (_mag_counter == (uint8_t)(OBS_BUFFER_LENGTH + 1)) {
 				// initialise filter states
 				_mag_filt_state = _mag_sample_delayed.mag;
-			} else if (_mag_counter > OBS_BUFFER_LENGTH+1) {
+			} else if (_mag_counter > (uint8_t)(OBS_BUFFER_LENGTH + 1)) {
 				// noise filter the data
 				_mag_filt_state = _mag_filt_state * 0.9f + _mag_sample_delayed.mag * 0.1f;
 			}
@@ -306,10 +306,10 @@ bool Ekf::initialiseFilter(void)
 				// increment the sample count and apply a LPF to the measurement
 				_hgt_counter ++;
 				// don't start using data until we can be certain all bad initial data has been flushed
-				if (_hgt_counter == OBS_BUFFER_LENGTH+1) {
+				if (_hgt_counter == (uint8_t)(OBS_BUFFER_LENGTH + 1)) {
 					// initialise filter states
 					_rng_filt_state = _range_sample_delayed.rng;
-				} else if (_hgt_counter > OBS_BUFFER_LENGTH+1) {
+				} else if (_hgt_counter > (uint8_t)(OBS_BUFFER_LENGTH + 1)) {
 					// noise filter the data
 					_rng_filt_state = 0.9f * _rng_filt_state + 0.1f * _range_sample_delayed.rng;
 				}
@@ -330,10 +330,10 @@ bool Ekf::initialiseFilter(void)
 				// increment the sample count and apply a LPF to the measurement
 				_hgt_counter ++;
 				// don't start using data until we can be certain all bad initial data has been flushed
-				if (_hgt_counter == OBS_BUFFER_LENGTH+1) {
+				if (_hgt_counter == (uint8_t)(OBS_BUFFER_LENGTH + 1)) {
 					// initialise filter states
 					_baro_hgt_offset = _baro_sample_delayed.hgt;
-				} else if (_hgt_counter > OBS_BUFFER_LENGTH+1) {
+				} else if (_hgt_counter > (uint8_t)(OBS_BUFFER_LENGTH + 1)) {
 					// noise filter the data
 					_baro_hgt_offset = 0.9f * _baro_hgt_offset + 0.1f * _baro_sample_delayed.hgt;
 				}

--- a/EKF/ekf.cpp
+++ b/EKF/ekf.cpp
@@ -259,10 +259,10 @@ bool Ekf::initialiseFilter(void)
 			// increment the sample count and apply a LPF to the measurement
 			_mag_counter ++;
 			// don't start using data until we can be certain all bad initial data has been flushed
-			if (_mag_counter == (uint8_t)(OBS_BUFFER_LENGTH + 1)) {
+			if (_mag_counter == (uint8_t)(_obs_buffer_length + 1)) {
 				// initialise filter states
 				_mag_filt_state = _mag_sample_delayed.mag;
-			} else if (_mag_counter > (uint8_t)(OBS_BUFFER_LENGTH + 1)) {
+			} else if (_mag_counter > (uint8_t)(_obs_buffer_length + 1)) {
 				// noise filter the data
 				_mag_filt_state = _mag_filt_state * 0.9f + _mag_sample_delayed.mag * 0.1f;
 			}
@@ -306,10 +306,10 @@ bool Ekf::initialiseFilter(void)
 				// increment the sample count and apply a LPF to the measurement
 				_hgt_counter ++;
 				// don't start using data until we can be certain all bad initial data has been flushed
-				if (_hgt_counter == (uint8_t)(OBS_BUFFER_LENGTH + 1)) {
+				if (_hgt_counter == (uint8_t)(_obs_buffer_length + 1)) {
 					// initialise filter states
 					_rng_filt_state = _range_sample_delayed.rng;
-				} else if (_hgt_counter > (uint8_t)(OBS_BUFFER_LENGTH + 1)) {
+				} else if (_hgt_counter > (uint8_t)(_obs_buffer_length + 1)) {
 					// noise filter the data
 					_rng_filt_state = 0.9f * _rng_filt_state + 0.1f * _range_sample_delayed.rng;
 				}
@@ -330,10 +330,10 @@ bool Ekf::initialiseFilter(void)
 				// increment the sample count and apply a LPF to the measurement
 				_hgt_counter ++;
 				// don't start using data until we can be certain all bad initial data has been flushed
-				if (_hgt_counter == (uint8_t)(OBS_BUFFER_LENGTH + 1)) {
+				if (_hgt_counter == (uint8_t)(_obs_buffer_length + 1)) {
 					// initialise filter states
 					_baro_hgt_offset = _baro_sample_delayed.hgt;
-				} else if (_hgt_counter > (uint8_t)(OBS_BUFFER_LENGTH + 1)) {
+				} else if (_hgt_counter > (uint8_t)(_obs_buffer_length + 1)) {
 					// noise filter the data
 					_baro_hgt_offset = 0.9f * _baro_hgt_offset + 0.1f * _baro_sample_delayed.hgt;
 				}
@@ -347,9 +347,9 @@ bool Ekf::initialiseFilter(void)
 	}
 
 	// check to see if we have enough measurements and return false if not
-	bool hgt_count_fail = _hgt_counter <= 2*OBS_BUFFER_LENGTH;
-	bool mag_count_fail = _mag_counter <= 2*OBS_BUFFER_LENGTH;
-	bool ev_count_fail = ((_params.fusion_mode & MASK_USE_EVPOS) || (_params.fusion_mode & MASK_USE_EVYAW)) && (_ev_counter <= 2*OBS_BUFFER_LENGTH);
+	bool hgt_count_fail = _hgt_counter <= 2*_obs_buffer_length;
+	bool mag_count_fail = _mag_counter <= 2*_obs_buffer_length;
+	bool ev_count_fail = ((_params.fusion_mode & MASK_USE_EVPOS) || (_params.fusion_mode & MASK_USE_EVYAW)) && (_ev_counter <= 2*_obs_buffer_length);
 	if (hgt_count_fail || mag_count_fail || ev_count_fail) {
 		return false;
 

--- a/EKF/estimator_interface.cpp
+++ b/EKF/estimator_interface.cpp
@@ -353,8 +353,14 @@ bool EstimatorInterface::initialise_interface(uint64_t timestamp)
 	// calculate the IMU buffer length required to accomodate the maximum delay with some allowance for jitter
 	IMU_BUFFER_LENGTH = (max_time_delay_ms / FILTER_UPDATE_PERIOD_MS) + 1;
 
-	// set the observaton buffer length to handle the minimum time of arrival between observations
-	OBS_BUFFER_LENGTH = (max_time_delay_ms / _params.sensor_interval_min_ms) + 1;
+	// set the observaton buffer length to handle the minimum time of arrival between observations in combination
+	// with the worst case delay from current time to ekf fusion time
+	// allow for worst case 50% extension of the ekf fusion time horizon delay due to timing jitter
+	uint16_t ekf_delay_ms = max_time_delay_ms + (int)(ceil((float)max_time_delay_ms * 0.5f));
+	OBS_BUFFER_LENGTH = (ekf_delay_ms / _params.sensor_interval_min_ms) + 1;
+
+	// limit to be no longer than the IMU buffer (we can't process data faster than the EKF prediction rate)
+	OBS_BUFFER_LENGTH = math::min(OBS_BUFFER_LENGTH,IMU_BUFFER_LENGTH);
 
 	ECL_INFO("EKF IMU buffer length = %i",(int)IMU_BUFFER_LENGTH);
 	ECL_INFO("EKF observation buffer length = %i",(int)OBS_BUFFER_LENGTH);

--- a/EKF/estimator_interface.h
+++ b/EKF/estimator_interface.h
@@ -280,14 +280,14 @@ protected:
 	 max freq (Hz) = (OBS_BUFFER_LENGTH - 1) / (IMU_BUFFER_LENGTH * FILTER_UPDATE_PERIOD_MS * 0.001)
 	 This can be adjusted to match the max sensor data rate plus some margin for jitter.
 	*/
-	uint8_t OBS_BUFFER_LENGTH;
+	uint8_t _obs_buffer_length;
 	/*
 	IMU_BUFFER_LENGTH defines how many IMU samples we buffer which sets the time delay from current time to the
 	EKF fusion time horizon and therefore the maximum sensor time offset relative to the IMU that we can compensate for.
 	max sensor time offet (msec) =  IMU_BUFFER_LENGTH * FILTER_UPDATE_PERIOD_MS
 	This can be adjusted to a value that is FILTER_UPDATE_PERIOD_MS longer than the maximum observation time delay.
 	*/
-	uint8_t IMU_BUFFER_LENGTH;
+	uint8_t _imu_buffer_length;
 	static const unsigned FILTER_UPDATE_PERIOD_MS = 10;	// ekf prediction period in milliseconds
 
 	unsigned _min_obs_interval_us; // minimum time interval between observations that will guarantee data is not lost (usec)

--- a/EKF/estimator_interface.h
+++ b/EKF/estimator_interface.h
@@ -273,8 +273,21 @@ protected:
 
 	parameters _params;		// filter parameters
 
-	static const uint8_t OBS_BUFFER_LENGTH = 10;	// defines how many measurement samples we can buffer
-	static const uint8_t IMU_BUFFER_LENGTH = 30;	// defines how many imu samples we can buffer
+	/*
+	 OBS_BUFFER_LENGTH defines how many observations (non-IMU measurements) we can buffer
+	 which sets the maximum frequency at which we can process non-IMU measurements. Measurements that
+	 arrive too soon after the previous measurement will not be processed.
+	 max freq (Hz) = (OBS_BUFFER_LENGTH - 1) / (IMU_BUFFER_LENGTH * FILTER_UPDATE_PERIOD_MS * 0.001)
+	 This can be adjusted to match the max sensor data rate plus some margin for jitter.
+	*/
+	uint8_t OBS_BUFFER_LENGTH;
+	/*
+	IMU_BUFFER_LENGTH defines how many IMU samples we buffer which sets the time delay from current time to the
+	EKF fusion time horizon and therefore the maximum sensor time offset relative to the IMU that we can compensate for.
+	max sensor time offet (msec) =  IMU_BUFFER_LENGTH * FILTER_UPDATE_PERIOD_MS
+	This can be adjusted to a value that is FILTER_UPDATE_PERIOD_MS longer than the maximum observation time delay.
+	*/
+	uint8_t IMU_BUFFER_LENGTH;
 	static const unsigned FILTER_UPDATE_PERIOD_MS = 10;	// ekf prediction period in milliseconds
 
 	unsigned _min_obs_interval_us; // minimum time interval between observations that will guarantee data is not lost (usec)


### PR DESCRIPTION
Saves RAM and reduces output predictor errors by using the smallest data buffer length that meets time delay and update rate requirements. Buffer sizes used are sent to ground via ECL info message to enable verification and testing with default parameters has verified the correct IMU buffer size of 21 and observation buffer size of 11.

<img width="574" alt="screen shot 2016-11-07 at 10 18 00 am" src="https://cloud.githubusercontent.com/assets/3596952/20042758/8242d58c-a4d3-11e6-9e5e-117d1b7e014d.png">

Replay flight log here (used https://github.com/PX4/Firmware/pull/5814): http://logs.uaventure.com/view/ULJNmyuTUe9SjAfkh6e3jG

Replay log result  here (used https://github.com/PX4/Firmware/pull/5814):  http://logs.uaventure.com/view/yN5xVF9K6CoNhFDPefK2zk
