### PR TITLE
Pr fw acro

### DIFF
--- a/attitude_fw/ecl_controller.h
+++ b/attitude_fw/ecl_controller.h
@@ -56,9 +56,9 @@ struct ECL_ControlData {
 	float roll;
 	float pitch;
 	float yaw;
-	float roll_rate;
-	float pitch_rate;
-	float yaw_rate;
+	float body_x_rate;
+	float body_y_rate;
+	float body_z_rate;
 	float speed_body_u;
 	float speed_body_v;
 	float speed_body_w;
@@ -78,6 +78,7 @@ struct ECL_ControlData {
 	float groundspeed;
 	float groundspeed_scaler;
 	bool lock_integrator;
+	bool do_turn_compensation;
 };
 
 class __EXPORT ECL_Controller
@@ -87,6 +88,7 @@ public:
 	~ECL_Controller() = default;
 
 	virtual float control_attitude(const struct ECL_ControlData &ctl_data) = 0;
+	virtual float control_euler_rate(const struct ECL_ControlData &ctl_data) = 0;
 	virtual float control_bodyrate(const struct ECL_ControlData &ctl_data) = 0;
 
 	/* Setters */
@@ -96,6 +98,7 @@ public:
 	void set_k_ff(float k_ff);
 	void set_integrator_max(float max);
 	void set_max_rate(float max_rate);
+	void set_bodyrate_setpoint(float rate) {_bodyrate_setpoint = rate;};
 
 	/* Getters */
 	float get_rate_error();

--- a/attitude_fw/ecl_controller.h
+++ b/attitude_fw/ecl_controller.h
@@ -78,7 +78,6 @@ struct ECL_ControlData {
 	float groundspeed;
 	float groundspeed_scaler;
 	bool lock_integrator;
-	bool do_turn_compensation;
 };
 
 class __EXPORT ECL_Controller

--- a/attitude_fw/ecl_controller.h
+++ b/attitude_fw/ecl_controller.h
@@ -59,12 +59,6 @@ struct ECL_ControlData {
 	float body_x_rate;
 	float body_y_rate;
 	float body_z_rate;
-	float speed_body_u;
-	float speed_body_v;
-	float speed_body_w;
-	float acc_body_x;
-	float acc_body_y;
-	float acc_body_z;
 	float roll_setpoint;
 	float pitch_setpoint;
 	float yaw_setpoint;

--- a/attitude_fw/ecl_pitch_controller.cpp
+++ b/attitude_fw/ecl_pitch_controller.cpp
@@ -112,51 +112,6 @@ float ECL_PitchController::control_bodyrate(const struct ECL_ControlData &ctl_da
 		lock_integrator = true;
 	}
 
-	/* apply turning offset to desired bodyrate setpoint*/
-	/* flying inverted (wings upside down)*/
-	bool inverted = false;
-	float constrained_roll;
-
-	/* roll is used as feedforward term and inverted flight needs to be considered */
-	if (fabsf(ctl_data.roll) < math::radians(90.0f)) {
-		/* not inverted, but numerically still potentially close to infinity */
-		constrained_roll = math::constrain(ctl_data.roll, -fabsf(ctl_data.roll_setpoint), fabsf(ctl_data.roll_setpoint));
-
-	} else {
-		/* inverted flight, constrain on the two extremes of -pi..+pi to avoid infinity */
-		inverted = true;
-
-		/* note: the ranges are extended by 10 deg here to avoid numeric resolution effects */
-		if (ctl_data.roll > 0.0f) {
-			/* right hemisphere */
-			constrained_roll = math::constrain(ctl_data.roll, math::radians(100.0f), math::radians(180.0f));
-
-		} else {
-			/* left hemisphere */
-			constrained_roll = math::constrain(ctl_data.roll, math::radians(-100.0f), math::radians(-180.0f));
-		}
-	}
-
-	/* input conditioning */
-	float airspeed = constrain_airspeed(ctl_data.airspeed, ctl_data.airspeed_min, ctl_data.airspeed_max);
-
-	if (ctl_data.do_turn_compensation) {
-		/* Calculate desired body fixed y-axis angular rate needed to compensate for roll angle.
-		   For reference see Automatic Control of Aircraft and Missiles by John H. Blakelock, pg. 175
-		   Availible on google books 8/11/2015:
-		   https://books.google.com/books?id=ubcczZUDCsMC&pg=PA175#v=onepage&q&f=false*/
-		float body_fixed_turn_offset = (fabsf((CONSTANTS_ONE_G / airspeed) *
-						tanf(constrained_roll) * sinf(constrained_roll)));
-
-		if (inverted) {
-			body_fixed_turn_offset = -body_fixed_turn_offset;
-		}
-
-		/* Finally add the turn offset to your bodyrate setpoint*/
-		_bodyrate_setpoint += body_fixed_turn_offset;
-	}
-
-
 	_rate_error = _bodyrate_setpoint - ctl_data.body_y_rate;
 
 	if (!lock_integrator && _k_i > 0.0f) {

--- a/attitude_fw/ecl_pitch_controller.cpp
+++ b/attitude_fw/ecl_pitch_controller.cpp
@@ -91,8 +91,8 @@ float ECL_PitchController::control_bodyrate(const struct ECL_ControlData &ctl_da
 	/* Do not calculate control signal with bad inputs */
 	if (!(PX4_ISFINITE(ctl_data.roll) &&
 	      PX4_ISFINITE(ctl_data.pitch) &&
-	      PX4_ISFINITE(ctl_data.pitch_rate) &&
-	      PX4_ISFINITE(ctl_data.yaw_rate) &&
+	      PX4_ISFINITE(ctl_data.body_y_rate) &&
+	      PX4_ISFINITE(ctl_data.body_z_rate) &&
 	      PX4_ISFINITE(ctl_data.yaw_rate_setpoint) &&
 	      PX4_ISFINITE(ctl_data.airspeed_min) &&
 	      PX4_ISFINITE(ctl_data.airspeed_max) &&
@@ -111,10 +111,6 @@ float ECL_PitchController::control_bodyrate(const struct ECL_ControlData &ctl_da
 	if (dt_micros > 500000) {
 		lock_integrator = true;
 	}
-
-	/* Transform setpoint to body angular rates (jacobian) */
-	_bodyrate_setpoint = cosf(ctl_data.roll) * _rate_setpoint +
-			     cosf(ctl_data.pitch) * sinf(ctl_data.roll) * ctl_data.yaw_rate_setpoint;
 
 	/* apply turning offset to desired bodyrate setpoint*/
 	/* flying inverted (wings upside down)*/
@@ -144,22 +140,24 @@ float ECL_PitchController::control_bodyrate(const struct ECL_ControlData &ctl_da
 	/* input conditioning */
 	float airspeed = constrain_airspeed(ctl_data.airspeed, ctl_data.airspeed_min, ctl_data.airspeed_max);
 
-	/* Calculate desired body fixed y-axis angular rate needed to compensate for roll angle.
-	   For reference see Automatic Control of Aircraft and Missiles by John H. Blakelock, pg. 175
-	   Availible on google books 8/11/2015:
-	   https://books.google.com/books?id=ubcczZUDCsMC&pg=PA175#v=onepage&q&f=false*/
-	float body_fixed_turn_offset = (fabsf((CONSTANTS_ONE_G / airspeed) *
-					      tanf(constrained_roll) * sinf(constrained_roll)));
+	if (ctl_data.do_turn_compensation) {
+		/* Calculate desired body fixed y-axis angular rate needed to compensate for roll angle.
+		   For reference see Automatic Control of Aircraft and Missiles by John H. Blakelock, pg. 175
+		   Availible on google books 8/11/2015:
+		   https://books.google.com/books?id=ubcczZUDCsMC&pg=PA175#v=onepage&q&f=false*/
+		float body_fixed_turn_offset = (fabsf((CONSTANTS_ONE_G / airspeed) *
+						tanf(constrained_roll) * sinf(constrained_roll)));
 
-	if (inverted) {
-		body_fixed_turn_offset = -body_fixed_turn_offset;
+		if (inverted) {
+			body_fixed_turn_offset = -body_fixed_turn_offset;
+		}
+
+		/* Finally add the turn offset to your bodyrate setpoint*/
+		_bodyrate_setpoint += body_fixed_turn_offset;
 	}
 
-	/* Finally add the turn offset to your bodyrate setpoint*/
-	_bodyrate_setpoint += body_fixed_turn_offset;
 
-
-	_rate_error = _bodyrate_setpoint - ctl_data.pitch_rate;
+	_rate_error = _bodyrate_setpoint - ctl_data.body_y_rate;
 
 	if (!lock_integrator && _k_i > 0.0f) {
 
@@ -188,7 +186,15 @@ float ECL_PitchController::control_bodyrate(const struct ECL_ControlData &ctl_da
 	_last_output = _bodyrate_setpoint * _k_ff * ctl_data.scaler +
 		       _rate_error * _k_p * ctl_data.scaler * ctl_data.scaler
 		       + integrator_constrained;  //scaler is proportional to 1/airspeed
-//	warnx("pitch: _integrator: %.4f, _integrator_max: %.4f, airspeed %.4f, _k_i %.4f, _k_p: %.4f", (double)_integrator, (double)_integrator_max, (double)airspeed, (double)_k_i, (double)_k_p);
-//	warnx("roll: _last_output %.4f", (double)_last_output);
+
 	return math::constrain(_last_output, -1.0f, 1.0f);
+}
+
+float ECL_PitchController::control_euler_rate(const struct ECL_ControlData &ctl_data)
+{
+	/* Transform setpoint to body angular rates (jacobian) */
+	_bodyrate_setpoint = cosf(ctl_data.roll) * _rate_setpoint +
+			     cosf(ctl_data.pitch) * sinf(ctl_data.roll) * ctl_data.yaw_rate_setpoint;
+
+	return control_bodyrate(ctl_data);
 }

--- a/attitude_fw/ecl_pitch_controller.h
+++ b/attitude_fw/ecl_pitch_controller.h
@@ -62,6 +62,7 @@ public:
 	~ECL_PitchController() = default;
 
 	float control_attitude(const struct ECL_ControlData &ctl_data);
+	float control_euler_rate(const struct ECL_ControlData &ctl_data);
 	float control_bodyrate(const struct ECL_ControlData &ctl_data);
 
 	/* Additional Setters */

--- a/attitude_fw/ecl_roll_controller.cpp
+++ b/attitude_fw/ecl_roll_controller.cpp
@@ -124,7 +124,7 @@ float ECL_RollController::control_bodyrate(const struct ECL_ControlData &ctl_dat
 
 	/* integrator limit */
 	//xxx: until start detection is available: integral part in control signal is limited here
-	float integrator_constrained = math::constrain(_integrator * _k_i, -_integrator_max, _integrator_max);
+	float integrator_constrained = math::constrain(_integrator, -_integrator_max, _integrator_max);
 
 	/* Apply PI rate controller and store non-limited output */
 	_last_output = _bodyrate_setpoint * _k_ff * ctl_data.scaler +

--- a/attitude_fw/ecl_roll_controller.h
+++ b/attitude_fw/ecl_roll_controller.h
@@ -62,6 +62,7 @@ public:
 	~ECL_RollController() = default;
 
 	float control_attitude(const struct ECL_ControlData &ctl_data);
+	float control_euler_rate(const struct ECL_ControlData &ctl_data);
 	float control_bodyrate(const struct ECL_ControlData &ctl_data);
 };
 

--- a/attitude_fw/ecl_wheel_controller.cpp
+++ b/attitude_fw/ecl_wheel_controller.cpp
@@ -54,12 +54,12 @@ ECL_WheelController::ECL_WheelController() :
 
 float ECL_WheelController::control_bodyrate(const struct ECL_ControlData &ctl_data)
 {
-	/* Do not calculate control signal with bad inputs */
-	if (!(PX4_ISFINITE(ctl_data.yaw_rate) &&
-	      PX4_ISFINITE(ctl_data.groundspeed) &&
-	      PX4_ISFINITE(ctl_data.groundspeed_scaler))) {
-		return math::constrain(_last_output, -1.0f, 1.0f);
-	}
+    /* Do not calculate control signal with bad inputs */
+    if (!(PX4_ISFINITE(ctl_data.body_z_rate) &&
+          PX4_ISFINITE(ctl_data.groundspeed) &&
+          PX4_ISFINITE(ctl_data.groundspeed_scaler))) {
+        return math::constrain(_last_output, -1.0f, 1.0f);
+    }
 
 	/* get the usual dt estimate */
 	uint64_t dt_micros = ecl_elapsed_time(&_last_run);
@@ -76,8 +76,8 @@ float ECL_WheelController::control_bodyrate(const struct ECL_ControlData &ctl_da
 	/* input conditioning */
 	float min_speed = 1.0f;
 
-	/* Calculate body angular rate error */
-	_rate_error = _rate_setpoint - ctl_data.yaw_rate; //body angular rate error
+    /* Calculate body angular rate error */
+    _rate_error = _rate_setpoint - ctl_data.body_z_rate; //body angular rate error
 
 	if (!lock_integrator && _k_i > 0.0f && ctl_data.groundspeed > min_speed) {
 

--- a/attitude_fw/ecl_wheel_controller.cpp
+++ b/attitude_fw/ecl_wheel_controller.cpp
@@ -54,12 +54,12 @@ ECL_WheelController::ECL_WheelController() :
 
 float ECL_WheelController::control_bodyrate(const struct ECL_ControlData &ctl_data)
 {
-    /* Do not calculate control signal with bad inputs */
-    if (!(PX4_ISFINITE(ctl_data.body_z_rate) &&
-          PX4_ISFINITE(ctl_data.groundspeed) &&
-          PX4_ISFINITE(ctl_data.groundspeed_scaler))) {
-        return math::constrain(_last_output, -1.0f, 1.0f);
-    }
+	/* Do not calculate control signal with bad inputs */
+	if (!(PX4_ISFINITE(ctl_data.body_z_rate) &&
+	      PX4_ISFINITE(ctl_data.groundspeed) &&
+	      PX4_ISFINITE(ctl_data.groundspeed_scaler))) {
+		return math::constrain(_last_output, -1.0f, 1.0f);
+	}
 
 	/* get the usual dt estimate */
 	uint64_t dt_micros = ecl_elapsed_time(&_last_run);
@@ -76,8 +76,8 @@ float ECL_WheelController::control_bodyrate(const struct ECL_ControlData &ctl_da
 	/* input conditioning */
 	float min_speed = 1.0f;
 
-    /* Calculate body angular rate error */
-    _rate_error = _rate_setpoint - ctl_data.body_z_rate; //body angular rate error
+	/* Calculate body angular rate error */
+	_rate_error = _rate_setpoint - ctl_data.body_z_rate; //body angular rate error
 
 	if (!lock_integrator && _k_i > 0.0f && ctl_data.groundspeed > min_speed) {
 
@@ -102,9 +102,9 @@ float ECL_WheelController::control_bodyrate(const struct ECL_ControlData &ctl_da
 	//xxx: until start detection is available: integral part in control signal is limited here
 	float integrator_constrained = math::constrain(_integrator, -_integrator_max, _integrator_max);
 
-    /* Apply PI rate controller and store non-limited output */
-    _last_output = _rate_setpoint * _k_ff * ctl_data.groundspeed_scaler +
-             ctl_data.groundspeed_scaler * ctl_data.groundspeed_scaler * (_rate_error * _k_p + integrator_constrained);
+	/* Apply PI rate controller and store non-limited output */
+	_last_output = _rate_setpoint * _k_ff * ctl_data.groundspeed_scaler +
+		       ctl_data.groundspeed_scaler * ctl_data.groundspeed_scaler * (_rate_error * _k_p + integrator_constrained);
 
 	return math::constrain(_last_output, -1.0f, 1.0f);
 }
@@ -118,10 +118,10 @@ float ECL_WheelController::control_attitude(const struct ECL_ControlData &ctl_da
 		return _rate_setpoint;
 	}
 
-    /* Calculate the error */
-    float yaw_error = ctl_data.yaw_setpoint - ctl_data.yaw;
-    /* shortest angle (wrap around) */
-    yaw_error = (float)fmod((float)fmod((yaw_error + M_PI_F), M_TWOPI_F) + M_TWOPI_F, M_TWOPI_F) - M_PI_F;
+	/* Calculate the error */
+	float yaw_error = ctl_data.yaw_setpoint - ctl_data.yaw;
+	/* shortest angle (wrap around) */
+	yaw_error = (float)fmod((float)fmod((yaw_error + M_PI_F), M_TWOPI_F) + M_TWOPI_F, M_TWOPI_F) - M_PI_F;
 
 	/*  Apply P controller: rate setpoint from current error and time constant */
 	_rate_setpoint =  yaw_error / _tc;

--- a/attitude_fw/ecl_wheel_controller.cpp
+++ b/attitude_fw/ecl_wheel_controller.cpp
@@ -119,9 +119,7 @@ float ECL_WheelController::control_attitude(const struct ECL_ControlData &ctl_da
 	}
 
 	/* Calculate the error */
-	float yaw_error = ctl_data.yaw_setpoint - ctl_data.yaw;
-	/* shortest angle (wrap around) */
-	yaw_error = (float)fmod((float)fmod((yaw_error + M_PI_F), M_TWOPI_F) + M_TWOPI_F, M_TWOPI_F) - M_PI_F;
+	float yaw_error = _wrap_pi(ctl_data.yaw_setpoint - ctl_data.yaw);
 
 	/*  Apply P controller: rate setpoint from current error and time constant */
 	_rate_setpoint =  yaw_error / _tc;

--- a/attitude_fw/ecl_wheel_controller.cpp
+++ b/attitude_fw/ecl_wheel_controller.cpp
@@ -102,13 +102,9 @@ float ECL_WheelController::control_bodyrate(const struct ECL_ControlData &ctl_da
 	//xxx: until start detection is available: integral part in control signal is limited here
 	float integrator_constrained = math::constrain(_integrator, -_integrator_max, _integrator_max);
 
-	/* Apply PI rate controller and store non-limited output */
-	_last_output = _rate_setpoint * _k_ff * ctl_data.groundspeed_scaler +
-		       _rate_error * _k_p * ctl_data.groundspeed_scaler * ctl_data.groundspeed_scaler +
-		       integrator_constrained;
-	/*warnx("wheel: _last_output: %.4f, _integrator: %.4f, scaler %.4f",
-	        (double)_last_output, (double)_integrator, (double)ctl_data.groundspeed_scaler);*/
-
+    /* Apply PI rate controller and store non-limited output */
+    _last_output = _rate_setpoint * _k_ff * ctl_data.groundspeed_scaler +
+             ctl_data.groundspeed_scaler * ctl_data.groundspeed_scaler * (_rate_error * _k_p + integrator_constrained);
 
 	return math::constrain(_last_output, -1.0f, 1.0f);
 }
@@ -122,11 +118,10 @@ float ECL_WheelController::control_attitude(const struct ECL_ControlData &ctl_da
 		return _rate_setpoint;
 	}
 
-	/* Calculate the error */
-	float yaw_error = ctl_data.yaw_setpoint - ctl_data.yaw;
-	/* shortest angle (wrap around) */
-	yaw_error = (float)fmodf((float)fmodf((yaw_error + M_PI_F), M_TWOPI_F) + M_TWOPI_F, M_TWOPI_F) - M_PI_F;
-	/*warnx("yaw_error: %.4f", (double)yaw_error);*/
+    /* Calculate the error */
+    float yaw_error = ctl_data.yaw_setpoint - ctl_data.yaw;
+    /* shortest angle (wrap around) */
+    yaw_error = (float)fmod((float)fmod((yaw_error + M_PI_F), M_TWOPI_F) + M_TWOPI_F, M_TWOPI_F) - M_PI_F;
 
 	/*  Apply P controller: rate setpoint from current error and time constant */
 	_rate_setpoint =  yaw_error / _tc;

--- a/attitude_fw/ecl_wheel_controller.h
+++ b/attitude_fw/ecl_wheel_controller.h
@@ -61,8 +61,11 @@ public:
 	ECL_WheelController();
 	~ECL_WheelController() = default;
 
-	float control_attitude(const struct ECL_ControlData &ctl_data);
-	float control_bodyrate(const struct ECL_ControlData &ctl_data);
+    float control_attitude(const struct ECL_ControlData &ctl_data);
+
+    float control_bodyrate(const struct ECL_ControlData &ctl_data);
+
+    float control_euler_rate(const struct ECL_ControlData &ctl_data) {return 0;};
 };
 
 #endif // ECL_HEADING_CONTROLLER_H

--- a/attitude_fw/ecl_wheel_controller.h
+++ b/attitude_fw/ecl_wheel_controller.h
@@ -61,11 +61,11 @@ public:
 	ECL_WheelController();
 	~ECL_WheelController() = default;
 
-    float control_attitude(const struct ECL_ControlData &ctl_data);
+	float control_attitude(const struct ECL_ControlData &ctl_data);
 
-    float control_bodyrate(const struct ECL_ControlData &ctl_data);
+	float control_bodyrate(const struct ECL_ControlData &ctl_data);
 
-    float control_euler_rate(const struct ECL_ControlData &ctl_data) {return 0;};
+	float control_euler_rate(const struct ECL_ControlData &ctl_data) {return 0;};
 };
 
 #endif // ECL_HEADING_CONTROLLER_H

--- a/attitude_fw/ecl_yaw_controller.cpp
+++ b/attitude_fw/ecl_yaw_controller.cpp
@@ -91,6 +91,7 @@ float ECL_YawController::control_attitude_impl_openloop(const struct ECL_Control
 
 	float constrained_roll;
 	bool inverted = false;
+
 	/* roll is used as feedforward term and inverted flight needs to be considered */
 	if (fabsf(ctl_data.roll) < math::radians(90.0f)) {
 		/* not inverted, but numerically still potentially close to infinity */
@@ -98,8 +99,9 @@ float ECL_YawController::control_attitude_impl_openloop(const struct ECL_Control
 
 	} else {
 		inverted = true;
-		 // inverted flight, constrain on the two extremes of -pi..+pi to avoid infinity
-		 //note: the ranges are extended by 10 deg here to avoid numeric resolution effects
+
+		// inverted flight, constrain on the two extremes of -pi..+pi to avoid infinity
+		//note: the ranges are extended by 10 deg here to avoid numeric resolution effects
 		if (ctl_data.roll > 0.0f) {
 			/* right hemisphere */
 			constrained_roll = math::constrain(ctl_data.roll, math::radians(100.0f), math::radians(180.0f));
@@ -115,10 +117,12 @@ float ECL_YawController::control_attitude_impl_openloop(const struct ECL_Control
 
 	if (!inverted) {
 		/* Calculate desired yaw rate from coordinated turn constraint / (no side forces) */
-		_rate_setpoint = tanf(constrained_roll) * cosf(ctl_data.pitch) * 9.81f / (ctl_data.airspeed < ctl_data.airspeed_min ? ctl_data.airspeed_min : ctl_data.airspeed);
+		_rate_setpoint = tanf(constrained_roll) * cosf(ctl_data.pitch) * 9.81f / (ctl_data.airspeed < ctl_data.airspeed_min ?
+				 ctl_data.airspeed_min : ctl_data.airspeed);
 	}
 
 	/* limit the rate */ //XXX: move to body angluar rates
+
 	if (_max_rate > 0.01f) {
 		_rate_setpoint = (_rate_setpoint > _max_rate) ? _max_rate : _rate_setpoint;
 		_rate_setpoint = (_rate_setpoint < -_max_rate) ? -_max_rate : _rate_setpoint;

--- a/attitude_fw/ecl_yaw_controller.cpp
+++ b/attitude_fw/ecl_yaw_controller.cpp
@@ -161,8 +161,8 @@ float ECL_YawController::control_bodyrate(const struct ECL_ControlData &ctl_data
 
 	/* Close the acceleration loop if _coordinated_method wants this: change body_rate setpoint */
 	if (_coordinated_method == COORD_METHOD_CLOSEACC) {
-		//XXX: filtering of acceleration?
-		_bodyrate_setpoint -= (ctl_data.acc_body_y / (airspeed * cosf(ctl_data.pitch)));
+		// XXX lateral acceleration needs to go into integrator with a gain
+		//_bodyrate_setpoint -= (ctl_data.acc_body_y / (airspeed * cosf(ctl_data.pitch)));
 	}
 
 	/* Calculate body angular rate error */

--- a/attitude_fw/ecl_yaw_controller.cpp
+++ b/attitude_fw/ecl_yaw_controller.cpp
@@ -110,7 +110,7 @@ float ECL_YawController::control_attitude_impl_openloop(const struct ECL_Control
 		}
 	}
 
-	constrained_roll = math::constrain(constrained_roll, -ctl_data.roll_setpoint, ctl_data.roll_setpoint);
+	constrained_roll = math::constrain(constrained_roll, -fabsf(ctl_data.roll_setpoint), fabsf(ctl_data.roll_setpoint));
 
 
 	if (!inverted) {

--- a/attitude_fw/ecl_yaw_controller.cpp
+++ b/attitude_fw/ecl_yaw_controller.cpp
@@ -81,9 +81,6 @@ float ECL_YawController::control_attitude_impl_openloop(const struct ECL_Control
 	/* Do not calculate control signal with bad inputs */
 	if (!(PX4_ISFINITE(ctl_data.roll) &&
 	      PX4_ISFINITE(ctl_data.pitch) &&
-	      PX4_ISFINITE(ctl_data.speed_body_u) &&
-	      PX4_ISFINITE(ctl_data.speed_body_v) &&
-	      PX4_ISFINITE(ctl_data.speed_body_w) &&
 	      PX4_ISFINITE(ctl_data.roll_rate_setpoint) &&
 	      PX4_ISFINITE(ctl_data.pitch_rate_setpoint))) {
 		return _rate_setpoint;

--- a/attitude_fw/ecl_yaw_controller.h
+++ b/attitude_fw/ecl_yaw_controller.h
@@ -61,6 +61,7 @@ public:
 	~ECL_YawController() = default;
 
 	float control_attitude(const struct ECL_ControlData &ctl_data);
+	float control_euler_rate(const struct ECL_ControlData &ctl_data);
 	float control_bodyrate(const struct ECL_ControlData &ctl_data);
 
 	/* Additional setters */
@@ -84,8 +85,6 @@ protected:
 	float _max_rate;
 
 	int32_t _coordinated_method;
-
-	float control_bodyrate_impl(const struct ECL_ControlData &ctl_data);
 
 	float control_attitude_impl_openloop(const struct ECL_ControlData &ctl_data);
 


### PR DESCRIPTION
This PR brings in acro support on the ecl side.

Changes:
1) Split rate control methods into
 - control_bodyrate() -> pure bodyrate control
 - control_euler_rate() -> control desired euler_rates (calls control_bodyrate())

2) Implemented coordinated turn logic using airspeed rather than body velocities.
See: https://books.google.ch/books?id=N4abCgAAQBAJ&pg=PA186&lpg=PA186&dq=coordinated+turn+constraint&source=bl&ots=5oupXeXFdB&sig=1MhdC7NUF5Uv9hUc6p-FB2JPBxg&hl=en&sa=X&ved=0ahUKEwj9sdzhxfnRAhXFvBoKHXUBCH4Q6AEIGjAA#v=onepage&q=coordinated%20turn%20constraint&f=false

3) Better naming of variables, e.g. body_x_rate instead of roll_rate when we mean body rates.

4) Commented sideslip control based on lateral acceleration measurements because implementation is not yet correct. Needs an integrator!