### PR TITLE
EKF: improve recovery from bad IMU accel data

### DIFF
--- a/EKF/common.h
+++ b/EKF/common.h
@@ -506,6 +506,7 @@ union ekf_solution_status {
 	uint16_t pred_pos_horiz_rel : 1; // 8 - True if the EKF has sufficient data to enter a mode that will provide a (relative) position estimate
 	uint16_t pred_pos_horiz_abs : 1; // 9 - True if the EKF has sufficient data to enter a mode that will provide a (absolute) position estimate
 	uint16_t gps_glitch         : 1; // 10 - True if the EKF has detected a GPS glitch
+	uint16_t accel_error        : 1; // 11 - True if the EKF has detected bad accelerometer data
     } flags;
     uint16_t value;
 };

--- a/EKF/common.h
+++ b/EKF/common.h
@@ -169,6 +169,11 @@ struct extVisionSample {
 #define RNG_MAX_INTERVAL	2e5
 #define EV_MAX_INTERVAL		2e5
 
+// bad accelerometer detection and mitigation
+#define BADACC_PROBATION	10E6	// Number of usec that accel data declared bad must continuously pass checks to be declared good
+#define BADACC_HGT_RESET	1E6	// Number of usec that accel data must continuously fail checks to trigger a height reset
+#define BADACC_BIAS_PNOISE_MULT 2.0f	// The delta velocity process noise is multiplied by this value when accel data is declared bad
+
 struct parameters {
 	// measurement source control
 	int fusion_mode;		// bitmasked integer that selects which of the GPS and optical flow aiding sources will be used

--- a/EKF/common.h
+++ b/EKF/common.h
@@ -172,7 +172,7 @@ struct extVisionSample {
 // bad accelerometer detection and mitigation
 #define BADACC_PROBATION	10E6	// Number of usec that accel data declared bad must continuously pass checks to be declared good
 #define BADACC_HGT_RESET	1E6	// Number of usec that accel data must continuously fail checks to trigger a height reset
-#define BADACC_BIAS_PNOISE_MULT 2.0f	// The delta velocity process noise is multiplied by this value when accel data is declared bad
+#define BADACC_BIAS_PNOISE	4.9f	// The delta velocity process noise is set to this when accel data is declared bad (m/s**2)
 
 struct parameters {
 	// measurement source control

--- a/EKF/covariance.cpp
+++ b/EKF/covariance.cpp
@@ -235,8 +235,9 @@ void Ekf::predictCovariance()
 	daxVar = dayVar = dazVar = sq(dt * gyro_noise);
 	float accel_noise = math::constrain(_params.accel_noise, 0.0f, 1.0f);
 	if (_bad_vert_accel_detected) {
-		// increase accelerometer process noise if bad accel data is detected
-		accel_noise *= BADACC_BIAS_PNOISE_MULT;
+		// Increase accelerometer process noise if bad accel data is detected. Measurement errors due to
+		// vibration induced clipping commonly reach an equivalent 0.5g offset.
+		accel_noise = BADACC_BIAS_PNOISE;
 	}
 	dvxVar = dvyVar = dvzVar = sq(dt * accel_noise);
 

--- a/EKF/ekf.cpp
+++ b/EKF/ekf.cpp
@@ -123,7 +123,9 @@ Ekf::Ekf():
 	_gps_hgt_faulty(false),
 	_rng_hgt_faulty(false),
 	_primary_hgt_source(VDIST_SENSOR_BARO),
-	_time_bad_vert_accel(0)
+	_time_bad_vert_accel(0),
+	_time_good_vert_accel(0),
+	_bad_vert_accel_detected(false)
 {
 	_state = {};
 	_last_known_posNE.setZero();

--- a/EKF/ekf.h
+++ b/EKF/ekf.h
@@ -349,6 +349,8 @@ private:
 
 	// imu fault status
 	uint64_t _time_bad_vert_accel;	// last time a bad vertical accel was detected (usec)
+	uint64_t _time_good_vert_accel;	// last time a good vertical accel was detected (usec)
+	bool _bad_vert_accel_detected;	// true when bad vertical accelerometer data has been detected
 
 	// update the real time complementary filter states. This includes the prediction
 	// and the correction step

--- a/EKF/ekf_helper.cpp
+++ b/EKF/ekf_helper.cpp
@@ -862,6 +862,7 @@ void Ekf::get_ekf_soln_status(uint16_t *status)
 	bool gps_pos_innov_bad = (_vel_pos_test_ratio[3] > 1.0f) || (_vel_pos_test_ratio[4] > 1.0f);
 	bool mag_innov_good = (_mag_test_ratio[0] < 1.0f) && (_mag_test_ratio[1] < 1.0f) && (_mag_test_ratio[2] < 1.0f) && (_yaw_test_ratio < 1.0f);
 	soln_status.flags.gps_glitch = (gps_vel_innov_bad || gps_pos_innov_bad) && mag_innov_good;
+	soln_status.flags.accel_error = _bad_vert_accel_detected;
 	*status = soln_status.value;
 }
 


### PR DESCRIPTION
This PR uses vertical velocity and position innovation consistency check failure to detect bad accelerometer data caused by clipping or aliasing which can cause large vertical acceleration errors and loss of height estimation. When bad accel data is detected it

1) Reports bad accel status using bit position 11 in the estimator solution status message.
2) Forces fusion of vertical velocity and height data by bypassing innovation consistency checks to reduce the vertical velocity and position error.
3) Inhibits accelerometer bias learning to prevent accel bias estimates being corrupted by forced fusion.
4) Increases accelerometer process noise to reduce effect of bad accel data on state estimates.

**Testing**

Testing on replay logs from vehicle with significant vibration induced clipping has been completed.