### PR TITLE
EKF: Add ability to use stored mag bias estimates

### DIFF
--- a/EKF/common.h
+++ b/EKF/common.h
@@ -280,6 +280,11 @@ struct parameters {
 	unsigned no_aid_timeout_max;	// maximum lapsed time from last fusion of measurements that constrain drift before
 					// the EKF will report that it is dead-reckoning (usec)
 
+	// magnetometer XYZ axis leanred bias values to be subtracted from the sensor data (milli-Gauss)
+	float _mag_bias_x;
+	float _mag_bias_y;
+	float _mag_bias_z;
+
 	// Initialize parameter values.  Initialization must be accomplished in the constructor to allow C99 compiler compatibility.
 	parameters()
 	{
@@ -390,6 +395,11 @@ struct parameters {
 		// dead reckoning timers
 		no_gps_timeout_max = 7e6;
 		no_aid_timeout_max = 1e6;
+
+		// magnetometer XYZ axis learned bias values to be subtracted from the sensor data (milli-Gauss)
+		_mag_bias_x = 0.0f;
+		_mag_bias_y = 0.0f;
+		_mag_bias_z = 0.0f;
 
 	}
 };

--- a/EKF/common.h
+++ b/EKF/common.h
@@ -281,9 +281,9 @@ struct parameters {
 					// the EKF will report that it is dead-reckoning (usec)
 
 	// magnetometer XYZ axis leanred bias values to be subtracted from the sensor data (milli-Gauss)
-	float _mag_bias_x;
-	float _mag_bias_y;
-	float _mag_bias_z;
+	float mag_bias_x;
+	float mag_bias_y;
+	float mag_bias_z;
 
 	// Initialize parameter values.  Initialization must be accomplished in the constructor to allow C99 compiler compatibility.
 	parameters()
@@ -397,9 +397,9 @@ struct parameters {
 		no_aid_timeout_max = 1e6;
 
 		// magnetometer XYZ axis learned bias values to be subtracted from the sensor data (milli-Gauss)
-		_mag_bias_x = 0.0f;
-		_mag_bias_y = 0.0f;
-		_mag_bias_z = 0.0f;
+		mag_bias_x = 0.0f;
+		mag_bias_y = 0.0f;
+		mag_bias_z = 0.0f;
 
 	}
 };

--- a/EKF/estimator_interface.cpp
+++ b/EKF/estimator_interface.cpp
@@ -168,9 +168,9 @@ void EstimatorInterface::setMagData(uint64_t time_usec, float (&data)[3])
 		memcpy(&mag_sample_new.mag._data[0], data, sizeof(mag_sample_new.mag._data));
 
 		// correct for EKF learned and stored bias offsets
-		mag_sample_new.mag(0) -= _params._mag_bias_x;
-		mag_sample_new.mag(1) -= _params._mag_bias_y;
-		mag_sample_new.mag(2) -= _params._mag_bias_z;
+		mag_sample_new.mag(0) -= _params.mag_bias_x;
+		mag_sample_new.mag(1) -= _params.mag_bias_y;
+		mag_sample_new.mag(2) -= _params.mag_bias_z;
 
 		_mag_buffer.push(mag_sample_new);
 	}

--- a/EKF/estimator_interface.cpp
+++ b/EKF/estimator_interface.cpp
@@ -167,6 +167,11 @@ void EstimatorInterface::setMagData(uint64_t time_usec, float (&data)[3])
 
 		memcpy(&mag_sample_new.mag._data[0], data, sizeof(mag_sample_new.mag._data));
 
+		// correct for EKF learned and stored bias offsets
+		mag_sample_new.mag(0) -= _params._mag_bias_x;
+		mag_sample_new.mag(1) -= _params._mag_bias_y;
+		mag_sample_new.mag(2) -= _params._mag_bias_z;
+
 		_mag_buffer.push(mag_sample_new);
 	}
 }


### PR DESCRIPTION
This PR adds parameters that will enable learned mag bias estimates to be stored for use at the next startup. The logic to check and save the parameter values based on filter status reporting will be implemented externally to the ecl library.