### PR TITLE
EKF: Release flow speed limit progressively

### DIFF
--- a/EKF/ekf.h
+++ b/EKF/ekf.h
@@ -348,6 +348,7 @@ private:
 	Vector3f _flow_gyro_bias;	///< bias errors in optical flow sensor rate gyro outputs (rad/sec)
 	Vector3f _imu_del_ang_of;	///< bias corrected delta angle measurements accumulated across the same time frame as the optical flow rates (rad)
 	float _delta_time_of{0.0f};	///< time in sec that _imu_del_ang_of was accumulated over (sec)
+	float _flow_gnd_spd_max{0.0f};	///< maximum ground speed that the flow sensor can reliably measure (m/s)
 
 	float _mag_declination{0.0f};	///< magnetic declination used by reset and fusion functions (rad)
 


### PR DESCRIPTION
When GPS use is gained whilst flying using optical flow data, the release of the speed limit can cause unexpected change in responsiveness the first time the operator moves the vehicle after the limit is released.

When another source of external aiding (eg GPS) is gained, this patch releases the speed limit as height is gained, but does not reduce it when the vehicle descends,  unless other aiding is lost and optical flow becomes the only source of aiding again.

Flight tested on a px4fmu-v4 board using https://github.com/PX4/Firmware/pull/8223

Test Log: https://logs.px4.io/plot_app?log=4bdc4540-9a52-450a-a14e-afeac2606f3d