### PR TITLE
EKF: Do not move EKF origin when performing GPS checks

### DIFF
--- a/EKF/gps_checks.cpp
+++ b/EKF/gps_checks.cpp
@@ -167,10 +167,6 @@ bool Ekf::gps_is_good(struct gps_message *gps)
 		_gps_check_fail_status.flags.hdrift = false;
 	}
 
-	// Save current position as the reference for next time
-	map_projection_init_timestamped(&_pos_ref, lat, lon, _time_last_imu);
-	_last_gps_origin_time_us = _time_last_imu;
-
 	// Calculate the vertical drift velocity and limit to 10x the threshold
 	vel_limit = 10.0f * _params.req_vdrift;
 	float velD = fminf(fmaxf((_gps_alt_ref - 1e-3f * (float)gps->alt) / dt, -vel_limit), vel_limit);


### PR DESCRIPTION
This fixes a bug that was introduced when GPS checks were enabled to run whenever the vehicle was on the ground by this PR https://github.com/PX4/ecl/pull/255 . This resulted in the EKF origin being continually being updated to match the GPS position when on ground.

Doing this can cause large jumps in GPS position and generate innovation check errors after landing and also reduces the usefulness of pre-flight GPs position innovation consistency checks.

Moving the origin is unnecessary because the origin is already performed here https://github.com/PX4/ecl/blob/master/EKF/gps_checks.cpp#L68  after all enabled GPS checks have passed.