### PR TITLE
EKF: Enable operation where mag heading is unreliable

### DIFF
--- a/EKF/common.h
+++ b/EKF/common.h
@@ -258,6 +258,10 @@ struct parameters {
 	int32_t mag_fusion_type{0};		///< integer used to specify the type of magnetometer fusion used
 	float mag_acc_gate{0.5f};		///< when in auto select mode, heading fusion will be used when manoeuvre accel is lower than this (m/sec**2)
 	float mag_yaw_rate_gate{0.25f};		///< yaw rate threshold used by mode select logic (rad/sec)
+	int32_t mag_earth_field_bad{0};		///< set to 1 or 2 when the earth magnetic field cannot be used to give a reliable heading.
+						///< A value of 1 will assume yaw = mag_yaw_ground when on the ground and do no yaw or mag fusion in air.
+						///< A value of 2 will assume yaw = mag_yaw_ground when on the ground and do 3-axis mag fusion in the air.
+	float mag_yaw_ground{0.0f};		///< This yaw angle will be used for alignment and fusion when on the ground if earth_mag_field_bad = 1 or 2 (deg)
 
 	// airspeed fusion
 	float tas_innov_gate{5.0f};		///< True Airspeed innovation consistency gate size (STD)

--- a/EKF/common.h
+++ b/EKF/common.h
@@ -262,6 +262,7 @@ struct parameters {
 						///< A value of 1 will assume yaw = mag_yaw_ground when on the ground and do no yaw or mag fusion in air.
 						///< A value of 2 will assume yaw = mag_yaw_ground when on the ground and do 3-axis mag fusion in the air.
 	float mag_yaw_ground{0.0f};		///< This yaw angle will be used for alignment and fusion when on the ground if earth_mag_field_bad = 1 or 2 (deg)
+	float quat_var_limit{0.1f};		///< Maximum quaternion variance sum allowed before synthetic fusion is required to prevent covariance instability
 
 	// airspeed fusion
 	float tas_innov_gate{5.0f};		///< True Airspeed innovation consistency gate size (STD)

--- a/EKF/common.h
+++ b/EKF/common.h
@@ -259,8 +259,8 @@ struct parameters {
 	float mag_acc_gate{0.5f};		///< when in auto select mode, heading fusion will be used when manoeuvre accel is lower than this (m/sec**2)
 	float mag_yaw_rate_gate{0.25f};		///< yaw rate threshold used by mode select logic (rad/sec)
 	int32_t mag_earth_field_bad{0};		///< set to 1 or 2 when the earth magnetic field cannot be used to give a reliable heading.
-						///< A value of 1 will assume yaw = mag_yaw_ground when on the ground and do no yaw or mag fusion in air.
-						///< A value of 2 will assume yaw = mag_yaw_ground when on the ground and do 3-axis mag fusion in the air.
+						///< A value of 1 will assume yaw = mag_yaw_ground when on the ground and do 3-axis mag fusion in the air.
+						///< A value of 2 will assume yaw = mag_yaw_ground when on the ground and do no yaw or mag fusion in air.
 	float mag_yaw_ground{0.0f};		///< This yaw angle will be used for alignment and fusion when on the ground if earth_mag_field_bad = 1 or 2 (deg)
 	float quat_var_limit{0.1f};		///< Maximum quaternion variance sum allowed before synthetic fusion is required to prevent covariance instability
 

--- a/EKF/control.cpp
+++ b/EKF/control.cpp
@@ -1219,7 +1219,7 @@ void Ekf::controlMagFusion()
 					_control_status.flags.in_air && // don't use when on the ground becasue of magnetic anomalies
 					(_flt_mag_align_complete || height_achieved) && // once in-flight field alignment has been performed, ignore relative height
 					((_imu_sample_delayed.time_us - _time_last_movement) < 2 * 1000 * 1000) && // Using 3-axis fusion for a minimum period after to allow for false negatives
-					!(_params.mag_earth_field_bad == 1); // don't use if explicitly prohibited by parameter
+					!(_params.mag_earth_field_bad == 2); // don't use if explicitly prohibited by parameter
 
 			// Quaternion variance has grown too high and needs to be constrained to prevent instability of the covariance matrix
 			bool high_quat_var = (P[0][0] + P[1][1] + P[2][2] + P[3][3]) > _params.quat_var_limit;

--- a/EKF/control.cpp
+++ b/EKF/control.cpp
@@ -1221,8 +1221,11 @@ void Ekf::controlMagFusion()
 					((_imu_sample_delayed.time_us - _time_last_movement) < 2 * 1000 * 1000) && // Using 3-axis fusion for a minimum period after to allow for false negatives
 					!(_params.mag_earth_field_bad == 1); // don't use if explicitly prohibited by parameter
 
+			// Quaternion variance has grown too high and needs to be constrained to prevent instability of the covariance matrix
+			bool high_quat_var = (P[0][0] + P[1][1] + P[2][2] + P[3][3]) > _params.quat_var_limit;
+
 			// Earth field quality insufficient to use the horizontal projection for yaw estimation
-			bool in_air_mag_hdg_prohibited = ((_params.mag_earth_field_bad == 1) || (_params.mag_earth_field_bad == 2));
+			bool in_air_mag_hdg_prohibited = ((_params.mag_earth_field_bad == 1) || (_params.mag_earth_field_bad == 2)) && !high_quat_var;
 
 			// Do not use mag heading fusion in air if earth field is close to vertical because small mag and tilt errors
 			// can produce large yaw errors.  We can use it on ground by using an assumed heading measurement

--- a/EKF/control.cpp
+++ b/EKF/control.cpp
@@ -1218,9 +1218,16 @@ void Ekf::controlMagFusion()
 			bool use_3D_fusion = _control_status.flags.tilt_align && // Use of 3D fusion requires valid tilt estimates
 					_control_status.flags.in_air && // don't use when on the ground becasue of magnetic anomalies
 					(_flt_mag_align_complete || height_achieved) && // once in-flight field alignment has been performed, ignore relative height
-					((_imu_sample_delayed.time_us - _time_last_movement) < 2 * 1000 * 1000); // Using 3-axis fusion for a minimum period after to allow for false negatives
+					((_imu_sample_delayed.time_us - _time_last_movement) < 2 * 1000 * 1000) && // Using 3-axis fusion for a minimum period after to allow for false negatives
+					!(_params.mag_earth_field_bad == 1); // don't use if explicitly prohibited by parameter
 
-			// perform switch-over
+			// Earth field quality insufficient to use the horizontal projection for yaw estimation
+			bool in_air_mag_hdg_prohibited = ((_params.mag_earth_field_bad == 1) || (_params.mag_earth_field_bad == 2));
+
+			// Do not use mag heading fusion in air if earth field is close to vertical because small mag and tilt errors
+			// can produce large yaw errors.  We can use it on ground by using an assumed heading measurement
+			bool use_hdg_fusion = !use_3D_fusion && !(_control_status.flags.in_air && in_air_mag_hdg_prohibited);
+
 			if (use_3D_fusion) {
 				if (!_control_status.flags.mag_3D) {
 					if (!_flt_mag_align_complete) {
@@ -1258,9 +1265,9 @@ void Ekf::controlMagFusion()
 					for (uint8_t index = 0; index <= 5; index ++) {
 						_saved_mag_variance[index] = P[index+16][index+16];
 					}
-					_control_status.flags.mag_3D = false;
 				}
-				_control_status.flags.mag_hdg = true;
+				_control_status.flags.mag_3D = false;
+				_control_status.flags.mag_hdg = use_hdg_fusion;
 			}
 
 			/*

--- a/EKF/ekf.cpp
+++ b/EKF/ekf.cpp
@@ -270,6 +270,9 @@ bool Ekf::initialiseFilter()
 		// calculate the averaged magnetometer reading
 		Vector3f mag_init = _mag_filt_state;
 
+		// set a yaw value we will use as a default if no other yaw estimate is available
+		_last_inflight_yaw = math::radians(_params.mag_yaw_ground);
+
 		// calculate the initial magnetic field and yaw alignment
 		_control_status.flags.yaw_align = resetMagHeading(mag_init);
 

--- a/EKF/ekf.h
+++ b/EKF/ekf.h
@@ -621,6 +621,9 @@ private:
 	// rotate quaternion covariances into variances for an equivalent rotation vector
 	Vector3f calcRotVecVariances();
 
+	// calculate the yaw variance from the quaternion covariances
+	float calcYawVariance();
+
 	// initialise the quaternion covariances using rotation vector variances
 	void initialiseQuatCovariances(Vector3f &rot_vec_var);
 

--- a/EKF/ekf_helper.cpp
+++ b/EKF/ekf_helper.cpp
@@ -506,6 +506,10 @@ bool Ekf::resetMagHeading(Vector3f &mag_init)
 			// calculate the yaw angle for a 312 sequence
 			euler321(2) = atan2f(R_to_earth_ev(1, 0), R_to_earth_ev(0, 0));
 
+		} else if ((_params.mag_earth_field_bad == 1) || (_params.mag_earth_field_bad == 2)) {
+			// use best estimate
+			euler321(2) = _last_inflight_yaw;
+
 		} else if (_params.mag_fusion_type <= MAG_FUSE_TYPE_AUTOFW) {
 			// rotate the magnetometer measurements into earth frame using a zero yaw angle
 			Vector3f mag_earth_pred = R_to_earth * _mag_sample_delayed.mag;
@@ -559,6 +563,10 @@ bool Ekf::resetMagHeading(Vector3f &mag_init)
 			Dcmf R_to_earth_ev(_ev_sample_delayed.quat);	// transformation matrix from body to world frame
 			// calculate the yaw angle for a 312 sequence
 			euler312(0) = atan2f(-R_to_earth_ev(0, 1), R_to_earth_ev(1, 1));
+
+		} else if ((_params.mag_earth_field_bad == 1) || (_params.mag_earth_field_bad == 2)) {
+			// use best estimate
+			euler312(0) = _last_inflight_yaw;
 
 		} else if (_params.mag_fusion_type <= MAG_FUSE_TYPE_AUTOFW) {
 			// rotate the magnetometer measurements into earth frame using a zero yaw angle
@@ -1337,6 +1345,38 @@ Vector3f Ekf::calcRotVecVariances()
 	}
 
 	return rot_var_vec;
+}
+
+// calculate the yaw variance from the quaternion covariances
+float Ekf::calcYawVariance()
+{
+	float yaw_variance;
+	float q0, q3;
+
+	if (_state.quat_nominal(0) >= 0.0f) {
+		q0 = _state.quat_nominal(0);
+		q3 = _state.quat_nominal(3);
+	} else {
+		q0 = -_state.quat_nominal(0);
+		q3 = -_state.quat_nominal(3);
+	}
+	float t2 = q0*q0;
+	float t3 = acosf(q0);
+	float t4 = -t2+1.0f;
+	float t5 = t2-1.0f;
+	if ((t4 > 1e-9f) && (t5 < -1e-9f)) {
+		float t6 = 1.0f/t5;
+		float t8 = powf(t4,-1.5f);
+		float t11 = 1.0f/sqrtf(t4);
+		float t15 = q3*t6*2.0f;
+		float t16 = q0*q3*t3*t8*2.0f;
+		float t17 = t15+t16;
+		yaw_variance = t17*(P[0][0]*t17+P[3][0]*t3*t11*2.0f)+t3*t11*(P[0][3]*t17+P[3][3]*t3*t11*2.0f)*2.0f;
+	} else {
+		yaw_variance = 4.0f * P[3][3];
+	}
+
+	return yaw_variance;
 }
 
 // initialise the quaternion covariances using rotation vector variances

--- a/EKF/estimator_interface.cpp
+++ b/EKF/estimator_interface.cpp
@@ -570,3 +570,22 @@ void EstimatorInterface::print_status() {
 	ECL_INFO("output vert buffer: %d (%d Bytes)", _output_vert_buffer.get_length(), _output_vert_buffer.get_total_size());
 	ECL_INFO("drag buffer: %d (%d Bytes)", _drag_buffer.get_length(), _drag_buffer.get_total_size());
 }
+
+// return Euler yaw angle  in radians at output time horizon using the best conditioned of a 321 or 312 sequence to avoid gimbal lock
+float EstimatorInterface::getOutputYawAngle(void)
+{
+	// determine if a 321 or 312 Euler sequence is best
+	float yaw_angle;
+	if (fabsf(_R_to_earth_now(2, 0)) < fabsf(_R_to_earth_now(2, 1))) {
+		// use a 321 sequence
+		yaw_angle = atan2f(_R_to_earth_now(1, 0), _R_to_earth_now(0, 0));
+
+	} else {
+		// Use a 312 sequence
+		// See http://www.atacolorado.com/eulersequences.doc
+		yaw_angle = atan2f(-_R_to_earth_now(0, 1), _R_to_earth_now(1, 1));
+
+	}
+
+	return yaw_angle;
+}


### PR DESCRIPTION
This PR adds a parameter controlled option that enables operation in environments where the earths magnetic field is either distorted or has insufficient horizontal strength to provide a reliable yaw estimate.

It has been tested using  https://github.com/priseborough/Firmware/tree/ekfHighLatMag-wip 

and 

'make posix_sitl_default gazebo_standard_vtol'

using EKF2_MAGEF_BAD = 0, 1 or 2 and EKF2_MAG_YAWGND = 90.0 to match the simulation initial yaw.

SITL TEST RESULTS

https://logs.px4.io/plot_app?log=399b212a-0a3e-4d8c-b0a9-5256adb2678a
EKF2_MAGEF_BAD = 0 : Normal mag heading fusion in the ground with a mixture of heading and 3D fusion in the air.
![screen shot 2017-10-13 at 12 31 12 pm](https://user-images.githubusercontent.com/3596952/31526518-0c7accaa-b013-11e7-8f3c-5d925cd89e6c.png)

https://logs.px4.io/plot_app?log=be4e651e-00dc-45f2-af9e-c89ee91ddf03
EKF2_MAGEF_BAD = 1 : Static heading fusion in the ground with no fusion of mag data in air.
![screen shot 2017-10-13 at 12 31 26 pm](https://user-images.githubusercontent.com/3596952/31526519-1046ed8c-b013-11e7-83a2-577bf183e3e8.png)

https://logs.px4.io/plot_app?log=a13c0c5f-9278-4900-b888-d2e1d0a56ed2
EKF2_MAGEF_BAD = 2 : Static heading fusion in the ground. 3-axis mag fusion is used when selected, mag heading fusion is blocked.
![screen shot 2017-10-13 at 12 31 38 pm](https://user-images.githubusercontent.com/3596952/31526522-1a1ca98c-b013-11e7-88d1-1e8977a5cd03.png)