### PR TITLE
EKF: Protect against ground effect induced static pressure rise

### DIFF
--- a/EKF/common.h
+++ b/EKF/common.h
@@ -192,6 +192,9 @@ struct dragSample {
 #define BADACC_PROBATION  (uint64_t)10e6	///< Period of time that accel data declared bad must continuously pass checks to be declared good again (uSec)
 #define BADACC_BIAS_PNOISE	4.9f	///< The delta velocity process noise is set to this when accel data is declared bad (m/sec**2)
 
+// ground effect compensation
+#define GNDEFFECT_TIMEOUT	10E6	///< Maximum period of time that ground effect protection will be active after it was last turned on (uSec)
+
 struct parameters {
 	// measurement source control
 	int32_t fusion_mode{MASK_USE_GPS};		///< bitmasked integer that selects which aiding sources will be used
@@ -235,6 +238,8 @@ struct parameters {
 	float baro_innov_gate{5.0f};		///< barometric and GPS height innovation consistency gate size (STD)
 	float posNE_innov_gate{5.0f};		///< GPS horizontal position innovation consistency gate size (STD)
 	float vel_innov_gate{5.0f};		///< GPS velocity innovation consistency gate size (STD)
+	float gnd_effect_deadzone{5.0f};	///< Size of deadzone applied to negative baro innovations when ground effect compensation is active (m)
+	float gnd_effect_max_hgt{0.5f};		///< Height above ground at which baro ground effect becomes insignificant (m)
 
 	// magnetometer fusion
 	float mag_heading_noise{3.0e-1f};	///< measurement noise used for simple heading fusion (rad)
@@ -416,7 +421,8 @@ union filter_control_status_u {
 		uint32_t update_mag_states_only   : 1; ///< 16 - true when only the magnetometer states are updated by the magnetometer
 		uint32_t fixed_wing  : 1; ///< 17 - true when the vehicle is operating as a fixed wing vehicle
 		uint32_t mag_fault   : 1; ///< 18 - true when the magnetomer has been declared faulty and is no longer being used
-		uint32_t fuse_aspd   : 1; ///< 19 - true when airspedd measurements are being fused
+		uint32_t fuse_aspd   : 1; ///< 19 - true when airspeed measurements are being fused
+		uint32_t gnd_effect  : 1; ///< 20 - true when protection from ground effect induced static pressure rise is active
 	} flags;
 	uint32_t value;
 };

--- a/EKF/estimator_interface.h
+++ b/EKF/estimator_interface.h
@@ -208,6 +208,15 @@ public:
 	// set flag if synthetic sideslip measurement should be fused
 	void set_fuse_beta_flag(bool fuse_beta) {_control_status.flags.fuse_beta = (fuse_beta && _control_status.flags.in_air);}
 
+	// set flag if static pressure rise due to ground effect is expected
+	// use _params.gnd_effect_deadzone to adjust for expected rise in static pressure
+	// flag will clear after GNDEFFECT_TIMEOUT uSec
+	void set_gnd_effect_flag(bool gnd_effect)
+	{
+		_control_status.flags.gnd_effect = gnd_effect;
+		_time_last_gnd_effect_on = _time_last_imu;
+	}
+
 	// set flag if only only mag states should be updated by the magnetometer
 	void set_update_mag_states_only_flag(bool update_mag_states_only) {_control_status.flags.update_mag_states_only = update_mag_states_only;}
 
@@ -473,6 +482,7 @@ protected:
 	uint64_t _time_last_airspeed{0};	// timestamp of last airspeed measurement in microseconds
 	uint64_t _time_last_ext_vision{0}; // timestamp of last external vision measurement in microseconds
 	uint64_t _time_last_optflow{0};
+	uint64_t _time_last_gnd_effect_on{0};	//last time the baro ground effect compensation was turned on externally (uSec)
 
 	fault_status_u _fault_status{};
 


### PR DESCRIPTION
Addresses #217 

Can be used to reduced the effect of ground effect induced static pressure rise during takeoff and landing. When rotary wing vehicles take off, the rotor wash often induces an increase in static pressure which causes the baro height to read low with a transient that is typically up to 5m for commonly used disc loadings and fuselage and rotor relative positions heights. The symptons observed by the pilot are typically an overshoot of the initial height demand, followed by a slow descent as the estimator recovers.

- This PR adds a method which applies a dead-band to the vertical position innovation if using baro for height and if in the ground effect region during and just after takeoff.
- The method needs to be activated externally.
- The method turns off automatically after 10 seconds or if a specified height is gained.

Requires changes on the firmware side to use. The following code was used to test it on multiple takeoffs: https://github.com/priseborough/Firmware/tree/ekfGndEffectComp-wip

Indoor test log: https://logs.px4.io/plot_app?log=9dfecbf4-6d21-4077-8508-76f54fc280d9

![screen shot 2017-11-04 at 6 52 09 pm](https://user-images.githubusercontent.com/3596952/32403561-48e75bec-c191-11e7-9dda-b078bd854a4c.png)
