### PR TITLE
Fixed vision position fusion bug

### DIFF
--- a/EKF/control.cpp
+++ b/EKF/control.cpp
@@ -150,6 +150,7 @@ void Ekf::controlExternalVisionFusion()
 				resetPosition();
 				resetVelocity();
 				resetHeight();
+				_control_status.flags.ev_pos=true;
 			}
 		}
 


### PR DESCRIPTION
Without this fix, the system constantly re-initialises the vision position and state estimator when new vision data becomes available.