### PR TITLE
EKF: Improve accuracy during sustained yaw spinning

### DIFF
--- a/EKF/estimator_interface.h
+++ b/EKF/estimator_interface.h
@@ -349,7 +349,7 @@ public:
 		return _imu_updated;
 	}
 
-	static const unsigned FILTER_UPDATE_PERIOD_MS = 12;	// ekf prediction period in milliseconds - this should ideally be an integer multiple of the IMU time delta
+	static const unsigned FILTER_UPDATE_PERIOD_MS = 8;	// ekf prediction period in milliseconds - this should ideally be an integer multiple of the IMU time delta
 
 protected:
 


### PR DESCRIPTION
Sustained yaw spinning during hover can result in a gradual divergence of the Z accel bias estimate and increase in vertical position and velocity innovations. I some cases this can result in an estimation error that prevents the height controller completing a landing.

This is caused by the covariance prediction slightly lagging the vehicle motion due to the 12msec prediction time step (the output observer runs at the IMU rate of 4msec).

Here are the vertical innovations for replay of a log that demonstrates the behaviour 

![screen shot 2017-11-02 at 5 43 18 pm](https://user-images.githubusercontent.com/3596952/32315754-8b2f0cfc-c001-11e7-88aa-ad34d5f9eeeb.png)

Reducing the EKF internal prediction time step from 12 to 8 msec eliminated the problem.

![screen shot 2017-11-02 at 5 40 07 pm](https://user-images.githubusercontent.com/3596952/32315781-a8f7b6c6-c001-11e7-9445-ea9fa6f24c8f.png)

**NOTE**

**Requires an increase in RAM allocation of 837 Bytes to allow for the longer IMU and output predictor buffers that can be created.**

**Processor utilisation on a pixracer board increased by 1.5 %**