### PR TITLE
EKF: Add method to enable the IMU bias states to be reset externally

### DIFF
--- a/EKF/covariance.cpp
+++ b/EKF/covariance.cpp
@@ -91,6 +91,9 @@ void Ekf::initialiseCovariance()
 	_prev_dvel_bias_var(1) = P[14][14] = P[13][13];
 	_prev_dvel_bias_var(2) = P[15][15] = P[13][13];
 
+	// record IMU bias state covariance reset time - used to prevent resets being performed too often
+	_last_imu_bias_cov_reset_us = _imu_sample_delayed.time_us;
+
 	// variances for optional states
 
 	// earth frame and body frame magnetic field

--- a/EKF/ekf.h
+++ b/EKF/ekf.h
@@ -145,6 +145,13 @@ public:
 	*/
 	void get_ekf_ctrl_limits(float *vxy_max, bool *limit_hagl);
 
+	/*
+	Reset all IMU bias states and covariances to initial alignment values.
+	Use when the IMU sensor has changed.
+	Returns true if reset performed, false if rejected due to less than 10 seconds lapsed since last reset.
+	*/
+	bool reset_imu_bias();
+
 	void get_vel_var(Vector3f &vel_var);
 
 	void get_pos_var(Vector3f &pos_var);
@@ -281,6 +288,8 @@ private:
 
 	uint64_t _time_acc_bias_check{0};	///< last time the  accel bias check passed (uSec)
 	uint64_t _delta_time_baro_us{0};	///< delta time between two consecutive delayed baro samples from the buffer (uSec)
+
+	uint64_t _last_imu_bias_cov_reset_us{0};	///< time the last reset of IMU delta angle and velocity state covariances was performed (uSec)
 
 	Vector3f _earth_rate_NED;	///< earth rotation vector (NED) in rad/s
 

--- a/EKF/estimator_interface.h
+++ b/EKF/estimator_interface.h
@@ -192,6 +192,13 @@ public:
 	// set vehicle landed status data
 	void set_in_air_status(bool in_air) {_control_status.flags.in_air = in_air;}
 
+	/*
+	Reset all IMU bias states and covariances to initial alignment values.
+	Use when the IMU sensor has changed.
+	Returns true if reset performed, false if rejected due to less than 10 seconds lapsed since last reset.
+	*/
+	virtual bool reset_imu_bias() = 0;
+
 	// get vehicle landed status data
 	bool get_in_air_status() {return _control_status.flags.in_air;}
 


### PR DESCRIPTION
This will be required as part of the fixes to IMU sensor fallback logic raised here https://github.com/PX4/Firmware/issues/8186

Test results will be added when the supporting code on the other side of the interface has been completed.