### PR TITLE
fw att fix pitch feedforward constrained roll

### DIFF
--- a/attitude_fw/ecl_pitch_controller.cpp
+++ b/attitude_fw/ecl_pitch_controller.cpp
@@ -127,7 +127,7 @@ float ECL_PitchController::control_bodyrate(const struct ECL_ControlData &ctl_da
 	/* roll is used as feedforward term and inverted flight needs to be considered */
 	if (fabsf(ctl_data.roll) < math::radians(90.0f)) {
 		/* not inverted, but numerically still potentially close to infinity */
-		constrained_roll = math::constrain(ctl_data.roll, -ctl_data.roll_setpoint, ctl_data.roll_setpoint);
+		constrained_roll = math::constrain(ctl_data.roll, -fabsf(ctl_data.roll_setpoint), fabsf(ctl_data.roll_setpoint));
 
 	} else {
 		/* inverted flight, constrain on the two extremes of -pi..+pi to avoid infinity */


### PR DESCRIPTION
@LorenzMeier this needs to get in before the next stable PX4. This commit is on top of the version of ecl in PX4 beta, so src/lib/ecl in beta could be reset to this branch (hotfix_ecl_pitch) if needed.

I've flown the current broken version in SITL/HIL/IRL multiple times, and only noticed the error in bench testing.