### PR TITLE
EKF: Add validity flag to ekf origin reporting

### DIFF
--- a/EKF/ekf.h
+++ b/EKF/ekf.h
@@ -114,7 +114,8 @@ public:
 	bool collect_imu(imuSample &imu);
 
 	// get the ekf WGS-84 origin position and height and the system time it was last set
-	void get_ekf_origin(uint64_t *origin_time, map_projection_reference_s *origin_pos, float *origin_alt);
+	// return true if the origin is valid
+	bool get_ekf_origin(uint64_t *origin_time, map_projection_reference_s *origin_pos, float *origin_alt);
 
 	// get the 1-sigma horizontal and vertical position uncertainty of the ekf WGS-84 position
 	void get_ekf_accuracy(float *ekf_eph, float *ekf_epv, bool *dead_reckoning);

--- a/EKF/ekf_helper.cpp
+++ b/EKF/ekf_helper.cpp
@@ -694,11 +694,13 @@ void Ekf::get_covariances(float *covariances)
 }
 
 // get the position and height of the ekf origin in WGS-84 coordinates and time the origin was set
-void Ekf::get_ekf_origin(uint64_t *origin_time, map_projection_reference_s *origin_pos, float *origin_alt)
+// return true if the origin is valid
+bool Ekf::get_ekf_origin(uint64_t *origin_time, map_projection_reference_s *origin_pos, float *origin_alt)
 {
 	memcpy(origin_time, &_last_gps_origin_time_us, sizeof(uint64_t));
 	memcpy(origin_pos, &_pos_ref, sizeof(map_projection_reference_s));
 	memcpy(origin_alt, &_gps_alt_ref, sizeof(float));
+	return _NED_origin_initialised;
 }
 
 // return an array containing the output predictor angular, velocity and position tracking

--- a/EKF/estimator_interface.h
+++ b/EKF/estimator_interface.h
@@ -125,8 +125,9 @@ public:
 	*/
 	virtual void get_imu_vibe_metrics(float vibe[3]) = 0;
 
-	// get the ekf WGS-84 origin positoin and height and the system time it was last set
-	virtual void get_ekf_origin(uint64_t *origin_time, map_projection_reference_s *origin_pos, float *origin_alt) = 0;
+	// get the ekf WGS-84 origin position and height and the system time it was last set
+	// return true if the origin is valid
+	virtual bool get_ekf_origin(uint64_t *origin_time, map_projection_reference_s *origin_pos, float *origin_alt) = 0;
 
 	// get the 1-sigma horizontal and vertical position uncertainty of the ekf WGS-84 position
 	virtual void get_ekf_accuracy(float *ekf_eph, float *ekf_epv, bool *dead_reckoning) = 0;


### PR DESCRIPTION
This is required to support PX4 Firmware fixes for https://github.com/PX4/Firmware/issues/6193. The origin is not valid until it has been fixed and the EKF is using it as a reference.