### PR TITLE
Reduce EKF prediction delta time jitter

### DIFF
--- a/EKF/ekf.cpp
+++ b/EKF/ekf.cpp
@@ -84,7 +84,7 @@ Ekf::Ekf():
 	_time_last_arsp_fuse(0),
 	_time_last_beta_fuse(0),
 	_last_disarmed_posD(0.0f),
-	_last_dt_overrun(0.0f),
+	_imu_collection_time_adj(0.0f),
 	_airspeed_innov(0.0f),
 	_airspeed_innov_var(0.0f),
 	_beta_innov(0.0f),
@@ -506,10 +506,12 @@ bool Ekf::collect_imu(imuSample &imu)
 	// if the target time delta between filter prediction steps has been exceeded
 	// write the accumulated IMU data to the ring buffer
 	float target_dt = (float)(FILTER_UPDATE_PERIOD_MS) / 1000;
-	if (_imu_down_sampled.delta_ang_dt >= target_dt - _last_dt_overrun) {
+	if (_imu_down_sampled.delta_ang_dt >= target_dt - _imu_collection_time_adj) {
 
-		// store the amount we have over-run the target update rate by
-		_last_dt_overrun = _imu_down_sampled.delta_ang_dt - target_dt;
+		// accumulate the amount of time to advance the IMU collection time so that we meet the
+		// average EKF update rate requirement
+		_imu_collection_time_adj += 0.01f * (_imu_down_sampled.delta_ang_dt - target_dt);
+		_imu_collection_time_adj = math::constrain(_imu_collection_time_adj, -0.5f * target_dt, 0.5f * target_dt);
 
 		imu.delta_ang     = _q_down_sampled.to_axis_angle();
 		imu.delta_vel     = _imu_down_sampled.delta_vel;

--- a/EKF/ekf.h
+++ b/EKF/ekf.h
@@ -250,7 +250,7 @@ private:
 	uint64_t _time_last_beta_fuse;	// time the last fusion of synthetic sideslip measurements were performed (usec)
 	Vector2f _last_known_posNE;     // last known local NE position vector (m)
 	float _last_disarmed_posD;      // vertical position recorded at arming (m)
-	float _last_dt_overrun;		// the amount of time the last IMU collection over-ran the target set by FILTER_UPDATE_PERIOD_MS (sec)
+	float _imu_collection_time_adj;	// the amount of time the IMU collection needs to be advanced to meet the target set by FILTER_UPDATE_PERIOD_MS (sec)
 
 	Vector3f _earth_rate_NED;	// earth rotation vector (NED) in rad/s
 

--- a/EKF/estimator_interface.h
+++ b/EKF/estimator_interface.h
@@ -297,7 +297,7 @@ protected:
 	This can be adjusted to a value that is FILTER_UPDATE_PERIOD_MS longer than the maximum observation time delay.
 	*/
 	uint8_t _imu_buffer_length;
-	static const unsigned FILTER_UPDATE_PERIOD_MS = 10;	// ekf prediction period in milliseconds
+	static const unsigned FILTER_UPDATE_PERIOD_MS = 12;	// ekf prediction period in milliseconds - this should ideally be an integer multiple of the IMU time delta
 
 	unsigned _min_obs_interval_us; // minimum time interval between observations that will guarantee data is not lost (usec)
 


### PR DESCRIPTION
The EKF currently takes the IMU data from the sensor_combined topic at a nominal time delta of 4 msec (250Hz). The output predictor updates the output states every time it receives new IMU data from the sensor _combined message.

To avoid running the EKF covariance prediction at a small time step that is computationally expensive and can cause problems with rounding errors, the IMU data is accumulated and down sampled to an average time step of 10 msec.

The algorithm used to do this and maintain the correct average rate means that the number of 4msec IMU frames accumulated could vary between 1 and 4, which created timing jitter inside the EKF.  This can make tuning process noise levels harder.

The changes in this PR significantly reduce the variability in the EKF time step by:

1) Making the target EKF rate an integer multiple of the IMU rate. This slightly increases the average prediction tie step for the EKF from just over 10msec to 12msec, but the variation reduces significantly which makes filter tuning more deterministic.
2) Changing the algorithm used to adjust the collection time criteria provide a smoother correction.

This has been tested on replay with negligible effect on the innovation levels:

Replay summary before:

INFO  [ekf2_replay] GPS vel innov RMS =  0.078
INFO  [ekf2_replay] GPS pos innov RMS =  0.083
INFO  [ekf2_replay] Hgt innov RMS =  0.551
INFO  [ekf2_replay] Mag innov RMS = 0.0073

Replay summary after:

INFO  [ekf2_replay] GPS vel innov RMS =  0.076
INFO  [ekf2_replay] GPS pos innov RMS =  0.084
INFO  [ekf2_replay] Hgt innov RMS =  0.552
INFO  [ekf2_replay] Mag innov RMS = 0.0073
