### PR TITLE
EKF: Prevent long periods of flight without movement causing yaw drift

### DIFF
--- a/EKF/common.h
+++ b/EKF/common.h
@@ -230,6 +230,8 @@ struct parameters {
 	float mag_innov_gate{3.0f};		// magnetometer fusion innovation consistency gate size (STD)
 	int mag_declination_source{7};		// bitmask used to control the handling of declination data
 	int mag_fusion_type{0};			// integer used to specify the type of magnetometer fusion used
+	float mag_acc_gate{0.5f};		// when in auto select mode, heading fusion will be used when manoeuvre accel is lower than this (m/s**2)
+	float mag_yaw_rate_gate{0.25f};		// yaw rate threshold used by mode select logic (rad/sec)
 
 	// airspeed fusion
 	float tas_innov_gate{5.0f};		// True Airspeed Innovation consistency gate size in standard deciation

--- a/EKF/control.cpp
+++ b/EKF/control.cpp
@@ -888,7 +888,7 @@ void Ekf::controlMagFusion()
 	}
 
 	// If we are on ground, store the local position and time to use as a reference
-	// Also reset the flight alignment falg so that the mag fields will be re-initialised next time we achieve flight altitude
+	// Also reset the flight alignment flag so that the mag fields will be re-initialised next time we achieve flight altitude
 	if (!_control_status.flags.in_air) {
 		_last_on_ground_posD = _state.pos(2);
 		_flt_mag_align_complete = false;
@@ -941,7 +941,7 @@ void Ekf::controlMagFusion()
 			bool use_3D_fusion = _control_status.flags.tilt_align && // Use of 3D fusion requires valid tilt estimates
 					_control_status.flags.in_air && // don't use when on the ground becasue of magnetic anomalies
 					(_flt_mag_align_complete || height_achieved) && // once in-flight field alignment has been performed, ignore relative height
-					((_imu_sample_delayed.time_us - _time_last_movement) < 2000000); // Using 3-axis fusion for a minimum period after to allow for false negatives
+					((_imu_sample_delayed.time_us - _time_last_movement) < 2 * 1000 * 1000); // Using 3-axis fusion for a minimum period after to allow for false negatives
 
 			// perform switch-over
 			if (use_3D_fusion) {

--- a/EKF/covariance.cpp
+++ b/EKF/covariance.cpp
@@ -467,13 +467,6 @@ void Ekf::predictCovariance()
 
 	// Don't do covariance prediction on magnetic field states unless we are using 3-axis fusion
 	if (_control_status.flags.mag_3D) {
-		// Check if we have just transitioned into 3-axis fusion and set the state variances
-		if (!_control_status_prev.flags.mag_3D) {
-			for (uint8_t index = 16; index <= 21; index++) {
-				P[index][index] = sq(fmaxf(_params.mag_noise, 0.001f));
-			}
-		}
-
 		// calculate variances and upper diagonal covariances for earth and body magnetic field states
 		nextP[0][16] = P[0][16] + P[1][16]*SF[9] + P[2][16]*SF[11] + P[3][16]*SF[10] + P[10][16]*SF[14] + P[11][16]*SF[15] + P[12][16]*SPP[10];
 		nextP[1][16] = P[1][16] + P[0][16]*SF[8] + P[2][16]*SF[7] + P[3][16]*SF[11] - P[12][16]*SF[15] + P[11][16]*SPP[10] - (P[10][16]*q0)/2;

--- a/EKF/ekf.cpp
+++ b/EKF/ekf.cpp
@@ -494,7 +494,8 @@ void Ekf::calculateOutputStates()
 			_R_to_earth_now(2,2) * delta_angle(2);
 	_yaw_delta_ef += spin_del_ang_D;
 
-	// calculate filtered yaw rate to be used by the magnetomer fusion type selection logic
+	// Calculate filtered yaw rate to be used by the magnetomer fusion type selection logic
+	// Note fixed coefficients are used to save operations. The exact time constant is not important.
 	_yaw_rate_lpf_ef = 0.95f * _yaw_rate_lpf_ef + 0.05f * spin_del_ang_D / _imu_sample_new.delta_ang_dt;
 
 	// correct delta velocity for bias offsets

--- a/EKF/ekf.h
+++ b/EKF/ekf.h
@@ -266,6 +266,13 @@ private:
 
 	matrix::Dcm<float> _R_to_earth;	// transformation matrix from body frame to earth frame from last EKF predition
 
+	// used by magnetomer fusion mode selection
+	Vector2f _accel_lpf_NE;			// Low pass filtered horizontal earth frame acceleration (m/s**2)
+	float _yaw_delta_ef{0.0f};		// Recent change in yaw angle measured about the earth frame D axis (rad)
+	float _yaw_rate_lpf_ef{0.0f};		// Filtered angular rate abut earth frame D axis (rad/sec)
+	bool _mag_bias_observable{false};	// true when there is enough rotation to make magnetomer bias errors observable
+	bool _yaw_angle_observable{false};	// true when there is enough horizontal acceleration to make yaw observable
+
 	float P[_k_num_states][_k_num_states] {};	// state covariance matrix
 
 	float _vel_pos_innov[6] {};	// innovations: 0-2 vel,  3-5 pos
@@ -328,7 +335,11 @@ private:
 	float _baro_hgt_offset{0.0f};		// baro height reading at the local NED origin (m)
 
 	// Variables used to control activation of post takeoff functionality
-	float _last_on_ground_posD{0.0f}; // last vertical position when the in_air status was false (m)
+	float _last_on_ground_posD{0.0f};	// last vertical position when the in_air status was false (m)
+	bool _flt_mag_align_complete{true};	// true when the in-flight mag field alignment has been completed
+	uint64_t _time_last_movement{0};	// last system time in usec that sufficient movement to use 3-axis magnetomer fusion was detected
+	float _saved_mag_variance[6] {};	// magnetic field state variances that have been saved for use at the next initialisation (Ga**2)
+	uint64_t _time_yaw_started{0};		// last system time in usec that a yaw rotation moaneouvre was detected
 
 	gps_check_fail_status_u _gps_check_fail_status{};
 
@@ -343,7 +354,7 @@ private:
 	float _terrain_var{1e4f};		// variance of terrain position estimate (m^2)
 	float _hagl_innov{0.0f};		// innovation of the last height above terrain measurement (m)
 	float _hagl_innov_var{0.0f};		// innovation variance for the last height above terrain measurement (m^2)
-	uint64_t _time_last_hagl_fuse;	// last system time in usec that the hagl measurement failed it's checks
+	uint64_t _time_last_hagl_fuse;		// last system time in usec that the hagl measurement failed it's checks
 	bool _terrain_initialised{false};	// true when the terrain estimator has been intialised
 	float _sin_tilt_rng{0.0f};		// sine of the range finder tilt rotation about the Y body axis
 	float _cos_tilt_rng{0.0f};		// cosine of the range finder tilt rotation about the Y body axis

--- a/EKF/ekf.h
+++ b/EKF/ekf.h
@@ -266,12 +266,13 @@ private:
 
 	matrix::Dcm<float> _R_to_earth;	// transformation matrix from body frame to earth frame from last EKF predition
 
-	// used by magnetomer fusion mode selection
+	// used by magnetometer fusion mode selection
 	Vector2f _accel_lpf_NE;			// Low pass filtered horizontal earth frame acceleration (m/s**2)
 	float _yaw_delta_ef{0.0f};		// Recent change in yaw angle measured about the earth frame D axis (rad)
-	float _yaw_rate_lpf_ef{0.0f};		// Filtered angular rate abut earth frame D axis (rad/sec)
-	bool _mag_bias_observable{false};	// true when there is enough rotation to make magnetomer bias errors observable
+	float _yaw_rate_lpf_ef{0.0f};		// Filtered angular rate about earth frame D axis (rad/sec)
+	bool _mag_bias_observable{false};	// true when there is enough rotation to make magnetometer bias errors observable
 	bool _yaw_angle_observable{false};	// true when there is enough horizontal acceleration to make yaw observable
+	uint64_t _time_yaw_started{0};		// last system time in usec that a yaw rotation moaneouvre was detected
 
 	float P[_k_num_states][_k_num_states] {};	// state covariance matrix
 
@@ -337,9 +338,8 @@ private:
 	// Variables used to control activation of post takeoff functionality
 	float _last_on_ground_posD{0.0f};	// last vertical position when the in_air status was false (m)
 	bool _flt_mag_align_complete{true};	// true when the in-flight mag field alignment has been completed
-	uint64_t _time_last_movement{0};	// last system time in usec that sufficient movement to use 3-axis magnetomer fusion was detected
+	uint64_t _time_last_movement{0};	// last system time in usec that sufficient movement to use 3-axis magnetometer fusion was detected
 	float _saved_mag_variance[6] {};	// magnetic field state variances that have been saved for use at the next initialisation (Ga**2)
-	uint64_t _time_yaw_started{0};		// last system time in usec that a yaw rotation moaneouvre was detected
 
 	gps_check_fail_status_u _gps_check_fail_status{};
 

--- a/EKF/ekf_helper.cpp
+++ b/EKF/ekf_helper.cpp
@@ -501,7 +501,10 @@ bool Ekf::resetMagHeading(Vector3f &mag_init)
 void Ekf::calcMagDeclination()
 {
 	// set source of magnetic declination for internal use
-	if (_params.mag_declination_source & MASK_USE_GEO_DECL) {
+	if (_flt_mag_align_complete) {
+		// Use value consistent with earth field state
+		_mag_declination = atan2f(_state.mag_I(1),_state.mag_I(0));
+	} else if (_params.mag_declination_source & MASK_USE_GEO_DECL) {
 		// use parameter value until GPS is available, then use value returned by geo library
 		if (_NED_origin_initialised) {
 			_mag_declination = _mag_declination_gps;


### PR DESCRIPTION
This PR modifies the logic that us used to automatically select whether the magnetometer heading or 3-axis measurement fusion method is used. The previous logic always used the 3-axis method once the vehicle had started flying, however this can cause problems for vehicle that enter into stable position hold for extended periods immediately after takeoff.

The revised logic uses horizontal acceleration to check if yaw is observable independent of the magnetometer and uses  about the vertical to check if mag bias states are observable.
If neither yaw of mag biases are observable, it saves the magnetic field variances, the learned declination and switch to magnetic yaw fusion. When yaw or biases become observable, the saved variances are reinstated and it and switches back to 3D mag fusion.

Here is a replay of a flight where the vehicle hovered for an extended periodi n 3-axis mag fusion mode which resulted in the mag bias states drifting, which led to eventual loss of heading and a flyaway with large velocity innovations and repeated resets back to GPS before the EKF eventually recovered.

XY mag bias estimates
![screen shot 2017-05-16 at 9 33 39 am](https://cloud.githubusercontent.com/assets/3596952/26083753/d5da30c8-3a1a-11e7-8ffe-f7af4c295037.png)

NE velocity innovations
![screen shot 2017-05-16 at 9 39 59 am](https://cloud.githubusercontent.com/assets/3596952/26083882/a9ad56a0-3a1b-11e7-9679-0eded4bafb23.png)

Here are the same plots after the changes:

XY mag bias estimates - estimates only update wen the vehicle has movement.
![screen shot 2017-05-16 at 9 41 15 am](https://cloud.githubusercontent.com/assets/3596952/26083922/d86d178c-3a1b-11e7-8ed9-3184345b0415.png)

NE velocity innovations
![screen shot 2017-05-16 at 9 42 51 am](https://cloud.githubusercontent.com/assets/3596952/26083964/0ebfff2a-3a1c-11e7-945b-dc0a87a88ded.png)

Here are the mag field variances after the changes - variances are reinstated when movement checks indicate observability.

![screen shot 2017-05-16 at 9 44 38 am](https://cloud.githubusercontent.com/assets/3596952/26084014/652d8b2a-3a1c-11e7-89bc-a3953582523e.png)
