### PR TITLE
The EKF can start normally when we don't have magnetometer. 

### DIFF
--- a/EKF/common.h
+++ b/EKF/common.h
@@ -179,6 +179,7 @@ struct dragSample {
 #define MAG_FUSE_TYPE_AUTO      0   // The selection of either heading or 3D magnetometer fusion will be automatic
 #define MAG_FUSE_TYPE_HEADING   1   // Simple yaw angle fusion will always be used. This is less accurate, but less affected by earth field distortions. It should not be used for pitch angles outside the range from -60 to +60 deg
 #define MAG_FUSE_TYPE_3D        2   // Magnetometer 3-axis fusion will always be used. This is more accurate, but more affected by localised earth field distortions
+#define MAG_FUSE_TYPE_NONE		3
 
 // Maximum sensor intervals in usec
 #define GPS_MAX_INTERVAL	5e5

--- a/EKF/ekf.cpp
+++ b/EKF/ekf.cpp
@@ -241,7 +241,7 @@ bool Ekf::initialiseFilter()
 
 	// check to see if we have enough measurements and return false if not
 	bool hgt_count_fail = _hgt_counter <= 2 * _obs_buffer_length;
-	bool mag_count_fail = _mag_counter <= 2 * _obs_buffer_length;
+	bool mag_count_fail = (_params.mag_fusion_type != MAG_FUSE_TYPE_NONE) && (_mag_counter <= 2 * _obs_buffer_length); // 
 	bool ev_count_fail = ((_params.fusion_mode & MASK_USE_EVPOS) || (_params.fusion_mode & MASK_USE_EVYAW)) && (_ev_counter <= 2 * _obs_buffer_length);
 
 	if (hgt_count_fail || mag_count_fail || ev_count_fail) {

--- a/EKF/ekf_helper.cpp
+++ b/EKF/ekf_helper.cpp
@@ -374,8 +374,10 @@ bool Ekf::resetMagHeading(Vector3f &mag_init)
 			// the angle of the projection onto the horizontal gives the yaw angle
 			euler321(2) = -atan2f(mag_earth_pred(1), mag_earth_pred(0)) + _mag_declination;
 
-		} else {
+		} else if(_params.mag_fusion_type == MAG_FUSE_TYPE_NONE){
 			// there is no yaw observation
+			euler321(2) = 0.0f;
+		} else {
 			return false;
 		}
 
@@ -428,8 +430,10 @@ bool Ekf::resetMagHeading(Vector3f &mag_init)
 			// the angle of the projection onto the horizontal gives the yaw angle
 			euler312(0) = -atan2f(mag_earth_pred(1), mag_earth_pred(0)) + _mag_declination;
 
-		} else {
+		} else if(_params.mag_fusion_type == MAG_FUSE_TYPE_NONE){
 			// there is no yaw observation
+			euler312(0) = 0.0f;
+		} else {
 			return false;
 		}
 


### PR DESCRIPTION
We can set the parameter "EKF2_MAG_TYPE" to NONE in QGC when we don't have magnetometer or do not want to use it. And the EKF2 can still work.