### PR TITLE
EKF: Improve handling of magnetometer errors

### DIFF
--- a/EKF/control.cpp
+++ b/EKF/control.cpp
@@ -136,6 +136,11 @@ void Ekf::controlFusionModes()
 			&& (_time_last_imu - _time_last_vel_fuse > _params.no_aid_timeout_max)
 			&& (_time_last_imu - _time_last_of_fuse > _params.no_aid_timeout_max);
 
+	// a combination of bad magnetometer and velocity or position innvovations usually indicates a bad yaw that the vehicle cannot recover from
+	// unless it is fixed wing type
+	_bad_velpos_yaw = (_fault_status.flags.bad_mag_hdg || _fault_status.flags.bad_mag_x  || _fault_status.flags.bad_mag_y || _fault_status.flags.bad_mag_z)
+			&& (_fault_status.flags.bad_vel_N || _fault_status.flags.bad_vel_E);
+
 }
 
 void Ekf::controlExternalVisionFusion()

--- a/EKF/ekf.h
+++ b/EKF/ekf.h
@@ -361,6 +361,7 @@ private:
 	bool _flt_mag_align_complete{true};	///< true when the in-flight mag field alignment has been completed
 	uint64_t _time_last_movement{0};	///< last system time that sufficient movement to use 3-axis magnetometer fusion was detected (uSec)
 	float _saved_mag_variance[6] {};	///< magnetic field state variances that have been saved for use at the next initialisation (Gauss**2)
+	uint64_t _time_last_flt_align{0};	///< system time of the last _flt_mag_align_complete event (uSec)
 
 	gps_check_fail_status_u _gps_check_fail_status{};
 

--- a/EKF/ekf_helper.cpp
+++ b/EKF/ekf_helper.cpp
@@ -396,6 +396,7 @@ bool Ekf::realignYawGPS()
 				// forward direction takeoff or launch and therefore the inertial and GPS ground course discrepancy is due to yaw error
 				euler321(2) += courseYawError;
 				_flt_mag_align_complete = true;
+				_time_last_flt_align = _imu_sample_delayed.time_us;
 
 			} else if (_control_status.flags.wind) {
 				// we have previously aligned yaw in-flight and have wind estimates so set the yaw such that the vehicle nose is

--- a/EKF/ekf_helper.cpp
+++ b/EKF/ekf_helper.cpp
@@ -920,7 +920,7 @@ void Ekf::get_ekf_gpos_accuracy(float *ekf_eph, float *ekf_epv, bool *dead_recko
 	// If we are dead-reckoning, use the innovations as a conservative alternate measure of the horizontal position error
 	// The reason is that complete rejection of measurements is often casued by heading misalignment or inertial sensing errors
 	// and using state variances for accuracy reporting is overly optimistic in these situations
-	if (_is_dead_reckoning && (_control_status.flags.gps || _control_status.flags.ev_pos)) {
+	if ((_is_dead_reckoning || _bad_velpos_yaw) && (_control_status.flags.gps || _control_status.flags.ev_pos)) {
 		hpos_err = math::max(hpos_err, sqrtf(_vel_pos_innov[3] * _vel_pos_innov[3] + _vel_pos_innov[4] * _vel_pos_innov[4]));
 
 	}
@@ -954,7 +954,7 @@ void Ekf::get_ekf_lpos_accuracy(float *ekf_eph, float *ekf_epv, bool *dead_recko
 	// If we are dead-reckoning, use the innovations as a conservative alternate measure of the horizontal position error
 	// The reason is that complete rejection of measurements is often casued by heading misalignment or inertial sensing errors
 	// and using state variances for accuracy reporting is overly optimistic in these situations
-	if (_is_dead_reckoning && (_control_status.flags.gps || _control_status.flags.ev_pos)) {
+	if ((_is_dead_reckoning || _bad_velpos_yaw)  && (_control_status.flags.gps || _control_status.flags.ev_pos)) {
 		hpos_err = math::max(hpos_err, sqrtf(_vel_pos_innov[3] * _vel_pos_innov[3] + _vel_pos_innov[4] * _vel_pos_innov[4]));
 
 	}
@@ -989,7 +989,7 @@ void Ekf::get_ekf_vel_accuracy(float *ekf_evh, float *ekf_evv, bool *dead_reckon
 	// and using state variances for accuracy reporting is overly optimistic in these situations
 	float vel_err_conservative = 0.0f;
 
-	if (_is_dead_reckoning) {
+	if ((_is_dead_reckoning || _bad_velpos_yaw)) {
 		if (_control_status.flags.opt_flow) {
 			float gndclearance = math::max(_params.rng_gnd_clearance, 0.1f);
 			vel_err_conservative = math::max((_terrain_vpos - _state.pos(2)),

--- a/EKF/estimator_interface.h
+++ b/EKF/estimator_interface.h
@@ -421,6 +421,7 @@ protected:
 	innovation_fault_status_u _innov_check_fail_status{};
 
 	bool _is_dead_reckoning{false};	// true if we are no longer fusing measurements that constrain horizontal velocity drift
+	bool _bad_velpos_yaw{false};	// true if the yaw and velocity or position innovations are failing checks
 
 	// IMU vibration monitoring
 	Vector3f _delta_ang_prev;	// delta angle from the previous IMU measurement


### PR DESCRIPTION
This PR contains the following improvements:

1) The use of 3-axis fusion is enforced for the first 30 seconds after the first in-flight magnetic yaw alignment. This reduces the possibility of switching back to magnetic yaw fusion when the mag field state estimates have not stabilised. Doing so can result in  large yaw errors and loss of navigation. 

2) The time for the no movement test to pass before switching back from 3-axis to magnetic yaw fusion has been increased from 2 to 5 seconds to allow the field states to relearn aster a sudden yaw rotation.

3) If magnetometer innovations are failing along with velocity or position, then velocity and position estimates are flagged as invalid because this combination of sensor inconsistency is nearly always caused by an invalid yaw angle that makes inertial navigation impossible until the yaw error is corrected.