### PR TITLE
EKF: Add a parameter to enable setting of a minimum buffer length

### DIFF
--- a/EKF/common.h
+++ b/EKF/common.h
@@ -186,6 +186,7 @@ struct parameters {
 	int32_t sensor_interval_min_ms{20};		// minimum time of arrival difference between non IMU sensor updates. Sets the size of the observation buffers.
 
 	// measurement time delays
+	float min_delay_ms{0.0f};			// used to a set a minimum buffer length independent of specified sensor delays
 	float mag_delay_ms{0.0f};		// magnetometer measurement delay relative to the IMU (msec)
 	float baro_delay_ms{0.0f};		// barometer height measurement delay relative to the IMU (msec)
 	float gps_delay_ms{110.0f};		// GPS measurement delay relative to the IMU (msec)

--- a/EKF/estimator_interface.cpp
+++ b/EKF/estimator_interface.cpp
@@ -350,13 +350,14 @@ void EstimatorInterface::setExtVisionData(uint64_t time_usec, ext_vision_message
 
 bool EstimatorInterface::initialise_interface(uint64_t timestamp)
 {
-	// find the maximum time delay required to compensate for
+	// find the maximum time delay the buffers are required to handle
 	uint16_t max_time_delay_ms = math::max(_params.mag_delay_ms,
 					 math::max(_params.range_delay_ms,
 					     math::max(_params.gps_delay_ms,
 						 math::max(_params.flow_delay_ms,
 						     math::max(_params.ev_delay_ms,
-							 math::max(_params.airspeed_delay_ms, _params.baro_delay_ms))))));
+							 math::max(_params.min_delay_ms,
+								math::max(_params.airspeed_delay_ms, _params.baro_delay_ms)))))));
 
 	// calculate the IMU buffer length required to accomodate the maximum delay with some allowance for jitter
 	_imu_buffer_length = (max_time_delay_ms / FILTER_UPDATE_PERIOD_MS) + 1;


### PR DESCRIPTION
If the longest time delay sensor(eg GPS) has significant jitter in the arrival time of the updates, then this can cause the time stamp to fall outside of the buffer wind, resulting in the measurement being fused at the incorrect time. See below for an example of the effect a periodic 1-sample GPS timing jitter this can have on GPS position innovations with a GPs with an 85 msec delay parameter  and the buffer length set automatically at 96 msec. This output was generated from replay of data with a large GPS jitter.

![buffer96](https://cloud.githubusercontent.com/assets/3596952/26536509/e26f272a-447a-11e7-96ae-20fe934395ea.png)

In this  instance, manually setting the buffer length to 200 msec using the min_delay_ms parameter, and repeating the replay significantly reduced the position innovation spikes during forward flight.

![buffer200](https://cloud.githubusercontent.com/assets/3596952/26536535/548cd096-447b-11e7-81f7-e7a38d902f5d.png)

The reason we do not set the buffers to a large value permanently is that this increases memory utilisation and reduces the angular  tracking accuracy of the output predictor. See the following plots comparing the angular tracking from replay of the same log file with the automatic 96msec buffer length and the 200 buffer length achieved by setting   min_delay_ms = 200.

output observer angular tracking error norm with  default 96 msec buffer length
![buffer96-ang](https://cloud.githubusercontent.com/assets/3596952/26536587/02141364-447c-11e7-9153-0ab2d1dc5d8b.png)

output observer angular tracking error norm with min_delay_ms = 200
![buffer200-ang](https://cloud.githubusercontent.com/assets/3596952/26536591/0696508c-447c-11e7-8de1-fb06532751aa.png)
