### PR TITLE
move code to accumulate imu samples for flow gyro correction

### DIFF
--- a/EKF/control.cpp
+++ b/EKF/control.cpp
@@ -280,6 +280,10 @@ void Ekf::controlExternalVisionFusion()
 
 void Ekf::controlOpticalFlowFusion()
 {
+	// accumulate the bias corrected delta angles from the navigation sensor and lapsed time for flow gyro correction
+	_imu_del_ang_of += _imu_sample_delayed.delta_ang;
+	_delta_time_of += _imu_sample_delayed.delta_ang_dt;
+
 	// Check for new optical flow data that has fallen behind the fusion time horizon
 	if (_flow_data_ready) {
 

--- a/EKF/optflow_fusion.cpp
+++ b/EKF/optflow_fusion.cpp
@@ -524,10 +524,6 @@ void Ekf::get_drag_innov_var(float drag_innov_var[2])
 // calculate optical flow gyro bias errors
 void Ekf::calcOptFlowBias()
 {
-	// accumulate the bias corrected delta angles from the navigation sensor and lapsed time
-	_imu_del_ang_of += _imu_sample_delayed.delta_ang;
-	_delta_time_of += _imu_sample_delayed.delta_ang_dt;
-
 	// reset the accumulators if the time interval is too large
 	if (_delta_time_of > 1.0f) {
 		_imu_del_ang_of.setZero();


### PR DESCRIPTION
Before it was using single samples because `calcOptFlowBias()` is only being called when flow is ready.