### PR TITLE
EKF: Improve use of range finder data

### DIFF
--- a/EKF/common.h
+++ b/EKF/common.h
@@ -234,6 +234,7 @@ struct parameters {
 	float range_noise;		// observation noise for range finder measurements (m)
 	float range_innov_gate;		// range finder fusion innovation consistency gate size (STD)
 	float rng_gnd_clearance;	// minimum valid value for range when on ground (m)
+	float rng_sens_pitch;		// Pitch offset of the range sensor (rad). Sensor points out along Z axis when offset is zero. Positive rotation is RH about Y axis.
 
 	// vision position fusion
 	float ev_innov_gate;		// vision estimator fusion innovation consistency gate size (STD)
@@ -337,6 +338,7 @@ struct parameters {
 		range_noise = 0.1f;
 		range_innov_gate = 5.0f;
 		rng_gnd_clearance = 0.1f;
+		rng_sens_pitch = 0.0f;
 
 		// optical flow fusion
 		flow_noise = 0.15f;

--- a/EKF/common.h
+++ b/EKF/common.h
@@ -235,6 +235,7 @@ struct parameters {
 	float range_innov_gate;		// range finder fusion innovation consistency gate size (STD)
 	float rng_gnd_clearance;	// minimum valid value for range when on ground (m)
 	float rng_sens_pitch;		// Pitch offset of the range sensor (rad). Sensor points out along Z axis when offset is zero. Positive rotation is RH about Y axis.
+	float range_noise_scaler;	// scaling from range measurement to noise (m/m)
 
 	// vision position fusion
 	float ev_innov_gate;		// vision estimator fusion innovation consistency gate size (STD)
@@ -339,6 +340,7 @@ struct parameters {
 		range_innov_gate = 5.0f;
 		rng_gnd_clearance = 0.1f;
 		rng_sens_pitch = 0.0f;
+		range_noise_scaler = 0.0f;
 
 		// optical flow fusion
 		flow_noise = 0.15f;

--- a/EKF/control.cpp
+++ b/EKF/control.cpp
@@ -71,8 +71,12 @@ void Ekf::controlFusionModes()
 	_gps_data_ready = _gps_buffer.pop_first_older_than(_imu_sample_delayed.time_us, &_gps_sample_delayed);
 	_mag_data_ready = _mag_buffer.pop_first_older_than(_imu_sample_delayed.time_us, &_mag_sample_delayed);
 	_baro_data_ready = _baro_buffer.pop_first_older_than(_imu_sample_delayed.time_us, &_baro_sample_delayed);
+
+	// calculate 2,2 element of rotation matrix from sensor frame to earth frame
+	_R_rng_to_earth_2_2 = _R_to_earth(2, 0) * _sin_tilt_rng + _R_to_earth(2, 2) * _cos_tilt_rng;
 	_range_data_ready = _range_buffer.pop_first_older_than(_imu_sample_delayed.time_us, &_range_sample_delayed)
-			&& (_R_to_earth(2, 2) > 0.7071f);
+			&& (_R_rng_to_earth_2_2 > 0.7071f);
+
 	_flow_data_ready = _flow_buffer.pop_first_older_than(_imu_sample_delayed.time_us, &_flow_sample_delayed)
 			&&  (_R_to_earth(2, 2) > 0.7071f);
 	_ev_data_ready = _ext_vision_buffer.pop_first_older_than(_imu_sample_delayed.time_us, &_ev_sample_delayed);
@@ -232,7 +236,7 @@ void Ekf::controlOpticalFlowFusion()
 					float heightAboveGndEst = fmaxf((_terrain_vpos - _state.pos(2)), _params.rng_gnd_clearance);
 
 					// calculate absolute distance from focal point to centre of frame assuming a flat earth
-					float range = heightAboveGndEst / _R_to_earth(2, 2);
+					float range = heightAboveGndEst / _R_rng_to_earth_2_2;
 
 					if ((range - _params.rng_gnd_clearance) > 0.3f && _flow_sample_delayed.dt > 0.05f) {
 						// we should have reliable OF measurements so
@@ -720,7 +724,7 @@ void Ekf::controlRangeFinderFusion()
 		// correct the range data for position offset relative to the IMU
 		Vector3f pos_offset_body = _params.rng_pos_body - _params.imu_pos_body;
 		Vector3f pos_offset_earth = _R_to_earth * pos_offset_body;
-		_range_sample_delayed.rng += pos_offset_earth(2) / _R_to_earth(2, 2);
+		_range_sample_delayed.rng += pos_offset_earth(2) / _R_rng_to_earth_2_2;
 
 		// always fuse available range finder data into a terrain height estimator if the estimator has been initialised
 		if (_terrain_initialised) {

--- a/EKF/control.cpp
+++ b/EKF/control.cpp
@@ -726,12 +726,6 @@ void Ekf::controlRangeFinderFusion()
 		Vector3f pos_offset_earth = _R_to_earth * pos_offset_body;
 		_range_sample_delayed.rng += pos_offset_earth(2) / _R_rng_to_earth_2_2;
 
-		// always fuse available range finder data into a terrain height estimator if the estimator has been initialised
-		if (_terrain_initialised) {
-			fuseHagl();
-
-		}
-
 		// only use range finder as a height observation in the main filter if specifically enabled
 		if (_control_status.flags.rng_hgt) {
 			_fuse_height = true;

--- a/EKF/ekf.cpp
+++ b/EKF/ekf.cpp
@@ -215,14 +215,8 @@ bool Ekf::update()
 		predictState();
 		predictCovariance();
 
-		// perform state and variance prediction for the terrain estimator
-		checkRangeDataContinuity();
-		if (!_terrain_initialised) {
-			_terrain_initialised = initHagl();
-
-		} else {
-			predictHagl();
-		}
+		// run a separate filter for terrain estimation
+		runTerrainEstimator();
 
 		// control fusion of observation data
 		controlFusionModes();

--- a/EKF/ekf.cpp
+++ b/EKF/ekf.cpp
@@ -184,6 +184,7 @@ bool Ekf::init(uint64_t timestamp)
 	_terrain_initialised = false;
 	_sin_tilt_rng = sinf(_params.rng_sens_pitch);
 	_cos_tilt_rng = cosf(_params.rng_sens_pitch);
+	_range_data_continuous = false;
 
 	_control_status.value = 0;
 	_control_status_prev.value = 0;
@@ -215,6 +216,7 @@ bool Ekf::update()
 		predictCovariance();
 
 		// perform state and variance prediction for the terrain estimator
+		checkRangeDataContinuity();
 		if (!_terrain_initialised) {
 			_terrain_initialised = initHagl();
 

--- a/EKF/ekf.cpp
+++ b/EKF/ekf.cpp
@@ -182,6 +182,8 @@ bool Ekf::init(uint64_t timestamp)
 
 	_filter_initialised = false;
 	_terrain_initialised = false;
+	_sin_tilt_rng = sinf(_params.rng_sens_pitch);
+	_cos_tilt_rng = cosf(_params.rng_sens_pitch);
 
 	_control_status.value = 0;
 	_control_status_prev.value = 0;
@@ -399,7 +401,7 @@ bool Ekf::initialiseFilter(void)
 			// so it can be used as a backup ad set the initial height using the range finder
 			baroSample baro_newest = _baro_buffer.get_newest();
 			_baro_hgt_offset = baro_newest.hgt;
-			_state.pos(2) = -math::max(_rng_filt_state * _R_to_earth(2, 2),_params.rng_gnd_clearance);
+			_state.pos(2) = -math::max(_rng_filt_state * _R_rng_to_earth_2_2,_params.rng_gnd_clearance);
 			ECL_INFO("EKF using range finder height - commencing alignment");
 
 		} else if (_control_status.flags.ev_hgt) {

--- a/EKF/ekf.h
+++ b/EKF/ekf.h
@@ -317,6 +317,7 @@ private:
 	float _sin_tilt_rng;		// sine of the range finder tilt rotation about the Y body axis
 	float _cos_tilt_rng;		// cosine of the range finder tilt rotation about the Y body axis
 	float _R_rng_to_earth_2_2;	// 2,2 element of the rotation matrix from sensor frame to earth frame
+	bool _range_data_continuous;	// true when we are receiving range finder data faster than a 2Hz average
 
 	// height sensor fault status
 	bool _baro_hgt_faulty;		// true if valid baro data is unavailable for use
@@ -477,5 +478,8 @@ private:
 
 	// perform a reset of the wind states
 	void resetWindStates();
+
+	// check that the range finder data is continuous
+	void checkRangeDataContinuity();
 
 };

--- a/EKF/ekf.h
+++ b/EKF/ekf.h
@@ -375,8 +375,8 @@ private:
 	// return true if the initialisation is successful
 	bool initHagl();
 
-	// predict the terrain vertical position state and variance
-	void predictHagl();
+	// run the terrain estimator
+	void runTerrainEstimator();
 
 	// update the terrain vertical position estimate using a height above ground measurement from the range finder
 	void fuseHagl();

--- a/EKF/ekf.h
+++ b/EKF/ekf.h
@@ -314,6 +314,9 @@ private:
 	float _hagl_innov_var;		// innovation variance for the last height above terrain measurement (m^2)
 	uint64_t _time_last_hagl_fuse;	// last system time in usec that the hagl measurement failed it's checks
 	bool _terrain_initialised;	// true when the terrain estimator has been intialised
+	float _sin_tilt_rng;		// sine of the range finder tilt rotation about the Y body axis
+	float _cos_tilt_rng;		// cosine of the range finder tilt rotation about the Y body axis
+	float _R_rng_to_earth_2_2;	// 2,2 element of the rotation matrix from sensor frame to earth frame
 
 	// height sensor fault status
 	bool _baro_hgt_faulty;		// true if valid baro data is unavailable for use

--- a/EKF/estimator_interface.cpp
+++ b/EKF/estimator_interface.cpp
@@ -117,17 +117,17 @@ void EstimatorInterface::setIMUData(uint64_t time_usec, uint64_t delta_ang_dt, u
 
 	// calculate a metric which indicates the amount of coning vibration
 	Vector3f temp = cross_product(imu_sample_new.delta_ang , _delta_ang_prev);
-	_vibe_metrics[0] = 0.99f * _vibe_metrics[0] + 0.01f * temp.length();
+	_vibe_metrics[0] = 0.99f * _vibe_metrics[0] + 0.01f * temp.norm();
 
 	// calculate a metric which indiates the amount of high frequency gyro vibration
 	temp = imu_sample_new.delta_ang - _delta_ang_prev;
 	_delta_ang_prev = imu_sample_new.delta_ang;
-	_vibe_metrics[1] = 0.99f * _vibe_metrics[1] + 0.01f * temp.length();
+	_vibe_metrics[1] = 0.99f * _vibe_metrics[1] + 0.01f * temp.norm();
 
 	// calculate a metric which indicates the amount of high fequency accelerometer vibration
 	temp = imu_sample_new.delta_vel - _delta_vel_prev;
 	_delta_vel_prev = imu_sample_new.delta_vel;
-	_vibe_metrics[2] = 0.99f * _vibe_metrics[2] + 0.01f * temp.length();
+	_vibe_metrics[2] = 0.99f * _vibe_metrics[2] + 0.01f * temp.norm();
 
 	// accumulate and down-sample imu data and push to the buffer when new downsampled data becomes available
 	if (collect_imu(imu_sample_new)) {

--- a/EKF/terrain_estimator.cpp
+++ b/EKF/terrain_estimator.cpp
@@ -99,7 +99,7 @@ void Ekf::fuseHagl()
 		_hagl_innov = pred_hagl - meas_hagl;
 
 		// calculate the observation variance adding the variance of the vehicles own height uncertainty and factoring in the effect of tilt on measurement error
-		float obs_variance = fmaxf(P[9][9], 0.0f) + sq(_params.range_noise / _R_rng_to_earth_2_2);
+		float obs_variance = fmaxf(P[9][9], 0.0f) + (sq(_params.range_noise) + sq(_params.range_noise_scaler * _range_sample_delayed.rng)) * _R_rng_to_earth_2_2;
 
 		// calculate the innovation variance - limiting it to prevent a badly conditioned fusion
 		_hagl_innov_var = fmaxf(_terrain_var + obs_variance, obs_variance);

--- a/EKF/terrain_estimator.cpp
+++ b/EKF/terrain_estimator.cpp
@@ -47,9 +47,9 @@ bool Ekf::initHagl()
 	// get most recent range measurement from buffer
 	rangeSample latest_measurement = _range_buffer.get_newest();
 
-	if ((_time_last_imu - latest_measurement.time_us) < 2e5 && _R_to_earth(2,2) > 0.7071f) {
+	if ((_time_last_imu - latest_measurement.time_us) < 2e5 && _R_rng_to_earth_2_2 > 0.7071f) {
 		// if we have a fresh measurement, use it to initialise the terrain estimator
-		_terrain_vpos = _state.pos(2) + latest_measurement.rng * _R_to_earth(2, 2);
+		_terrain_vpos = _state.pos(2) + latest_measurement.rng * _R_rng_to_earth_2_2;
 		// initialise state variance to variance of measurement
 		_terrain_var = sq(_params.range_noise);
 		// success
@@ -88,9 +88,9 @@ void Ekf::predictHagl()
 void Ekf::fuseHagl()
 {
 	// If the vehicle is excessively tilted, do not try to fuse range finder observations
-	if (_R_to_earth(2, 2) > 0.7071f) {
+	if (_R_rng_to_earth_2_2 > 0.7071f) {
 		// get a height above ground measurement from the range finder assuming a flat earth
-		float meas_hagl = _range_sample_delayed.rng * _R_to_earth(2, 2);
+		float meas_hagl = _range_sample_delayed.rng * _R_rng_to_earth_2_2;
 
 		// predict the hagl from the vehicle position and terrain height
 		float pred_hagl = _terrain_vpos - _state.pos(2);
@@ -99,7 +99,7 @@ void Ekf::fuseHagl()
 		_hagl_innov = pred_hagl - meas_hagl;
 
 		// calculate the observation variance adding the variance of the vehicles own height uncertainty and factoring in the effect of tilt on measurement error
-		float obs_variance = fmaxf(P[9][9], 0.0f) + sq(_params.range_noise / _R_to_earth(2, 2));
+		float obs_variance = fmaxf(P[9][9], 0.0f) + sq(_params.range_noise / _R_rng_to_earth_2_2);
 
 		// calculate the innovation variance - limiting it to prevent a badly conditioned fusion
 		_hagl_innov_var = fmaxf(_terrain_var + obs_variance, obs_variance);

--- a/EKF/terrain_estimator.cpp
+++ b/EKF/terrain_estimator.cpp
@@ -98,8 +98,8 @@ void Ekf::fuseHagl()
 		// calculate the innovation
 		_hagl_innov = pred_hagl - meas_hagl;
 
-		// calculate the observation variance adding the variance of the vehicles own height uncertainty and factoring in the effect of tilt on measurement error
-		float obs_variance = fmaxf(P[9][9], 0.0f) + (sq(_params.range_noise) + sq(_params.range_noise_scaler * _range_sample_delayed.rng)) * _R_rng_to_earth_2_2;
+		// calculate the observation variance adding the variance of the vehicles own height uncertainty
+		float obs_variance = fmaxf(P[9][9], 0.0f) + sq(_params.range_noise) + sq(_params.range_noise_scaler * _range_sample_delayed.rng);
 
 		// calculate the innovation variance - limiting it to prevent a badly conditioned fusion
 		_hagl_innov_var = fmaxf(_terrain_var + obs_variance, obs_variance);

--- a/EKF/terrain_estimator.cpp
+++ b/EKF/terrain_estimator.cpp
@@ -135,10 +135,7 @@ bool Ekf::get_terrain_vert_pos(float *ret)
 {
 	memcpy(ret, &_terrain_vpos, sizeof(float));
 
-	// The height is useful if the uncertainty in terrain height is significantly smaller than than the estimated height above terrain
-	bool accuracy_useful = (sqrtf(_terrain_var) < 0.2f * fmaxf((_terrain_vpos - _state.pos(2)), _params.rng_gnd_clearance));
-
-	if (_time_last_imu - _time_last_hagl_fuse < 1e6 || accuracy_useful) {
+	if (_terrain_initialised && (_time_last_imu - _time_last_hagl_fuse < 1e6)) {
 		return true;
 
 	} else {

--- a/EKF/vel_pos_fusion.cpp
+++ b/EKF/vel_pos_fusion.cpp
@@ -155,10 +155,10 @@ void Ekf::fuseVelPosHeight()
 			// innovation gate size
 			gate_size[5] = fmaxf(_params.baro_innov_gate, 1.0f);
 
-		} else if (_control_status.flags.rng_hgt && (_R_to_earth(2, 2) > 0.7071f)) {
+		} else if (_control_status.flags.rng_hgt && (_R_rng_to_earth_2_2 > 0.7071f)) {
 			fuse_map[5] = true;
 			// use range finder with tilt correction
-			_vel_pos_innov[5] = _state.pos(2) - (-math::max(_range_sample_delayed.rng * _R_to_earth(2, 2),
+			_vel_pos_innov[5] = _state.pos(2) - (-math::max(_range_sample_delayed.rng * _R_rng_to_earth_2_2,
 							     _params.rng_gnd_clearance));
 			// observation variance - user parameter defined
 			R[5] = fmaxf(_params.range_noise, 0.01f);

--- a/EKF/vel_pos_fusion.cpp
+++ b/EKF/vel_pos_fusion.cpp
@@ -161,8 +161,7 @@ void Ekf::fuseVelPosHeight()
 			_vel_pos_innov[5] = _state.pos(2) - (-math::max(_range_sample_delayed.rng * _R_rng_to_earth_2_2,
 							     _params.rng_gnd_clearance));
 			// observation variance - user parameter defined
-			R[5] = fmaxf(_params.range_noise, 0.01f);
-			R[5] = R[5] * R[5];
+			R[5] = fmaxf((sq(_params.range_noise) + sq(_params.range_noise_scaler * _range_sample_delayed.rng)) * sq(_R_rng_to_earth_2_2), 0.01f);
 			// innovation gate size
 			gate_size[5] = fmaxf(_params.range_innov_gate, 1.0f);
 		} else if (_control_status.flags.ev_hgt) {


### PR DESCRIPTION
- Enables use of range finders that are misaligned in pitch relative to the Z body axis.
- Enables the range finder observation variance to be scaled with range to ground to allow for scale factor errors associated with some ranging techniques.
- Fixes a false triggering in the local position height above ground validity checks when operating close to the ground.
- Use norm() instead of length() to maintain consistency with rest of code.