### PR TITLE
EKF: Add ability to use EV and GPS data together

### DIFF
--- a/EKF/ekf.h
+++ b/EKF/ekf.h
@@ -238,6 +238,12 @@ private:
 	bool _fuse_hor_vel{false};	///< true when gps horizontal velocity measurement should be fused
 	bool _fuse_vert_vel{false};	///< true when gps vertical velocity measurement should be fused
 
+	// variables used when position data is being fused using a relative position odometry model
+	bool _hpos_odometry{false};		///< true when the NE position data is being fused using an odometry assumption
+	Vector2f _hpos_meas_prev;		///< previous value of NE position measurement fused using odometry assumption (m)
+	Vector2f _hpos_pred_prev;		///< previous value of NE position state used by odometry fusion (m)
+	bool _hpos_prev_available{false};	///< true when previous values of the estimate and measurement are available for use
+
 	// booleans true when fresh sensor data is available at the fusion time horizon
 	bool _gps_data_ready{false};	///< true when new GPS data has fallen behind the fusion time horizon and is available to be fused
 	bool _mag_data_ready{false};	///< true when new magnetometer data has fallen behind the fusion time horizon and is available to be fused

--- a/EKF/ekf_helper.cpp
+++ b/EKF/ekf_helper.cpp
@@ -98,6 +98,9 @@ bool Ekf::resetPosition()
 	posNE_before_reset(0) = _state.pos(0);
 	posNE_before_reset(1) = _state.pos(1);
 
+	// let the next odometry update know that the previous value of states cannot be used to calculate the change in position
+	_hpos_prev_available = false;
+
 	if (_control_status.flags.gps) {
 		// this reset is only called if we have new gps data at the fusion time horizon
 		_state.pos(0) = _gps_sample_delayed.pos(0);

--- a/EKF/gps_checks.cpp
+++ b/EKF/gps_checks.cpp
@@ -68,7 +68,7 @@ bool Ekf::collect_gps(uint64_t time_usec, struct gps_message *gps)
 			map_projection_init_timestamped(&_pos_ref, lat, lon, _time_last_imu);
 
 			// if we are already doing aiding, corect for the change in posiiton since the EKF started navigating
-			if (_control_status.flags.opt_flow || _control_status.flags.gps) {
+			if (_control_status.flags.opt_flow || _control_status.flags.gps || _control_status.flags.ev_pos) {
 				double est_lat, est_lon;
 				map_projection_reproject(&_pos_ref, -_state.pos(0), -_state.pos(1), &est_lat, &est_lon);
 				map_projection_init_timestamped(&_pos_ref, est_lat, est_lon, _time_last_imu);


### PR DESCRIPTION
Fuse external vision data using a relative position odometry method when GPS data is also being used and enable both GPOS and EV data to be fused on the same time step.

The previous filter logic turned of EV data fusion when GPS data was present to avoid conflict between the two data sources. This PR switches to using a delta position observation model for EV position data when GPs data is also being fused.

Initial response to https://github.com/PX4/Firmware/issues/7408

A replay log containing EV and GPs data is required to test this. This should be obtained with SDLOG_MODE = 2 and EKF2_REC_RPL = 1