### PR TITLE
remove setting rng faulty in ev mode because not checked

### DIFF
--- a/EKF/control.cpp
+++ b/EKF/control.cpp
@@ -655,7 +655,6 @@ void Ekf::controlHeightSensorTimeouts()
 
 			if (reset_to_baro) {
 				// set height sensor health
-				_rng_hgt_faulty = true;
 				_baro_hgt_faulty = false;
 
 				// reset the height mode


### PR DESCRIPTION
It hasn't done any harm so far because I don't know anyone who uses external vision for height estimation. But I cannot see why `_rng_hgt_faulty` is set to `true` at this point. There isn't even a check. Maybe I'm missing something?