### PR TITLE
[WIP] Mag Validator

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,6 +45,7 @@ px4_add_module(
 		l1/ecl_l1_pos_controller.cpp
 		validation/data_validator.cpp
 		validation/data_validator_group.cpp
+		validation/mag_validator.cpp
 		EKF/estimator_interface.cpp
 		EKF/ekf.cpp
 		EKF/ekf_helper.cpp

--- a/validation/data_validator.h
+++ b/validation/data_validator.h
@@ -85,6 +85,18 @@ public:
 	uint64_t		error_count() { return _error_count; }
 
 	/**
+	 * Update complex error check with new values
+	 * @return		True if an error is detected
+	 */
+	virtual void		complex_error_update() { }
+
+	/**
+	 * Check the state of the complex error checking
+	 * @return		True if an error is detected
+	 */
+	virtual bool		complex_error_state() { return false; }
+
+	/**
 	 * Get the values of this validator
 	 * @return		the stored value
 	 */
@@ -129,7 +141,7 @@ public:
 	 * Print the validator value
 	 *
 	 */
-	void			print();
+	virtual void		print();
 
 	/**
 	 * Set the timeout value
@@ -161,7 +173,10 @@ public:
 	static constexpr uint32_t ERROR_FLAG_TIMEOUT 	   	= (0x00000001U << 2);
 	static constexpr uint32_t ERROR_FLAG_HIGH_ERRCOUNT 	= (0x00000001U << 3);
 	static constexpr uint32_t ERROR_FLAG_HIGH_ERRDENSITY 	= (0x00000001U << 4);
+	static constexpr uint32_t ERROR_FLAG_COMPLEX_ERROR	= (0x00000001U << 5);
 
+protected:
+	float _value[dimensions];		/**< last value */
 private:
 	uint32_t _error_mask;			/**< sensor error state */
 	uint32_t _timeout_interval;		/**< interval in which the datastream times out in us */
@@ -174,7 +189,6 @@ private:
 	float _lp[dimensions];			/**< low pass value */
 	float _M2[dimensions];			/**< RMS component value */
 	float _rms[dimensions];			/**< root mean square error */
-	float _value[dimensions];		/**< last value */
 	float _vibe[dimensions];		/**< vibration level, in sensor unit */
 	float _value_equal_count;		/**< equal values in a row */
 	float _value_equal_count_threshold; /**< when to consider an equal count as a problem */

--- a/validation/data_validator_group.h
+++ b/validation/data_validator_group.h
@@ -45,10 +45,16 @@
 
 class __EXPORT DataValidatorGroup {
 public:
+	enum data_type_t {
+		STANDARD,
+		MAGNETOMETER,
+		DATA_TYPE_MAX
+	};
+
 	/**
 	 * @param siblings initial number of DataValidator's. Must be > 0.
 	 */
-	DataValidatorGroup(unsigned siblings);
+	DataValidatorGroup(unsigned siblings, data_type_t type = STANDARD);
 	virtual ~DataValidatorGroup();
 
 	/**
@@ -139,6 +145,7 @@ private:
 	int _prev_best;		/**< the previous best index */
 	uint64_t _first_failover_time;	/**< timestamp where the first failover occured or zero if none occured */
 	unsigned _toggle_count;		/**< number of back and forth switches between two sensors */
+	const data_type_t _type;	/**< data type for the validator */
 	static constexpr float MIN_REGULAR_CONFIDENCE = 0.9f;
 
 	/* we don't want this class to be copied */

--- a/validation/mag_validator.cpp
+++ b/validation/mag_validator.cpp
@@ -1,0 +1,113 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2017 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * @file mag_validator.cpp
+ *
+ * A data validation class to identify anomalies in magnetometer data streams
+ *
+ * @author Stephan Brown <Stephan.Brown.07@gmail.com>
+ */
+
+#include "mag_validator.h"
+
+#include <uORB/topics/vehicle_attitude.h>
+#include <uORB/topics/vehicle_global_position.h>
+
+#include <geo_lookup/geo_mag_declination.h>
+
+#include <matrix/matrix/math.hpp>
+#include <ecl/ecl.h>
+#include <math.h>
+
+MagValidator::MagValidator(DataValidator *prev_sibling) :
+		DataValidator(prev_sibling),
+		_att_sub(-1),
+		_gpos_sub(-1),
+		_error_filter(150, 1),
+		_local_inc(0.0f),
+		_mag_inc(0.0f),
+		_error_filtered(0.0f)
+	{ }
+
+void MagValidator::complex_error_update()
+{
+	if (_att_sub < 0) {
+		ECL_INFO("Subscribing to vehicle attitude");
+		_att_sub = orb_subscribe(ORB_ID(vehicle_attitude));
+	}
+
+	if (_gpos_sub < 0) {
+		ECL_INFO("Subscribing to global position");
+		_gpos_sub = orb_subscribe(ORB_ID(vehicle_global_position));
+	}
+
+	bool updated = false;
+
+	static struct vehicle_global_position_s gpos = {};
+	int ret = orb_check(_gpos_sub, &updated);
+	if (ret == OK && updated) {
+		orb_copy(ORB_ID(vehicle_global_position), _gpos_sub, &gpos);
+		if (gpos.timestamp > 0) {
+			_local_inc = get_mag_inclination(gpos.lat, gpos.lon);
+		}
+	}
+
+	struct vehicle_attitude_s att = {};
+	ret = orb_check(_att_sub, &updated);
+	if (ret == OK && updated) {
+		orb_copy(ORB_ID(vehicle_attitude), _att_sub, &att);
+
+		matrix::Vector<float, 3> mag_vect_bf(_value);
+		matrix::Quaternionf att_q(att.q);
+		matrix::Vector<float, 3> mag_vect_wf = att_q.conjugate(mag_vect_bf);
+
+		_mag_inc = 90.0f - acosf((mag_vect_wf(2)/mag_vect_wf.length())) * (180.0f / M_PI_F);
+		if (gpos.timestamp > 0) {
+			_error_filtered = _error_filter.apply(fabsf(_local_inc - _mag_inc));
+		}
+	}
+}
+
+bool MagValidator::complex_error_state()
+{
+	return _error_filtered > 20.0f;
+}
+
+void
+MagValidator::print()
+{
+	DataValidator::print();
+	ECL_INFO("\tLcl: %.2f, Act: %.2f Err: %.2f",
+		(double)_local_inc, (double)_mag_inc, (double)(_error_filtered));
+}

--- a/validation/mag_validator.h
+++ b/validation/mag_validator.h
@@ -1,0 +1,67 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2017 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * @file mag_validator.h
+ *
+ * A data validation class to identify anomalies in magnetometer data streams
+ *
+ * @author Stephan Brown <Stephan.Brown.07@gmail.com>
+ */
+
+#pragma once
+
+#include "data_validator.h"
+
+#include <uORB/uORB.h>
+
+#include <mathlib/math/filter/LowPassFilter2p.hpp>
+
+class __EXPORT MagValidator : public DataValidator {
+public:
+	MagValidator(DataValidator *prev_sibling);
+
+	void complex_error_update();
+	bool complex_error_state();
+
+	virtual void print() override;
+
+private:
+	int _att_sub;
+	int _gpos_sub;
+	math::LowPassFilter2p _error_filter;
+	float _local_inc;
+	float _mag_inc;
+	float _error_filtered;
+};
+


### PR DESCRIPTION
This PR adds a data validator with specific checks for magnetometer data. The current error checking involves getting a GPS location, using lat and lon to get an inclination value from a lookup table, calculating the magnetometer's earth frame inclination, and generating an error with too high a difference between the two.

Additional changes:
* Adds the concept of "complex error" checking, which is a type specific error check and can be overridden by a derived class
* Moves `value[dimmensions]` to a protected member so it can be used by derived classes
* Check the state of complex errors when getting the validator's confidence
* Create validators based on a type enum, which currently only includes Magnetometer and Standard