### PR TITLE
EKF: protect accel bias learning from high manoeuvre and vibration levels

### DIFF
--- a/EKF/common.h
+++ b/EKF/common.h
@@ -412,6 +412,7 @@ union fault_status_u {
 		bool bad_pos_N: 1;	// 12 - true if fusion of the North position has encountered a numerical error
 		bool bad_pos_E: 1;	// 13 - true if fusion of the East position has encountered a numerical error
 		bool bad_pos_D: 1;	// 14 - true if fusion of the Down position has encountered a numerical error
+		bool bad_acc_bias: 1;	// 15 - true if bad delta velocity bias estimates have been detected
 	} flags;
 	uint16_t value;
 

--- a/EKF/common.h
+++ b/EKF/common.h
@@ -269,8 +269,11 @@ struct parameters {
 	float vel_Tau;	// velocity state correction time constant (1/sec)
 	float pos_Tau;	// postion state correction time constant (1/sec)
 
-	// state limits
-	float acc_bias_lim;	// maximum accel bias magnitude (m/s/s)
+	// accel bias learning control
+	float acc_bias_lim;		// maximum accel bias magnitude (m/s/s)
+	float acc_bias_learn_acc_lim;	// learning is disabled if the magnitude of the IMU acceleration vector is greeater than this (m/sec**2)
+	float acc_bias_learn_gyr_lim;	// learning is disabled if the magnitude of the IMU angular rate vector is greeater than this (rad/sec)
+	float acc_bias_learn_tc;	// time constant used to control the decaying envelope filters applied to the accel and gyro magnitudes (sec)
 
 	unsigned no_gps_timeout_max;	// maximum time we allow dead reckoning while both gps position and velocity measurements are being
 									// rejected
@@ -376,8 +379,11 @@ struct parameters {
 		vel_Tau = 0.25f;
 		pos_Tau = 0.25f;
 
-		// state limiting
+		// accel bias state limiting
 		acc_bias_lim = 0.4f;
+		acc_bias_learn_acc_lim = 25.0f;
+		acc_bias_learn_gyr_lim = 3.0f;
+		acc_bias_learn_tc = 0.5f;
 
 		no_gps_timeout_max = 7e6;	// maximum seven seconds of dead reckoning time for gps
 

--- a/EKF/common.h
+++ b/EKF/common.h
@@ -269,6 +269,9 @@ struct parameters {
 	float vel_Tau;	// velocity state correction time constant (1/sec)
 	float pos_Tau;	// postion state correction time constant (1/sec)
 
+	// state limits
+	float acc_bias_lim;	// maximum accel bias magnitude (m/s/s)
+
 	unsigned no_gps_timeout_max;	// maximum time we allow dead reckoning while both gps position and velocity measurements are being
 									// rejected
 
@@ -372,6 +375,9 @@ struct parameters {
 		// output complementary filter tuning time constants
 		vel_Tau = 0.25f;
 		pos_Tau = 0.25f;
+
+		// state limiting
+		acc_bias_lim = 0.4f;
 
 		no_gps_timeout_max = 7e6;	// maximum seven seconds of dead reckoning time for gps
 

--- a/EKF/covariance.cpp
+++ b/EKF/covariance.cpp
@@ -715,10 +715,12 @@ void Ekf::fixCovarianceErrors()
 				     && down_dvel_bias * _vel_pos_innov[2] < 0.0f
 				     && down_dvel_bias * _vel_pos_innov[5] < 0.0f);
 
-		// record the pass and force symmetry on the covariance matrix
+		// record the pass/fail
 		if (!bad_acc_bias) {
+			_fault_status.flags.bad_acc_bias = true;
 			_time_acc_bias_check = _time_last_imu;
-			makeSymmetrical(P,13,15);
+		} else {
+			_fault_status.flags.bad_acc_bias = true;
 		}
 
 		// if we have failed for 7 seconds continuously, reset the accel bias covariance
@@ -732,7 +734,11 @@ void Ekf::fixCovarianceErrors()
 			P[14][14] = varY;
 			P[15][15] = varZ;
 			_time_acc_bias_check = _time_last_imu;
+			_fault_status.flags.bad_acc_bias = false;
 			ECL_WARN("EKF invalid accel bias - resetting covariance");
+		} else {
+			// ensure the covariance values are symmetrical
+			makeSymmetrical(P,13,15);
 		}
 
 	}

--- a/EKF/covariance.cpp
+++ b/EKF/covariance.cpp
@@ -40,6 +40,7 @@
  *
  */
 
+#include "../ecl.h"
 #include "ekf.h"
 #include <math.h>
 #include "mathlib.h"
@@ -730,6 +731,8 @@ void Ekf::fixCovarianceErrors()
 			P[13][13] = varX;
 			P[14][14] = varY;
 			P[15][15] = varZ;
+			_time_acc_bias_check = _time_last_imu;
+			ECL_WARN("EKF invalid accel bias - resetting covariance");
 		}
 
 	}

--- a/EKF/ekf.cpp
+++ b/EKF/ekf.cpp
@@ -85,6 +85,7 @@ Ekf::Ekf():
 	_time_last_beta_fuse(0),
 	_last_disarmed_posD(0.0f),
 	_last_dt_overrun(0.0f),
+	_time_acc_bias_check(0.0f),
 	_airspeed_innov(0.0f),
 	_airspeed_innov_var(0.0f),
 	_beta_innov(0.0f),

--- a/EKF/ekf.cpp
+++ b/EKF/ekf.cpp
@@ -196,6 +196,9 @@ bool Ekf::init(uint64_t timestamp)
 	_fault_status.value = 0;
 	_innov_check_fail_status.value = 0;
 
+	_accel_mag_filt = 0.0f;
+	_ang_rate_mag_filt = 0.0f;
+
 	return ret;
 }
 

--- a/EKF/ekf.h
+++ b/EKF/ekf.h
@@ -252,6 +252,8 @@ private:
 	float _last_disarmed_posD;      // vertical position recorded at arming (m)
 	float _last_dt_overrun;		// the amount of time the last IMU collection over-ran the target set by FILTER_UPDATE_PERIOD_MS (sec)
 
+	uint64_t _time_acc_bias_check;	// last time the  accel bias check passed (usec)
+
 	Vector3f _earth_rate_NED;	// earth rotation vector (NED) in rad/s
 
 	matrix::Dcm<float> _R_to_earth;	// transformation matrix from body frame to earth frame from last EKF predition

--- a/EKF/ekf.h
+++ b/EKF/ekf.h
@@ -250,7 +250,7 @@ private:
 	uint64_t _time_last_beta_fuse;	// time the last fusion of synthetic sideslip measurements were performed (usec)
 	Vector2f _last_known_posNE;     // last known local NE position vector (m)
 	float _last_disarmed_posD;      // vertical position recorded at arming (m)
-	float _last_dt_overrun;		// the amount of time the last IMU collection over-ran the target set by FILTER_UPDATE_PERIOD_MS (sec)
+	float _imu_collection_time_adj;	// the amount of time the IMU collection needs to be advanced to meet the target set by FILTER_UPDATE_PERIOD_MS (sec)
 
 	uint64_t _time_acc_bias_check;	// last time the  accel bias check passed (usec)
 

--- a/EKF/ekf.h
+++ b/EKF/ekf.h
@@ -321,6 +321,11 @@ private:
 
 	gps_check_fail_status_u _gps_check_fail_status{};
 
+	// variables used to inhibit accel bias learning
+	bool _accel_bias_inhibit;	// true when the accel bias learning is being inhibited
+	float _accel_mag_filt;		// acceleration magnitude after application of a decaying envelope filter (m/sec**2)
+	float _ang_rate_mag_filt;	// angular rate magnitude after application of a decaying envelope filter (rad/sec)
+
 	// Terrain height state estimation
 	float _terrain_vpos;		// estimated vertical position of the terrain underneath the vehicle in local NED frame (m)
 	float _terrain_var;		// variance of terrain position estimate (m^2)

--- a/EKF/ekf_helper.cpp
+++ b/EKF/ekf_helper.cpp
@@ -535,11 +535,11 @@ void Ekf::constrainStates()
 	}
 
 	for (int i = 0; i < 3; i++) {
-		_state.gyro_bias(i) = math::constrain(_state.gyro_bias(i), -0.349066f * _dt_imu_avg, 0.349066f * _dt_imu_avg);
+		_state.gyro_bias(i) = math::constrain(_state.gyro_bias(i), -0.349066f * _dt_ekf_avg, 0.349066f * _dt_ekf_avg);
 	}
 
 	for (int i = 0; i < 3; i++) {
-		_state.accel_bias(i) = math::constrain(_state.accel_bias(i), -1.0f * _dt_imu_avg, 1.0f * _dt_imu_avg);
+		_state.accel_bias(i) = math::constrain(_state.accel_bias(i), -_params.acc_bias_lim * _dt_ekf_avg, _params.acc_bias_lim * _dt_ekf_avg);
 	}
 
 	for (int i = 0; i < 3; i++) {

--- a/EKF/estimator_interface.h
+++ b/EKF/estimator_interface.h
@@ -297,7 +297,7 @@ protected:
 	This can be adjusted to a value that is FILTER_UPDATE_PERIOD_MS longer than the maximum observation time delay.
 	*/
 	uint8_t _imu_buffer_length;
-	static const unsigned FILTER_UPDATE_PERIOD_MS = 10;	// ekf prediction period in milliseconds
+	static const unsigned FILTER_UPDATE_PERIOD_MS = 12;	// ekf prediction period in milliseconds - this should ideally be an integer multiple of the IMU time delta
 
 	unsigned _min_obs_interval_us; // minimum time interval between observations that will guarantee data is not lost (usec)
 


### PR DESCRIPTION
**Fixes**

Flight at high angular rate and vibration levels in a multi-rotor was able to cause the IMU delta velocity bias values to be learned incorrectly. This created an offset in the vertical velocity that prevented the vehicle from completing a landing.

**Description of changes**

A bad delta velocity bias evidenced by baro and GPS vertical velocity innovations having the same sign and a bias value over 90% of the maximum for a continuous period will cause the covariance matrix entries for accel bias values to be reset.

The downsampling from the 4msec IMU to 10msec EKF covariance prediction time step has been changed so that the EKF now uses 12 msec as the target time and the downsampling algorithm has been modified so that the jitter in EKF prediction time step is greatly reduced.  This has made tuning of process noise values for slowly time varying states more deterministic and slightly reduced CPU load.

The IMU gyro and accel vector magnitudes are monitored and if thresholds set by parameters are exceeded, accel bias learning is disabled. A decaying envelope filter is applied to the magnitudes to prevent rapid toggling due to noise and provide some persistence to the learning inhibit.

**Testing**

These changes have been tested on two replay logs. Here are example before and after results from one of the logs:

Vertical Innovations Before:
<img width="1203" alt="screen shot 2017-03-10 at 9 50 42 am" src="https://cloud.githubusercontent.com/assets/3596952/23774278/1c868ee6-0577-11e7-9b98-42b743b75860.png">

Delta Velocity Bias Estimates Before:
<img width="1170" alt="screen shot 2017-03-10 at 9 50 59 am" src="https://cloud.githubusercontent.com/assets/3596952/23777491/45b5cf22-0589-11e7-9c52-a76ffe1b6fa6.png">

Vertical Innovations After:
<img width="1160" alt="screen shot 2017-03-10 at 9 46 55 am" src="https://cloud.githubusercontent.com/assets/3596952/23774167/89826f0c-0576-11e7-9eb9-5f33bcf1a5e2.png">

Delta Velocity Bias Estimates After:
<img width="1186" alt="screen shot 2017-03-10 at 9 45 30 am" src="https://cloud.githubusercontent.com/assets/3596952/23774140/71f047ce-0576-11e7-9260-634a6f025c0c.png">