### PR TITLE
run terrain estimator after control fusion modes. Otherwise _range_da…

### DIFF
--- a/EKF/ekf.cpp
+++ b/EKF/ekf.cpp
@@ -127,11 +127,11 @@ bool Ekf::update()
 		predictState();
 		predictCovariance();
 
-		// run a separate filter for terrain estimation
-		runTerrainEstimator();
-
 		// control fusion of observation data
 		controlFusionModes();
+
+		// run a separate filter for terrain estimation
+		runTerrainEstimator();
 
 	}
 


### PR DESCRIPTION
…ta_ready will never be true and fuseHagl() will never run

Before, https://github.com/PX4/ecl/blob/fix_terrain_est/EKF/terrain_estimator.cpp#L96 was never true if the rangefinder runs at a lower frequency than the IMU.