### PR TITLE
EKF RingBuffer allocation minor improvements + print memory usage

### DIFF
--- a/EKF/RingBuffer.h
+++ b/EKF/RingBuffer.h
@@ -155,6 +155,8 @@ public:
 		return false;
 	}
 
+	int get_total_size() { return sizeof(*this) + sizeof(data_type) * _size; }
+
 private:
 	data_type *_buffer{nullptr};
 

--- a/EKF/RingBuffer.h
+++ b/EKF/RingBuffer.h
@@ -45,7 +45,13 @@ template <typename data_type>
 class RingBuffer
 {
 public:
-	RingBuffer() = default;
+	RingBuffer() {
+		if (allocate(1)) {
+			// initialize with one empty sample
+			data_type d = {};
+			push(d);
+		}
+	}
 	~RingBuffer() { delete[] _buffer; }
 
 	// no copy, assignment, move, move assignment
@@ -72,8 +78,8 @@ public:
 		_tail = 0;
 
 		// set the time elements to zero so that bad data is not retrieved from the buffers
-		for (unsigned index = 0; index < _size; index++) {
-			_buffer[index].time_us = 0;
+		for (uint8_t index = 0; index < _size; index++) {
+			_buffer[index] = {};
 		}
 		_first_write = true;
 
@@ -149,13 +155,6 @@ public:
 		return false;
 	}
 
-
-
-	// return ttrue if allocated
-	unsigned is_allocated()
-	{
-		return (_buffer != NULL);
-	}
 private:
 	data_type *_buffer{nullptr};
 

--- a/EKF/estimator_interface.cpp
+++ b/EKF/estimator_interface.cpp
@@ -519,3 +519,20 @@ bool EstimatorInterface::local_position_is_valid()
 	// return true if we are not doing unconstrained free inertial navigation
 	return !inertial_dead_reckoning();
 }
+
+void EstimatorInterface::print_status() {
+	ECL_INFO("local position valid: %s", local_position_is_valid() ? "yes" : "no");
+	ECL_INFO("global position valid: %s", global_position_is_valid() ? "yes" : "no");
+
+	ECL_INFO("imu buffer: %d (%d Bytes)", _imu_buffer.get_length(), _imu_buffer.get_total_size());
+	ECL_INFO("gps buffer: %d (%d Bytes)", _gps_buffer.get_length(), _gps_buffer.get_total_size());
+	ECL_INFO("mag buffer: %d (%d Bytes)", _mag_buffer.get_length(), _mag_buffer.get_total_size());
+	ECL_INFO("baro buffer: %d (%d Bytes)", _baro_buffer.get_length(), _baro_buffer.get_total_size());
+	ECL_INFO("range buffer: %d (%d Bytes)", _range_buffer.get_length(), _range_buffer.get_total_size());
+	ECL_INFO("airspeed buffer: %d (%d Bytes)", _airspeed_buffer.get_length(), _airspeed_buffer.get_total_size());
+	ECL_INFO("flow buffer: %d (%d Bytes)", _flow_buffer.get_length(), _flow_buffer.get_total_size());
+	ECL_INFO("ext vision buffer: %d (%d Bytes)", _ext_vision_buffer.get_length(), _ext_vision_buffer.get_total_size());
+	ECL_INFO("output buffer: %d (%d Bytes)", _output_buffer.get_length(), _output_buffer.get_total_size());
+	ECL_INFO("output vert buffer: %d (%d Bytes)", _output_vert_buffer.get_length(), _output_vert_buffer.get_total_size());
+	ECL_INFO("drag buffer: %d (%d Bytes)", _drag_buffer.get_length(), _drag_buffer.get_total_size());
+}

--- a/EKF/estimator_interface.h
+++ b/EKF/estimator_interface.h
@@ -463,16 +463,6 @@ protected:
 	bool _ev_buffer_fail{false};
 	bool _drag_buffer_fail{false};
 
-	// observation buffer final allocation succeeded
-	bool _gps_buffer_pass{false};
-	bool _mag_buffer_pass{false};
-	bool _baro_buffer_pass{false};
-	bool _range_buffer_pass{false};
-	bool _airspeed_buffer_pass{false};
-	bool _flow_buffer_pass{false};
-	bool _ev_buffer_pass{false};
-	bool _drag_buffer_pass{false};
-
 	uint64_t _time_last_imu{0};	// timestamp of last imu sample in microseconds
 	uint64_t _time_last_gps{0};	// timestamp of last gps measurement in microseconds
 	uint64_t _time_last_mag{0};	// timestamp of last magnetometer measurement in microseconds

--- a/EKF/estimator_interface.h
+++ b/EKF/estimator_interface.h
@@ -352,6 +352,8 @@ public:
 		return _imu_updated;
 	}
 
+	void print_status();
+
 	static const unsigned FILTER_UPDATE_PERIOD_MS = 8;	// ekf prediction period in milliseconds - this should ideally be an integer multiple of the IMU time delta
 
 protected:


### PR DESCRIPTION
Expanding the simple status for command line debugging. This is crude, but helps give you an idea where the memory is going.

	nsh> ekf2 status
	INFO  [ekf2] time slip: -40 us
	INFO  [ekf2] Ekf2 class: 6896 Bytes
	INFO  [ekf2] Ekf2 stack size: 6600 Bytes
	INFO  [lib__ecl] local position valid: no
	INFO  [lib__ecl] global position valid: no
	INFO  [lib__ecl] imu buffer: 22 (888 Bytes)
	INFO  [lib__ecl] gps buffer: 14 (680 Bytes)
	INFO  [lib__ecl] mag buffer: 14 (344 Bytes)
	INFO  [lib__ecl] baro buffer: 14 (232 Bytes)
	INFO  [lib__ecl] range buffer: 1 (24 Bytes)
	INFO  [lib__ecl] airspeed buffer: 1 (24 Bytes)
	INFO  [lib__ecl] flow buffer: 1 (56 Bytes)
	INFO  [lib__ecl] ext vision buffer: 1 (56 Bytes)
	INFO  [lib__ecl] output buffer: 22 (1064 Bytes)
	INFO  [lib__ecl] output vert buffer: 22 (536 Bytes)
	INFO  [lib__ecl] drag buffer: 1 (24 Bytes)

Ideas for future memory savings
 - take a pass over the EstimatorInterface, Ekf, Ekf2 classes and remove anything that doesn't need to persist. What can be calculated as needed? What's already available in another form?
 - use relative timestamps where possible?
 - ekf2_main stack size can be reduced a bit with a small structural change.
 - don't keep params on both sides