### PR TITLE
EKF: set wind states to 0 if we are not estimating wind

### DIFF
--- a/EKF/control.cpp
+++ b/EKF/control.cpp
@@ -998,6 +998,8 @@ void Ekf::controlAirDataFusion()
 
 	if (_control_status.flags.wind && airspeed_timed_out && sideslip_timed_out && !(_params.fusion_mode & MASK_USE_DRAG)) {
 		_control_status.flags.wind = false;
+		_state.wind_vel(0) = 0.0f;
+		_state.wind_vel(1) = 0.0f;
 
 	}
 


### PR DESCRIPTION
As described [here](https://github.com/PX4/ecl/issues/328) the consumer of estimated wind speed needs to check the covariance of the wind velocity states in order to know if they are nonzero and hence valid. However, this is not done e.g. [here](https://github.com/PX4/Firmware/blob/master/src/modules/ekf2/ekf2_main.cpp#L1135), or [here](https://github.com/PX4/Firmware/blob/master/src/modules/bottle_drop/bottle_drop.cpp#L514). In order to make it easier for the consumer of the estimated wind speed data I propose to set the states to zero if we know that they are invalid, this since that is the best guess anyway if you don't know the wind.