### PR TITLE
Reverse the linked list of data_validator_group

### DIFF
--- a/validation/data_validator.cpp
+++ b/validation/data_validator.cpp
@@ -42,7 +42,7 @@
 #include "data_validator.h"
 #include <ecl/ecl.h>
 
-DataValidator::DataValidator(DataValidator *prev_sibling) :
+DataValidator::DataValidator() :
 	_error_mask(ERROR_FLAG_NO_ERROR),
 	_timeout_interval(20000),
 	_time_last(0),
@@ -58,7 +58,7 @@ DataValidator::DataValidator(DataValidator *prev_sibling) :
 	_vibe{0.0f},
 	_value_equal_count(0),
 	_value_equal_count_threshold(VALUE_EQUAL_COUNT_DEFAULT),
-	_sibling(prev_sibling)
+	_sibling(nullptr)
 {
 
 }

--- a/validation/data_validator.h
+++ b/validation/data_validator.h
@@ -48,7 +48,7 @@ class __EXPORT DataValidator {
 public:
 	static const unsigned dimensions = 3;
 
-	DataValidator(DataValidator *prev_sibling = nullptr);
+	DataValidator();
 	virtual ~DataValidator() = default;
 
 	/**
@@ -71,6 +71,12 @@ public:
 	 * @return		the next sibling
 	 */
 	DataValidator*		sibling() { return _sibling; }
+
+	/**
+	 * Set the sibling to the next node in the group
+	 *
+	 */
+	void			sibling(DataValidator* sibling) { _sibling = sibling; }
 
 	/**
 	 * Get the confidence of this validator

--- a/validation/data_validator_group.cpp
+++ b/validation/data_validator_group.cpp
@@ -45,19 +45,31 @@
 
 DataValidatorGroup::DataValidatorGroup(unsigned siblings) :
 	_first(nullptr),
+	_last(nullptr),
 	_curr_best(-1),
 	_prev_best(-1),
 	_first_failover_time(0),
 	_toggle_count(0)
 {
-	DataValidator *next = _first;
+	DataValidator *next = nullptr;
+	DataValidator *prev = nullptr;
 
 	for (unsigned i = 0; i < siblings; i++) {
-		next = new DataValidator(next);
+		next = new DataValidator();
+		if(i == 0) {
+			_first = next;
+		}
+		else {
+			prev->sibling(next);
+		}
+		prev = next;
 	}
 
-	_first = next;
-	_timeout_interval_us = _first->get_timeout();
+	_last = next;
+
+	if(_first) {
+		_timeout_interval_us = _first->get_timeout();
+	}
 }
 
 DataValidatorGroup::~DataValidatorGroup()
@@ -71,13 +83,14 @@ DataValidatorGroup::~DataValidatorGroup()
 
 DataValidator *DataValidatorGroup::add_new_validator()
 {
-	DataValidator *validator = new DataValidator(_first);
+	DataValidator *validator = new DataValidator();
 	if (!validator) {
 		return nullptr;
 	}
-	_first = validator;
-	_first->set_timeout(_timeout_interval_us);
-	return _first;
+	_last->sibling(validator);
+	_last = validator;
+	_last->set_timeout(_timeout_interval_us);
+	return _last;
 }
 
 void

--- a/validation/data_validator_group.h
+++ b/validation/data_validator_group.h
@@ -133,7 +133,8 @@ public:
 
 
 private:
-	DataValidator *_first;		/**< sibling in the group */
+	DataValidator *_first;		/**< first node in the group */
+	DataValidator *_last;		/**< last node in the group */
 	uint32_t _timeout_interval_us; /**< currently set timeout */
 	int _curr_best;		/**< currently best index */
 	int _prev_best;		/**< the previous best index */


### PR DESCRIPTION
---

maintain a first node for search from index 0 to fix issue PX4/Firmware#8644

before fix:
I tested with jlink debug on real hardware
I have 2 mag sensor connected to board, mag0 have orb priority 75(ORB_PRIO_DEFAULT), mag1 have orb priority 125(ORB_PRIO_VERY_HIGH). mag0 publish first, and then mag1, image below show screen shot of breakpoint at the moment before adding mag1 to validator group, you can see **_first** is mag0 (which has priority 75)
![image](https://user-images.githubusercontent.com/4757414/34858455-707841c8-f78b-11e7-8f10-24aa1fa53007.png)

---

this image is screen shot of breakpoint at the first time mag0 data put to validator after adding mag1, see the mess here, **_first** is actually the last one we added to group(mag1), **_priority** field is empty(not set yet), but we are putting mag0 data!
![image](https://user-images.githubusercontent.com/4757414/34858464-7de39e20-f78b-11e7-9810-534bc285ce73.png)

---

this image is screen shot after bug fixed
![image](https://user-images.githubusercontent.com/4757414/34858478-95863254-f78b-11e7-835f-01ba35172f43.png)