### PR TITLE
EKF: don't accept GPS data without a 3D lock

### DIFF
--- a/EKF/estimator_interface.cpp
+++ b/EKF/estimator_interface.cpp
@@ -178,7 +178,7 @@ void EstimatorInterface::setGpsData(uint64_t time_usec, struct gps_message *gps)
 
 	// limit data rate to prevent data being lost
 	bool need_gps = (_params.fusion_mode & MASK_USE_GPS) || (_params.vdist_sensor_type == VDIST_SENSOR_GPS);
-	if (((time_usec - _time_last_gps) > _min_obs_interval_us) && need_gps) {
+	if (((time_usec - _time_last_gps) > _min_obs_interval_us) && need_gps && gps->fix_type > 2) {
 		gpsSample gps_sample_new = {};
 		gps_sample_new.time_us = gps->time_usec - _params.gps_delay_ms * 1000;
 


### PR DESCRIPTION
This fixes a bug that allows the EKF to try using GPS data when there is no longer a 3D fix. This prevents the timeout reversion back to non-GPS operation that is supposed to occur after 10 seconds of no GPS lock