### PR TITLE
EKF: fix bugs preventing preflight checks passing

### DIFF
--- a/EKF/covariance.cpp
+++ b/EKF/covariance.cpp
@@ -737,7 +737,7 @@ void Ekf::fixCovarianceErrors()
 
 		// record the pass/fail
 		if (!bad_acc_bias) {
-			_fault_status.flags.bad_acc_bias = true;
+			_fault_status.flags.bad_acc_bias = false;
 			_time_acc_bias_check = _time_last_imu;
 		} else {
 			_fault_status.flags.bad_acc_bias = true;

--- a/EKF/estimator_interface.cpp
+++ b/EKF/estimator_interface.cpp
@@ -435,7 +435,7 @@ bool EstimatorInterface::initialise_interface(uint64_t timestamp)
 	_time_last_range = 0;
 	_time_last_airspeed = 0;
 	_time_last_optflow = 0;
-	memset(&_fault_status.flags, 0, sizeof(_fault_status.flags));
+	_fault_status.value = 0;
 	_time_last_ext_vision = 0;
 	return true;
 }


### PR DESCRIPTION
This fixes a bug where movement of the vehicle during alignment can cause the bad accel bias condition to latch to true which will cause the solution status to report incorrectly.