### PR TITLE
EKF: Fix bug when resetting position and velocities for fw due to som…

### DIFF
--- a/EKF/control.cpp
+++ b/EKF/control.cpp
@@ -454,6 +454,8 @@ void Ekf::controlGpsFusion()
 				if (_control_status.flags.fixed_wing) {
 					// if flying a fixed wing aircraft, do a complete reset that includes yaw, velocity and position
 					realignYawGPS();
+					resetVelocity();
+					resetPosition();
 				} else {
 					resetVelocity();
 					resetPosition();

--- a/EKF/ekf_helper.cpp
+++ b/EKF/ekf_helper.cpp
@@ -414,10 +414,6 @@ bool Ekf::realignYawGPS()
 			// update transformation matrix from body to world frame using the current state estimate
 			_R_to_earth = quat_to_invrotmat(_state.quat_nominal);
 
-			// reset the velocity and posiiton states as they will be inaccurate due to bad yaw
-			resetVelocity();
-			resetPosition();
-
 			// Use the last magnetometer measurements to reset the field states
 			_state.mag_B.zero();
 			_state.mag_I = _R_to_earth * _mag_sample_delayed.mag;


### PR DESCRIPTION
…ething else than bad yaw estimate

There was a bug for fixed wing and position/velocity reset. If the estimator needs to reset the position and velocity states due to something else than bad yaw estimate the EKF would just carry on indefinitely without doing anything.