### PR TITLE
EKF: Enable operation close to magnetic poles

### DIFF
--- a/EKF/common.h
+++ b/EKF/common.h
@@ -245,6 +245,10 @@ struct parameters {
 	int32_t mag_fusion_type{0};		///< integer used to specify the type of magnetometer fusion used
 	float mag_acc_gate{0.5f};		///< when in auto select mode, heading fusion will be used when manoeuvre accel is lower than this (m/sec**2)
 	float mag_yaw_rate_gate{0.25f};		///< yaw rate threshold used by mode select logic (rad/sec)
+	int32_t mag_field_vertical{0};		///< set to 1 or 2 when the earth field is too close to vertical to give reliable heading.
+						///< A value of 1 will assume yaw = mag_yaw_ground when on the ground and do no yaw or mag fusion in air.
+						///< A value of 2 will assume yaw = mag_yaw_ground when on the ground and do 3-axis mag fusion in the air.
+	float mag_yaw_ground{0.0f};		///< This yaw angle will be used for alignment and fusion when on the ground if mag_field_vertical = 1 or 2 (deg)
 
 	// airspeed fusion
 	float tas_innov_gate{5.0f};		///< True Airspeed innovation consistency gate size (STD)

--- a/EKF/control.cpp
+++ b/EKF/control.cpp
@@ -1230,6 +1230,14 @@ void Ekf::controlMagFusion()
 			_control_status.flags.mag_3D = false;
 		}
 
+		// If we are not fusing in observations to constrain yaw variance growth, and yaw variance has become large,
+		// then we must fuse in a measurement to prevent the covariance matrix from becoming badly conditioned.
+		if (_control_status.flags.yaw_align && !_control_status.flags.mag_hdg && !_control_status.flags.mag_3D ) {
+			if (calcYawVariance() > sq(_params.mag_heading_noise)) {
+				_control_status.flags.mag_hdg = true;
+			}
+		}
+
 		// if we are using 3-axis magnetometer fusion, but without external aiding, then the declination must be fused as an observation to prevent long term heading drift
 		// fusing declination when gps aiding is available is optional, but recommended to prevent problem if the vehicle is static for extended periods of time
 		// do not attempt to fuse declination if the earth field is too close to vertical

--- a/EKF/ekf.cpp
+++ b/EKF/ekf.cpp
@@ -270,6 +270,9 @@ bool Ekf::initialiseFilter()
 		// calculate the averaged magnetometer reading
 		Vector3f mag_init = _mag_filt_state;
 
+		// set a yaw value we will use as a default if no other yaw estimate is available
+		_last_inflight_yaw = math::radians(_params.mag_yaw_ground);
+
 		// calculate the initial magnetic field and yaw alignment
 		_control_status.flags.yaw_align = resetMagHeading(mag_init);
 

--- a/EKF/ekf.h
+++ b/EKF/ekf.h
@@ -561,6 +561,9 @@ private:
 	// rotate quaternion covariances into variances for an equivalent rotation vector
 	Vector3f calcRotVecVariances();
 
+	// calculate the yaw variance from the quaternion covariances
+	float calcYawVariance();
+
 	// initialise the quaternion covariances using rotation vector variances
 	void initialiseQuatCovariances(Vector3f &rot_vec_var);
 

--- a/EKF/ekf_helper.cpp
+++ b/EKF/ekf_helper.cpp
@@ -506,6 +506,10 @@ bool Ekf::resetMagHeading(Vector3f &mag_init)
 			// calculate the yaw angle for a 312 sequence
 			euler321(2) = atan2f(R_to_earth_ev(1, 0), R_to_earth_ev(0, 0));
 
+		} else if ((_params.mag_field_vertical == 1) || (_params.mag_field_vertical == 2)) {
+			// force use of the parameter defined yaw angle
+			euler321(2) = math::radians(_params.mag_yaw_ground);
+
 		} else if (_params.mag_fusion_type <= MAG_FUSE_TYPE_3D) {
 			// rotate the magnetometer measurements into earth frame using a zero yaw angle
 			Vector3f mag_earth_pred = R_to_earth * _mag_sample_delayed.mag;
@@ -578,6 +582,10 @@ bool Ekf::resetMagHeading(Vector3f &mag_init)
 			Dcmf R_to_earth_ev(_ev_sample_delayed.quat);	// transformation matrix from body to world frame
 			// calculate the yaw angle for a 312 sequence
 			euler312(0) = atan2f(-R_to_earth_ev(0, 1), R_to_earth_ev(1, 1));
+
+		} else if ((_params.mag_field_vertical == 1) || (_params.mag_field_vertical == 2)) {
+			// force use of the parameter defined yaw angle
+			euler312(0) = math::radians(_params.mag_yaw_ground);
 
 		} else if (_params.mag_fusion_type <= MAG_FUSE_TYPE_3D) {
 			// rotate the magnetometer measurements into earth frame using a zero yaw angle

--- a/EKF/ekf_helper.cpp
+++ b/EKF/ekf_helper.cpp
@@ -507,8 +507,8 @@ bool Ekf::resetMagHeading(Vector3f &mag_init)
 			euler321(2) = atan2f(R_to_earth_ev(1, 0), R_to_earth_ev(0, 0));
 
 		} else if ((_params.mag_field_vertical == 1) || (_params.mag_field_vertical == 2)) {
-			// force use of the parameter defined yaw angle
-			euler321(2) = math::radians(_params.mag_yaw_ground);
+			// use best estimate
+			euler321(2) = _last_inflight_yaw;
 
 		} else if (_params.mag_fusion_type <= MAG_FUSE_TYPE_3D) {
 			// rotate the magnetometer measurements into earth frame using a zero yaw angle
@@ -584,8 +584,8 @@ bool Ekf::resetMagHeading(Vector3f &mag_init)
 			euler312(0) = atan2f(-R_to_earth_ev(0, 1), R_to_earth_ev(1, 1));
 
 		} else if ((_params.mag_field_vertical == 1) || (_params.mag_field_vertical == 2)) {
-			// force use of the parameter defined yaw angle
-			euler312(0) = math::radians(_params.mag_yaw_ground);
+			// use best estimate
+			euler312(0) = _last_inflight_yaw;
 
 		} else if (_params.mag_fusion_type <= MAG_FUSE_TYPE_3D) {
 			// rotate the magnetometer measurements into earth frame using a zero yaw angle

--- a/EKF/estimator_interface.cpp
+++ b/EKF/estimator_interface.cpp
@@ -461,3 +461,22 @@ bool EstimatorInterface::local_position_is_valid()
 	       (((_time_last_imu - _time_last_ext_vision) < 5e6) && _control_status.flags.ev_pos) ||
 	       global_position_is_valid();
 }
+
+// return Euler yaw angle  in radians at output time horizon using the best conditioned of a 321 or 312 sequence to avoid gimbal lock
+float EstimatorInterface::getOutputYawAngle(void)
+{
+	// determine if a 321 or 312 Euler sequence is best
+	float yaw_angle;
+	if (fabsf(_R_to_earth_now(2, 0)) < fabsf(_R_to_earth_now(2, 1))) {
+		// use a 321 sequence
+		yaw_angle = atan2f(_R_to_earth_now(1, 0), _R_to_earth_now(0, 0));
+
+	} else {
+		// Use a 312 sequence
+		// See http://www.atacolorado.com/eulersequences.doc
+		yaw_angle = atan2f(-_R_to_earth_now(0, 1), _R_to_earth_now(1, 1));
+
+	}
+
+	return yaw_angle;
+}

--- a/EKF/estimator_interface.h
+++ b/EKF/estimator_interface.h
@@ -181,7 +181,13 @@ public:
 	parameters *getParamHandle() {return &_params;}
 
 	// set vehicle landed status data
-	void set_in_air_status(bool in_air) {_control_status.flags.in_air = in_air;}
+	void set_in_air_status(bool in_air) {
+		// store the latest yaw angle if landing
+		if (!in_air && _control_status.flags.in_air) {
+			_last_inflight_yaw = getOutputYawAngle();
+		}
+		_control_status.flags.in_air = in_air;
+	}
 
 	// set vehicle is fixed wing status
 	void set_is_fixed_wing(bool is_fixed_wing) {_control_status.flags.fixed_wing = is_fixed_wing;}
@@ -324,6 +330,9 @@ public:
 
 	static const unsigned FILTER_UPDATE_PERIOD_MS = 12;	// ekf prediction period in milliseconds - this should ideally be an integer multiple of the IMU time delta
 
+	// return Euler yaw angle  in radians at output time horizon using the best conditioned of a 321 or 312 sequence to avoid gimbal lock
+	float getOutputYawAngle(void);
+
 protected:
 
 	parameters _params;		// filter parameters
@@ -375,6 +384,7 @@ protected:
 	imuSample _imu_sample_new{};		// imu sample capturing the newest imu data
 	Matrix3f _R_to_earth_now;		// rotation matrix from body to earth frame at current time
 	Vector3f _vel_imu_rel_body_ned;		// velocity of IMU relative to body origin in NED earth frame
+	float _last_inflight_yaw{0.0f};		// value of output yaw angle saved at touchdown (rad)
 
 	uint64_t _imu_ticks{0};	// counter for imu updates
 

--- a/EKF/mag_fusion.cpp
+++ b/EKF/mag_fusion.cpp
@@ -467,9 +467,16 @@ void Ekf::fuseHeading()
 			Dcmf R_to_earth(euler321);
 
 			if ((_params.mag_field_vertical == 1) || (_params.mag_field_vertical == 2)) {
-				// use the parameter specified yaw angle when on ground if the earth field inclination is too close to vertical
-				measured_hdg = math::radians(_params.mag_yaw_ground);
+				if (!_control_status.flags.in_air) {
+					// use the parameter specified yaw angle when on ground if the earth field inclination is too close to vertical
+					measured_hdg = math::radians(_params.mag_yaw_ground);
 
+				} else {
+					// use the current heading so that the innovation is zero
+					// this can be used if the yaw variance has become too large
+					measured_hdg = predicted_hdg;
+
+				}
 			} else {
 				// rotate the magnetometer measurements into earth frame using a zero yaw angle
 				mag_earth_pred = R_to_earth * _mag_sample_delayed.mag;
@@ -560,9 +567,16 @@ void Ekf::fuseHeading()
 			R_to_earth(2,2) = cp*cr;
 
 			if ((_params.mag_field_vertical == 1) || (_params.mag_field_vertical == 2)) {
-				// use the parameter specified yaw angle when on ground if the earth field inclination is too close to vertical
-				measured_hdg = math::radians(_params.mag_yaw_ground);
+				if (!_control_status.flags.in_air) {
+					// use the parameter specified yaw angle when on ground if the earth field inclination is too close to vertical
+					measured_hdg = math::radians(_params.mag_yaw_ground);
 
+				} else {
+					// use the current heading so that the innovation is zero
+					// this can be used if the yaw variance has become too large
+					measured_hdg = predicted_hdg;
+
+				}
 			} else {
 				// rotate the magnetometer measurements into earth frame using a zero yaw angle
 				mag_earth_pred = R_to_earth * _mag_sample_delayed.mag;

--- a/EKF/mag_fusion.cpp
+++ b/EKF/mag_fusion.cpp
@@ -468,8 +468,8 @@ void Ekf::fuseHeading()
 
 			if ((_params.mag_field_vertical == 1) || (_params.mag_field_vertical == 2)) {
 				if (!_control_status.flags.in_air) {
-					// use the parameter specified yaw angle when on ground if the earth field inclination is too close to vertical
-					measured_hdg = math::radians(_params.mag_yaw_ground);
+					// use the last known good yaw angle
+					measured_hdg = _last_inflight_yaw;
 
 				} else {
 					// use the current heading so that the innovation is zero
@@ -568,8 +568,8 @@ void Ekf::fuseHeading()
 
 			if ((_params.mag_field_vertical == 1) || (_params.mag_field_vertical == 2)) {
 				if (!_control_status.flags.in_air) {
-					// use the parameter specified yaw angle when on ground if the earth field inclination is too close to vertical
-					measured_hdg = math::radians(_params.mag_yaw_ground);
+					// use the last known good yaw angle
+					measured_hdg = _last_inflight_yaw;
 
 				} else {
 					// use the current heading so that the innovation is zero

--- a/EKF/mag_fusion.cpp
+++ b/EKF/mag_fusion.cpp
@@ -466,12 +466,18 @@ void Ekf::fuseHeading()
 			euler321(2) = 0.0f;
 			Dcmf R_to_earth(euler321);
 
-			// rotate the magnetometer measurements into earth frame using a zero yaw angle
-			mag_earth_pred = R_to_earth * _mag_sample_delayed.mag;
+			if ((_params.mag_field_vertical == 1) || (_params.mag_field_vertical == 2)) {
+				// use the parameter specified yaw angle when on ground if the earth field inclination is too close to vertical
+				measured_hdg = math::radians(_params.mag_yaw_ground);
 
-			// the angle of the projection onto the horizontal gives the yaw angle
-			measured_hdg = -atan2f(mag_earth_pred(1), mag_earth_pred(0)) + _mag_declination;
+			} else {
+				// rotate the magnetometer measurements into earth frame using a zero yaw angle
+				mag_earth_pred = R_to_earth * _mag_sample_delayed.mag;
 
+				// the angle of the projection onto the horizontal gives the yaw angle
+				measured_hdg = -atan2f(mag_earth_pred(1), mag_earth_pred(0)) + _mag_declination;
+
+			}
 		} else if (_control_status.flags.ev_yaw) {
 			// calculate the yaw angle for a 321 sequence
 			// Expressions obtained from yaw_input_321.c produced by https://github.com/PX4/ecl/blob/master/matlab/scripts/Inertial%20Nav%20EKF/quat2yaw321.m
@@ -553,12 +559,18 @@ void Ekf::fuseHeading()
 			R_to_earth(2,1) = sr;
 			R_to_earth(2,2) = cp*cr;
 
-			// rotate the magnetometer measurements into earth frame using a zero yaw angle
-			mag_earth_pred = R_to_earth * _mag_sample_delayed.mag;
+			if ((_params.mag_field_vertical == 1) || (_params.mag_field_vertical == 2)) {
+				// use the parameter specified yaw angle when on ground if the earth field inclination is too close to vertical
+				measured_hdg = math::radians(_params.mag_yaw_ground);
 
-			// the angle of the projection onto the horizontal gives the yaw angle
-			measured_hdg = -atan2f(mag_earth_pred(1), mag_earth_pred(0)) + _mag_declination;
+			} else {
+				// rotate the magnetometer measurements into earth frame using a zero yaw angle
+				mag_earth_pred = R_to_earth * _mag_sample_delayed.mag;
 
+				// the angle of the projection onto the horizontal gives the yaw angle
+				measured_hdg = -atan2f(mag_earth_pred(1), mag_earth_pred(0)) + _mag_declination;
+
+			}
 		} else if (_control_status.flags.ev_yaw) {
 			// calculate the yaw angle for a 312 sequence
 			// Values from yaw_input_312.c file produced by https://github.com/PX4/ecl/blob/master/matlab/scripts/Inertial%20Nav%20EKF/quat2yaw312.m


### PR DESCRIPTION
**DESCRIPTION**

This PR enables operation close to the earths magnetic poles where the normal method of determining yaw orientation using the on-board compass is unreliable. It uses the following strategy:

1) A parameter mag_field_vertical is used to specify if the mode is active.
2) If the parameter mag_field_vertical is set to either 1 or 2, the vehicles yaw will be aligned to the value in degrees set by parameter mag_yaw_ground
3) In flight 3-axis fusion will be enabled if mag_field_vertical = 2, and no mag fusion of any type will be used if mag_field_vertical = 1. 
4) If the yaw variance is excessive, the current yaw estimate is fused as an observation to prevent a situation where a badly conditioned covariance matrix causes filter instability.
5) The last in-flight yaw angle estimate is saved and used to constrain the heading drift when on the ground so subsequent takeoffs can be performed after landing at arbitrary yaw angles

**TESTING**

Completed. See following comment.