### PR TITLE
Increase VALUE_EQUAL_COUNT_MAX to prevent false positive stale data errors

### DIFF
--- a/validation/data_validator.h
+++ b/validation/data_validator.h
@@ -173,7 +173,7 @@ private:
 	DataValidator *_sibling;		/**< sibling in the group */
 	static const constexpr unsigned NORETURN_ERRCOUNT = 10000;	/**< if the error count reaches this value, return sensor as invalid */
 	static const constexpr float ERROR_DENSITY_WINDOW = 100.0f; 	/**< window in measurement counts for errors */
-	static const constexpr unsigned VALUE_EQUAL_COUNT_MAX = 100;	/**< if the sensor value is the same (accumulated also between axes) this many times, flag it */
+	static const constexpr unsigned VALUE_EQUAL_COUNT_MAX = 1000;	/**< if the sensor value is the same (accumulated also between axes) this many times, flag it */
 
 	/* we don't want this class to be copied */
 	DataValidator(const DataValidator&) = delete;


### PR DESCRIPTION
Current approach to stale data detection rests on the assumption that at least one dimension of the monitored sensor feed will contain enough noise to periodically reset the stale data counter. We (+ @PierricG) found out that this assumption does not hold for sensors that produce measurements with minimal resolution that is enough to convey the data with adequate precision, but not enough to accommodate sufficient noise.

An example of such a sensor would be a UAVCAN connected magnetometer, where the magnetic field strength measurements are carried in a three dimensional vector of float16. It can be seen that while epsilon of float16 is low enough to provide sufficient resolution (0.001), a sufficiently low noise stationary sensor will be susceptible to reporting exactly the same values for periods of time that are long enough to trigger the stale data detector. Obviously, this issue should never manifest in flight, since no platform can be that stable, but it does cause problems while the UAV is stationary, e.g. in the lab.

Fundamentally I see two solutions to this problem, neither of which are ideal:

- Increase the stale data detection threshold. This solution is implemented in this PR. We were unable to trigger stale data errors with this setting, so it does solve the problem, at the cost of increased detection latency. Using 100 Hz three dimensional sensor feed as a reference, the stale data detection latency provided by the old setting is 100 Hz / 100 samples / 3 dimensions = 0.3 s; the new setting raises the latency tenfold.

- The other possible solution is to introduce dithering to the sensor feed in the driver, if it is known ahead of time that said driver will have stale data issues. Not only this solution is masking the real problem instead of solving it, it actually defeats the purpose of the stale data check, so I am against it.

Hopefully this change will be merged and included into PX4 v2.0 release, at least as a temporary fix, if better solution exists.