### PR TITLE
EKF: Don't use EKF origin in GPS drift check calculation

### DIFF
--- a/EKF/estimator_interface.cpp
+++ b/EKF/estimator_interface.cpp
@@ -67,6 +67,8 @@ EstimatorInterface::EstimatorInterface():
 	_gps_origin_eph(0.0f),
 	_gps_origin_epv(0.0f),
 	_pos_ref{},
+	_gps_pos_prev{},
+	_gps_alt_prev(0.0f),
 	_yaw_test_ratio(0.0f),
 	_mag_test_ratio{},
 	_vel_pos_test_ratio{},

--- a/EKF/estimator_interface.h
+++ b/EKF/estimator_interface.h
@@ -328,7 +328,9 @@ protected:
 	bool _gps_speed_valid;
 	float _gps_origin_eph; // horizontal position uncertainty of the GPS origin
 	float _gps_origin_epv; // vertical position uncertainty of the GPS origin
-	struct map_projection_reference_s _pos_ref;    // Contains WGS-84 position latitude and longitude (radians)
+	struct map_projection_reference_s _pos_ref;    // Contains WGS-84 position latitude and longitude (radians) of the EKF origin
+	struct map_projection_reference_s _gps_pos_prev;    // Contains WGS-84 position latitude and longitude (radians) of the previous GPS message
+	float _gps_alt_prev;	// height from the previous GPS message (m)
 
 	// innovation consistency check monitoring ratios
 	float _yaw_test_ratio;          // yaw innovation consistency check ratio


### PR DESCRIPTION
The GPS drift calculations need to be able to run independently of the EKF origin. This PR uses separate variables for the GPS drift calculation so that the EKF origin is not modified after GPS checks have passed and the vehicle is on-ground.

It also fixes the bug that was effectively bypassing the horizontal GPS drift check.