### PR TITLE
EKF: Enable operation with arbitrary External Vision reference frame

### DIFF
--- a/EKF/common.h
+++ b/EKF/common.h
@@ -174,6 +174,7 @@ struct dragSample {
 #define MASK_USE_EVPOS	(1<<3)		///< set to true to use external vision NED position data
 #define MASK_USE_EVYAW  (1<<4)		///< set to true to use exernal vision quaternion data for yaw
 #define MASK_USE_DRAG  (1<<5)		///< set to true to use the multi-rotor drag model to estimate wind
+#define MASK_ROTATE_EV  (1<<6)		///< set to true to if the EV observations are in a non NED reference frame and need to be rotated before being used
 
 // Integer definitions for mag_fusion_type
 #define MAG_FUSE_TYPE_AUTO      0	///< The selection of either heading or 3D magnetometer fusion will be automatic

--- a/EKF/control.cpp
+++ b/EKF/control.cpp
@@ -167,12 +167,6 @@ void Ekf::controlExternalVisionFusion()
 				} else {
 					resetPosition();
 					resetVelocity();
-					// we cannot use an absolue position from a rotating reference frame
-					if (_params.fusion_mode & MASK_ROTATE_EV) {
-						_fuse_hpos_as_odom = true;
-					} else {
-						_fuse_hpos_as_odom = false;
-					}
 
 				}
 			}

--- a/EKF/control.cpp
+++ b/EKF/control.cpp
@@ -133,6 +133,7 @@ void Ekf::controlFusionModes()
 
 	// report dead reckoning if we are no longer fusing measurements that directly constrain velocity drift
 	_is_dead_reckoning = (_time_last_imu - _time_last_pos_fuse > _params.no_aid_timeout_max)
+			&& (_time_last_imu - _time_last_delpos_fuse > _params.no_aid_timeout_max)
 			&& (_time_last_imu - _time_last_vel_fuse > _params.no_aid_timeout_max)
 			&& (_time_last_imu - _time_last_of_fuse > _params.no_aid_timeout_max);
 
@@ -142,6 +143,13 @@ void Ekf::controlExternalVisionFusion()
 {
 	// Check for new exernal vision data
 	if (_ev_data_ready) {
+
+		// if the ev data is not in a NED reference frame, then the transformation between EV and EKF navigation frames
+		// needs to be calculated and the observations rotated into the EKF frame of reference
+		if ((_params.fusion_mode & MASK_ROTATE_EV) && (_params.fusion_mode & MASK_USE_EVPOS) && !(_params.fusion_mode & MASK_USE_EVYAW)) {
+			// rotate EV measurements into the EKF Navigation frame
+			calcExtVisRotMat();
+		}
 
 		// external vision position aiding selection logic
 		if ((_params.fusion_mode & MASK_USE_EVPOS) && !_control_status.flags.ev_pos && _control_status.flags.tilt_align && _control_status.flags.yaw_align) {
@@ -154,12 +162,17 @@ void Ekf::controlExternalVisionFusion()
 				// reset the position if we are not already aiding using GPS, else use a relative position
 				// method for fusing the position data
 				if (_control_status.flags.gps) {
-					_hpos_odometry = true;
+					_fuse_hpos_as_odom = true;
 
 				} else {
 					resetPosition();
 					resetVelocity();
-					_hpos_odometry = false;
+					// we cannot use an absolue position from a rotating reference frame
+					if (_params.fusion_mode & MASK_ROTATE_EV) {
+						_fuse_hpos_as_odom = true;
+					} else {
+						_fuse_hpos_as_odom = false;
+					}
 
 				}
 			}
@@ -243,16 +256,57 @@ void Ekf::controlExternalVisionFusion()
 			_ev_sample_delayed.posNED(1) -= pos_offset_earth(1);
 			_ev_sample_delayed.posNED(2) -= pos_offset_earth(2);
 
-			// if GPS data is being used, then use an incremental position fusion method for EV data
-			if (_control_status.flags.gps) {
-				_hpos_odometry = true;
+			// Use an incremental position fusion method for EV data if using GPS or if the observations are not in NED
+			if (_control_status.flags.gps || (_params.fusion_mode & MASK_ROTATE_EV)) {
+				_fuse_hpos_as_odom = true;
+			} else {
+				_fuse_hpos_as_odom = false;
 			}
+
+			if(_fuse_hpos_as_odom) {
+				if(!_hpos_prev_available) {
+					// no previous observation available to calculate position change
+					_fuse_pos = false;
+					_hpos_prev_available = true;
+
+				} else {
+					// calculate the change in position since the last measurement
+					Vector3f ev_delta_pos = _ev_sample_delayed.posNED - _pos_meas_prev;
+
+					// rotate measurement into body frame if required
+					if (_params.fusion_mode & MASK_ROTATE_EV) {
+						ev_delta_pos = _ev_rot_mat * ev_delta_pos;
+					}
+
+					// use the change in position since the last measurement
+					_vel_pos_innov[3] = _state.pos(0) - _hpos_pred_prev(0) - ev_delta_pos(0);
+					_vel_pos_innov[4] = _state.pos(1) - _hpos_pred_prev(1) - ev_delta_pos(1);
+
+				}
+
+				// record observation and estimate for use next time
+				_pos_meas_prev = _ev_sample_delayed.posNED;
+				_hpos_pred_prev(0) = _state.pos(0);
+				_hpos_pred_prev(1) = _state.pos(1);
+
+			} else {
+				// use the absolute position
+				_vel_pos_innov[3] = _state.pos(0) - _ev_sample_delayed.posNED(0);
+				_vel_pos_innov[4] = _state.pos(1) - _ev_sample_delayed.posNED(1);
+			}
+
+			// observation 1-STD error
+			_posObsNoiseNE = fmaxf(_ev_sample_delayed.posErr, 0.01f);
+
+			// innovation gate size
+			_posInnovGateNE = fmaxf(_params.ev_innov_gate, 1.0f);
 		}
 
 		// Fuse available NED position data into the main filter
 		if (_fuse_height || _fuse_pos) {
 			fuseVelPosHeight();
 			_fuse_pos = _fuse_height = false;
+			_fuse_hpos_as_odom = false;
 
 		}
 
@@ -423,12 +477,16 @@ void Ekf::controlGpsFusion()
 		}
 
 		// handle the case when we now have GPS, but have not been using it for an extended period
-		if (_control_status.flags.gps && !_control_status.flags.opt_flow) {
-			// We are relying on GPS aiding to constrain attitude drift so after 7 seconds without aiding we need to do something
-			bool do_reset = (_time_last_imu - _time_last_pos_fuse > _params.no_gps_timeout_max) && (_time_last_imu - _time_last_vel_fuse > _params.no_gps_timeout_max);
+		if (_control_status.flags.gps) {
+			// We are relying on aiding to constrain drift so after a specified time
+			// with no aiding we need to do something
+			bool do_reset = (_time_last_imu - _time_last_pos_fuse > _params.no_gps_timeout_max)
+					&& (_time_last_imu - _time_last_delpos_fuse > _params.no_gps_timeout_max)
+					&& (_time_last_imu - _time_last_vel_fuse > _params.no_gps_timeout_max)
+					&& (_time_last_imu - _time_last_of_fuse > _params.no_gps_timeout_max);
 
-			// Our position measurments have been rejected for more than 14 seconds
-			do_reset |= _time_last_imu - _time_last_pos_fuse > 2 * _params.no_gps_timeout_max;
+			// We haven't had an absolute position fix for a longer time so need to do something
+			do_reset = do_reset || (_time_last_imu - _time_last_pos_fuse > 2 * _params.no_gps_timeout_max);
 
 			if (do_reset) {
 				// Reset states to the last GPS measurement
@@ -468,6 +526,19 @@ void Ekf::controlGpsFusion()
 			_gps_sample_delayed.pos(0) -= pos_offset_earth(0);
 			_gps_sample_delayed.pos(1) -= pos_offset_earth(1);
 			_gps_sample_delayed.hgt += pos_offset_earth(2);
+
+			// calculate observation process noise
+			float lower_limit = fmaxf(_params.gps_pos_noise, 0.01f);
+			float upper_limit = fmaxf(_params.pos_noaid_noise, lower_limit);
+			_posObsNoiseNE = math::constrain(_gps_sample_delayed.hacc, lower_limit, upper_limit);
+
+			// calculate innovations
+			_vel_pos_innov[3] = _state.pos(0) - _gps_sample_delayed.pos(0);
+			_vel_pos_innov[4] = _state.pos(1) - _gps_sample_delayed.pos(1);
+
+			// set innovation gate size
+			_posInnovGateNE = fmaxf(_params.posNE_innov_gate, 1.0f);
+
 
 		}
 
@@ -1251,12 +1322,24 @@ void Ekf::controlVelPosFusion()
 			_last_known_posNE(0) = _state.pos(0);
 			_last_known_posNE(1) = _state.pos(1);
 			_state.vel.setZero();
+			_fuse_hpos_as_odom = false;
 			ECL_WARN("EKF stopping navigation");
 
 		}
 
 		_fuse_pos = true;
 		_time_last_fake_gps = _time_last_imu;
+
+		if (_control_status.flags.in_air && _control_status.flags.tilt_align) {
+			_posObsNoiseNE = fmaxf(_params.pos_noaid_noise, _params.gps_pos_noise);
+		} else {
+			_posObsNoiseNE = 0.5f;
+		}
+		_vel_pos_innov[3] = _state.pos(0) - _last_known_posNE(0);
+		_vel_pos_innov[4] = _state.pos(1) - _last_known_posNE(1);
+
+		// glitch protection is not required so set gate to a large value
+		_posInnovGateNE = 100.0f;
 
 	}
 

--- a/EKF/ekf.cpp
+++ b/EKF/ekf.cpp
@@ -273,6 +273,11 @@ bool Ekf::initialiseFilter()
 		// calculate the initial magnetic field and yaw alignment
 		_control_status.flags.yaw_align = resetMagHeading(mag_init);
 
+		// initialise the rotation from EV to EKF navigation frame if required
+		if ((_params.fusion_mode & MASK_ROTATE_EV) && (_params.fusion_mode & MASK_USE_EVPOS) && !(_params.fusion_mode & MASK_USE_EVYAW)) {
+			resetExtVisRotMat();
+		}
+
 		if (_control_status.flags.rng_hgt) {
 			// if we are using the range finder as the primary source, then calculate the baro height at origin so  we can use baro as a backup
 			// so it can be used as a backup ad set the initial height using the range finder
@@ -297,6 +302,7 @@ bool Ekf::initialiseFilter()
 		// reset the essential fusion timeout counters
 		_time_last_hgt_fuse = _time_last_imu;
 		_time_last_pos_fuse = _time_last_imu;
+		_time_last_delpos_fuse = _time_last_imu;
 		_time_last_vel_fuse = _time_last_imu;
 		_time_last_hagl_fuse = _time_last_imu;
 		_time_last_of_fuse = _time_last_imu;

--- a/EKF/estimator_interface.h
+++ b/EKF/estimator_interface.h
@@ -236,6 +236,9 @@ public:
 		}
 	}
 
+	// return the quaternion defining the rotation from the EKF to the External Vision reference frame
+	virtual void get_ekf2ev_quaternion(float *quat) = 0;
+
 	// get the velocity of the body frame origin in local NED earth frame
 	void get_velocity(float *vel)
 	{


### PR DESCRIPTION
This PR adds a parameter activated function that uses the navigation to body frame quaternion from the external vision system to estimate the rotation from the EKF to the EV reference frame. This is then used to rotate EV position measurements into the EKF NED navigation frame before they are used.

It has been created in response to requirements identified in https://github.com/PX4/Firmware/issues/7408.

This function is enabled by setting bit position 6 in EKF2_AID_MASK to true. If bit position 4 is also set to true (EKF is using the EV system's yaw angle) then the compensation is disabled because the EV system's navigation frame becomes the reference.

**TESTING**

Testing has been performed using SITL with the following branch to enable the EV data to be rotated into a different frame of reference. 

https://github.com/priseborough/Firmware/tree/pr-ekfExtVisQuat

See the following log produced running make posix_sitl_default gazebo_iris.

https://review.px4.io/plot_app?log=b17ec2dd-f150-4b47-9534-e9ff96106561

Position innovations were small and the EV system alignment was correctly estimated as 1 radian of yaw. 
![screen shot 2017-09-26 at 4 27 42 pm](https://user-images.githubusercontent.com/3596952/30845643-bd2a35de-a2d7-11e7-93db-3838c3e179f5.png)

The test was successfully repeated with EKF2_AID_MASK = 73 to enable GPS fusion:

https://review.px4.io/plot_app?log=ef6fac87-b038-49fe-bc9c-fe07a783473c

Position innovations were small and the EV system alignment was correctly estimated as 1 radian of yaw. 
![screen shot 2017-09-26 at 5 19 37 pm](https://user-images.githubusercontent.com/3596952/30847462-f9a19e38-a2de-11e7-9f11-6e20dd403fb9.png)

The position hold with GPS fusion (EKF2_AID_MASK = 73) was more as precise than with using EV data (EKF2_AID_MASK = 72). This may be due to the loss of velocity observations and/or the use of differential position to fuse EV data when it is not in a NED frame.