### PR TITLE
EKF: Increase sensitivity and add tuning of bad accel checks

### DIFF
--- a/EKF/common.h
+++ b/EKF/common.h
@@ -177,7 +177,6 @@ struct dragSample {
 
 // bad accelerometer detection and mitigation
 #define BADACC_PROBATION	10E6	// Number of usec that accel data declared bad must continuously pass checks to be declared good
-#define BADACC_HGT_RESET	1E6	// Number of usec that accel data must continuously fail checks to trigger a height reset
 #define BADACC_BIAS_PNOISE	4.9f	// The delta velocity process noise is set to this when accel data is declared bad (m/s**2)
 
 struct parameters {
@@ -295,6 +294,10 @@ struct parameters {
 	float drag_noise{2.5f};			// observation noise for drag specific force measurements (m/sec**2)
 	float bcoef_x{25.0f};			// ballistic coefficient along the X-axis (kg/m**2)
 	float bcoef_y{25.0f};			// ballistic coefficient along the Y-axis (kg/m**2)
+
+	// control of accel error detection and mitigation (IMU clipping)
+	float vert_innov_test_lim{4.5f};	// Number of standard deviations allowed before the combined vertical velocity and position test is declared as failed
+	int bad_acc_reset_delay_us{500000};	// Continuous time that the vertical position and velocity innovation test must fail before the states are reset (usec)
 
 };
 


### PR DESCRIPTION
These changes implement an improved method of detecting the loss of vertical estimation accuracy due to vibration induced accelerometer clipping. The statistical confidence check is not a combined check using the product of the vertical velocity and position innovations and tuneable via a single confidence parameter. The amount of failure time required to trigger a state reset is also adjustable.

This has resulted in reductions in the time required to recover from clipping. The following plots show the vertical velocity and position innovation results from replay testing of a flight log with a clipping event that starts at 622.5 seconds. 

**Before**
![before](https://cloud.githubusercontent.com/assets/3596952/25370972/8af4c28e-29d1-11e7-86b4-90d0850eaa95.png)

**After**
![after](https://cloud.githubusercontent.com/assets/3596952/25370974/8f8fce38-29d1-11e7-9bb4-d3f25c58eb1a.png)
