### PR TITLE
EKF: Add parameter control of individual IMU axis delta velocity bias…

### DIFF
--- a/EKF/common.h
+++ b/EKF/common.h
@@ -246,6 +246,7 @@ struct parameters {
 	float rng_gnd_clearance{0.1f};		// minimum valid value for range when on ground (m)
 	float rng_sens_pitch{0.0f};		// Pitch offset of the range sensor (rad). Sensor points out along Z axis when offset is zero. Positive rotation is RH about Y axis.
 	float range_noise_scaler{0.0f};		// scaling from range measurement to noise (m/m)
+	float vehicle_variance_scaler{0.0f};	// gain applied to vehicle height variance used in calculation of height above ground observation variance
 
 	// vision position fusion
 	float ev_innov_gate{5.0f};		// vision estimator fusion innovation consistency gate size (STD)
@@ -284,6 +285,7 @@ struct parameters {
 	float acc_bias_learn_acc_lim{25.0f};	// learning is disabled if the magnitude of the IMU acceleration vector is greeater than this (m/sec**2)
 	float acc_bias_learn_gyr_lim{3.0f};	// learning is disabled if the magnitude of the IMU angular rate vector is greeater than this (rad/sec)
 	float acc_bias_learn_tc{0.5f};		// time constant used to control the decaying envelope filters applied to the accel and gyro magnitudes (sec)
+	int acc_bias_learn_mask{7};		// bitmask used to control which accelerometer axes learn an in-flight bias
 
 	unsigned no_gps_timeout_max{7000000};	// maximum time we allow dead reckoning while both gps position and velocity measurements are being
 						// rejected before attempting to reset the states to the GPS measurement (usec)

--- a/EKF/ekf_helper.cpp
+++ b/EKF/ekf_helper.cpp
@@ -549,8 +549,14 @@ void Ekf::constrainStates()
 		_state.gyro_bias(i) = math::constrain(_state.gyro_bias(i), -0.349066f * _dt_ekf_avg, 0.349066f * _dt_ekf_avg);
 	}
 
-	for (int i = 0; i < 3; i++) {
-		_state.accel_bias(i) = math::constrain(_state.accel_bias(i), -_params.acc_bias_lim * _dt_ekf_avg, _params.acc_bias_lim * _dt_ekf_avg);
+	float del_vel_bias_lim = _params.acc_bias_lim * _dt_ekf_avg;
+	for (uint8_t i=0; i < 3; i++) {
+		uint8_t state_index = 13 + i;
+		if (_params.acc_bias_learn_mask & (1<<i)) {
+			_state.accel_bias(state_index) = math::constrain(_state.accel_bias(state_index), -del_vel_bias_lim, del_vel_bias_lim);
+		} else {
+			_state.accel_bias(state_index) = 0.0f;
+		}
 	}
 
 	for (int i = 0; i < 3; i++) {


### PR DESCRIPTION
This enables IMU delta velocity bias learning to be enabled for individual axes for applications where the biases may be unobservable for extended periods of time. An example may be a multi-rotor or ground vehicle operating in a very still position hold for extended periods of time. An algorithm to dynamically set the components will be added later.

This is achieved by forcing the disabled states and their corresponding variances to zero at all times.

Other minor amendments include:

Minor cleanup of the covariance prediction comments.
Removal of unnecessary variable copy operations.
Use of more efficient memset operation to zero covariance matrix during initialisation.

Here is a replay from a flight with extended periods of stable hover in still air conditions with occasional maneouvres:

Before - note large variation in Y delta velocity bias:

![screen shot 2017-05-11 at 12 41 43 pm](https://cloud.githubusercontent.com/assets/3596952/25930065/5b395988-3647-11e7-80a8-fac662b6ae92.png)

Here are the corresponding GPS velocity innovations. A yaw rotation was performed  just before landing which combined with the Y axis bias error to cause a significant innovation transient:

![screen shot 2017-05-11 at 12 45 17 pm](https://cloud.githubusercontent.com/assets/3596952/25930125/b67d5a74-3647-11e7-9cc1-1b521e3bf79b.png)

After with acc_bias_learn_mask = 4 to disable X and Y bias estimation:

![screen shot 2017-05-11 at 12 43 25 pm](https://cloud.githubusercontent.com/assets/3596952/25930076/755bc878-3647-11e7-920a-177f0d71dd81.png)

Here are the corresponding GPS velocity innovations. Levels are noticeably lower.

![screen shot 2017-05-11 at 12 49 10 pm](https://cloud.githubusercontent.com/assets/3596952/25930195/40b53694-3648-11e7-9227-3845ca729d80.png)
