### PR TITLE
EKF: add option to output velocity as time derivative of position

### DIFF
--- a/EKF/RingBuffer.h
+++ b/EKF/RingBuffer.h
@@ -113,6 +113,11 @@ public:
 		return _buffer[_tail];
 	}
 
+	unsigned get_oldest_index()
+	{
+		return _tail;
+	}
+
 	inline data_type get_newest()
 	{
 		return _buffer[_head];

--- a/EKF/common.h
+++ b/EKF/common.h
@@ -79,9 +79,16 @@ struct ext_vision_message {
 
 struct outputSample {
 	Quaternion  quat_nominal;	// nominal quaternion describing vehicle attitude
-	Vector3f    vel;	// NED velocity estimate in earth frame in m/s
-	Vector3f    pos;	// NED position estimate in earth frame in m/s
-	uint64_t 	time_us;	// timestamp in microseconds
+	Vector3f    vel;		// NED velocity estimate in earth frame in m/s
+	Vector3f    pos;		// NED position estimate in earth frame in m/s
+	uint64_t    time_us;		// timestamp in microseconds
+};
+
+struct outputVert {
+	float	    vel_d;		// D velocity calculated using alternative algorithm
+	float	    vel_d_integ;	// Integral of vel_d
+	float	    dt;			// delta time in seconds
+	uint64_t    time_us;		// timestamp in microseconds
 };
 
 struct imuSample {

--- a/EKF/estimator_interface.cpp
+++ b/EKF/estimator_interface.cpp
@@ -379,7 +379,8 @@ bool EstimatorInterface::initialise_interface(uint64_t timestamp)
 	      _flow_buffer.allocate(_obs_buffer_length) &&
 	      _ext_vision_buffer.allocate(_obs_buffer_length) &&
 	      _drag_buffer.allocate(_obs_buffer_length) &&
-	      _output_buffer.allocate(_imu_buffer_length))) {
+	      _output_buffer.allocate(_imu_buffer_length) &&
+	      _output_vert_buffer.allocate(_imu_buffer_length))) {
 		ECL_ERR("EKF buffer allocation failed!");
 		unallocate_buffers();
 		return false;
@@ -448,6 +449,7 @@ void EstimatorInterface::unallocate_buffers()
 	_flow_buffer.unallocate();
 	_ext_vision_buffer.unallocate();
 	_output_buffer.unallocate();
+	_output_vert_buffer.unallocate();
 
 }
 


### PR DESCRIPTION
This PR adds a parameter selectable option to output a more kinematically position and velocity. This will have degraded tracking relative to the EKF states, but the velocity will be closer to the first derivative of the position and reduce the effect of inertial prediction errors on control loops that are operating in a pure velocity feedback mode.

Results show that this significantly reduces steady state velocity estimation errors due to inertial sensor bias, but at the expense of an increased effect of baro disturbances on vertical velocity error and therefore height tracking.

The option is disabled by default.

These changes have been tested on replay and a single flight test.

**Vertical Velocity Consistency**
The following plots show the local vertical velocity (black), time derivative of the local vertical position (green) and GPS vertical velocity (red) generated using  _params.link_vel_pos = 0 (the default) and  _params.link_vel_pos = 1 which activates the option introduced by this PR. It can be seen that with the option enabled, the local output vertical velocity is closer to the derivative of the local vertical position, but does not match the GPs velocity as well.

_params.link_vel_pos = 0
![vert vel - default](https://cloud.githubusercontent.com/assets/3596952/25319915/8fedac20-28e5-11e7-8bc6-36e0db866016.png)

_params.link_vel_pos = 1
![vert vel - option](https://cloud.githubusercontent.com/assets/3596952/25319917/9577cac2-28e5-11e7-9e1c-a488936c8bab.png)

** EKF state tracking
The following plots show the norm of the output predictor velocity (cyan) and position (magenta) tracking errors relative the EKF at the EKF fusion time horizon. It can be seen that the option degrades the tracking.

_params.link_vel_pos = 0
![tracking - default](https://cloud.githubusercontent.com/assets/3596952/25319951/f0a74300-28e5-11e7-9a36-8e47eb278627.png)

_params.link_vel_pos = 1
![tracking - option](https://cloud.githubusercontent.com/assets/3596952/25319957/f77bc7d2-28e5-11e7-8ff4-b19cfba6862e.png)

**UPDATE**

After discussion with the position control developers, the PR has been modified so that the revised algorithm is performed in parallel to the legacy algorithm, but only for the vertical states and the vertical position derivative is made available via the ecl EKF interface. This removes the need for a parameter and enables the controllers to decide which vertical velocity measure estimate is the best to use. The impact on resources of estimating the extra two states in the output predictor was negligible with a 1% rise in CPU utilisation from 54% to 55%. See plots here https://github.com/PX4/ecl/pull/265#issuecomment-297364600