### PR TITLE
EKF: Improve in-flight mag error detection, recovery and isolation for fixed wing

### DIFF
--- a/EKF/common.h
+++ b/EKF/common.h
@@ -413,6 +413,7 @@ union filter_control_status_u {
 		uint32_t fuse_beta   : 1; ///< 15 - true when synthetic sideslip measurements are being fused
 		uint32_t update_mag_states_only   : 1; ///< 16 - true when only the magnetometer states are updated by the magnetometer
 		uint32_t fixed_wing  : 1; ///< 17 - true when the vehicle is operating as a fixed wing vehicle
+		uint32_t mag_fault   : 1; ///< 18 - true when the magnetomer has been declared faulty and is no longer being used
 	} flags;
 	uint32_t value;
 };

--- a/EKF/ekf.h
+++ b/EKF/ekf.h
@@ -279,6 +279,7 @@ private:
 	bool _mag_bias_observable{false};	///< true when there is enough rotation to make magnetometer bias errors observable
 	bool _yaw_angle_observable{false};	///< true when there is enough horizontal acceleration to make yaw observable
 	uint64_t _time_yaw_started{0};		///< last system time in usec that a yaw rotation moaneouvre was detected
+	uint8_t _num_bad_flight_yaw_events{0};	///< number of times a bad heading has been detected in flight and required a yaw reset
 
 	float P[_k_num_states][_k_num_states] {};	///< state covariance matrix
 

--- a/EKF/ekf_helper.cpp
+++ b/EKF/ekf_helper.cpp
@@ -372,7 +372,7 @@ bool Ekf::realignYawGPS()
 			ECL_WARN("EKF bad yaw corrected using GPS course");
 
 			// declare the magnetomer as failed if a bad yaw has occurred more than once
-			if (_flt_mag_align_complete && (_num_bad_flight_yaw_events >= 2)) {
+			if (_flt_mag_align_complete && (_num_bad_flight_yaw_events >= 2) && !_control_status.flags.mag_fault) {
 				ECL_WARN("EKF stopping magnetometer use");
 				_control_status.flags.mag_fault = true;
 			}


### PR DESCRIPTION
This PR improves the handling of in-flight yaw reset and magnetometer error handling   and further develops the functionality introduced by https://github.com/PX4/ecl/pull/294 which was able to recover from yaw errors present at launch/takeoff.

The following functions have been added:

If the EKF rejects GPS data long enough to result in an in-flight reset (which also causes loss of global position validity), then the yaw will be reset to the wind relative GPS course over ground vector.

If two in-flight mag yaw failure and reset events occur, then the mag is declared as unhealthy and magnetometer fusion is halted resulting in a warning message to the console:

"EKF stopping magnetometer use"

and bit position 18 in the filter status message being set to true.

**Testing**

Testing is ongoing with an initial assessment  performed using replay of the following flight log: http://review.px4.io/plot_app?log=ed369adf-4e46-486a-bc18-14a2ed188bd0 with the magnetometer data rotated in ekf2_main.cpp to simulate a  sensor yaw misalignment.

Testing with a crash log http://review.px4.io/plot_app?log=1c1b7c69-d55c-4f63-a287-85d5be996453 from https://github.com/PX4/Firmware/issues/7609 showed that the changes prevented the GPS rejection being repeated after first in-flight reset and would have enabled the flight to continue given an appropriate failsafe strategy.

velocity innovations just prior to crash - current master
![screen shot 2017-07-31 at 4 50 25 pm](https://user-images.githubusercontent.com/3596952/28765920-788658e8-7610-11e7-8606-cda33a6d68f8.png)

velocity innovations just prior to crash - this PR
![screen shot 2017-07-31 at 4 52 05 pm](https://user-images.githubusercontent.com/3596952/28765949-9dc6ac3e-7610-11e7-8315-aa115bf641d0.png)


