### PR TITLE
Reverse the linked list of data_validator_group #2

### DIFF
--- a/validation/data_validator.cpp
+++ b/validation/data_validator.cpp
@@ -42,7 +42,7 @@
 #include "data_validator.h"
 #include <ecl/ecl.h>
 
-DataValidator::DataValidator(DataValidator *prev_sibling) :
+DataValidator::DataValidator() :
 	_error_mask(ERROR_FLAG_NO_ERROR),
 	_timeout_interval(20000),
 	_time_last(0),
@@ -58,7 +58,7 @@ DataValidator::DataValidator(DataValidator *prev_sibling) :
 	_vibe{0.0f},
 	_value_equal_count(0),
 	_value_equal_count_threshold(VALUE_EQUAL_COUNT_DEFAULT),
-	_sibling(prev_sibling)
+	_sibling(nullptr)
 {
 
 }

--- a/validation/data_validator.h
+++ b/validation/data_validator.h
@@ -48,7 +48,7 @@ class __EXPORT DataValidator {
 public:
 	static const unsigned dimensions = 3;
 
-	DataValidator(DataValidator *prev_sibling = nullptr);
+	DataValidator();
 	virtual ~DataValidator() = default;
 
 	/**
@@ -71,6 +71,12 @@ public:
 	 * @return		the next sibling
 	 */
 	DataValidator*		sibling() { return _sibling; }
+
+	/**
+	 * Set the sibling to the next node in the group
+	 *
+	 */
+	void			sibling(DataValidator* sibling) { _sibling = sibling; }
 
 	/**
 	 * Get the confidence of this validator

--- a/validation/data_validator.h
+++ b/validation/data_validator.h
@@ -76,7 +76,7 @@ public:
 	 * Set the sibling to the next node in the group
 	 *
 	 */
-	void			sibling(DataValidator* sibling) { _sibling = sibling; }
+	void			setSibling(DataValidator* sibling) { _sibling = sibling; }
 
 	/**
 	 * Get the confidence of this validator

--- a/validation/data_validator.h
+++ b/validation/data_validator.h
@@ -76,7 +76,7 @@ public:
 	 * Set the sibling to the next node in the group
 	 *
 	 */
-	void			setSibling(DataValidator* sibling) { _sibling = sibling; }
+	void			setSibling(DataValidator* new_sibling) { _sibling = new_sibling; }
 
 	/**
 	 * Get the confidence of this validator

--- a/validation/data_validator_group.cpp
+++ b/validation/data_validator_group.cpp
@@ -58,9 +58,8 @@ DataValidatorGroup::DataValidatorGroup(unsigned siblings) :
 		next = new DataValidator();
 		if(i == 0) {
 			_first = next;
-		}
-		else {
-			prev->sibling(next);
+		} else {
+			prev->setSibling(next);
 		}
 		prev = next;
 	}
@@ -87,7 +86,7 @@ DataValidator *DataValidatorGroup::add_new_validator()
 	if (!validator) {
 		return nullptr;
 	}
-	_last->sibling(validator);
+	_last->setSibling(validator);
 	_last = validator;
 	_last->set_timeout(_timeout_interval_us);
 	return _last;

--- a/validation/data_validator_group.cpp
+++ b/validation/data_validator_group.cpp
@@ -45,19 +45,31 @@
 
 DataValidatorGroup::DataValidatorGroup(unsigned siblings) :
 	_first(nullptr),
+	_last(nullptr),
 	_curr_best(-1),
 	_prev_best(-1),
 	_first_failover_time(0),
 	_toggle_count(0)
 {
-	DataValidator *next = _first;
+	DataValidator *next = nullptr;
+	DataValidator *prev = nullptr;
 
 	for (unsigned i = 0; i < siblings; i++) {
-		next = new DataValidator(next);
+		next = new DataValidator();
+		if(i == 0) {
+			_first = next;
+		}
+		else {
+			prev->sibling(next);
+		}
+		prev = next;
 	}
 
-	_first = next;
-	_timeout_interval_us = _first->get_timeout();
+	_last = next;
+
+	if(_first) {
+		_timeout_interval_us = _first->get_timeout();
+	}
 }
 
 DataValidatorGroup::~DataValidatorGroup()
@@ -71,13 +83,14 @@ DataValidatorGroup::~DataValidatorGroup()
 
 DataValidator *DataValidatorGroup::add_new_validator()
 {
-	DataValidator *validator = new DataValidator(_first);
+	DataValidator *validator = new DataValidator();
 	if (!validator) {
 		return nullptr;
 	}
-	_first = validator;
-	_first->set_timeout(_timeout_interval_us);
-	return _first;
+	_last->sibling(validator);
+	_last = validator;
+	_last->set_timeout(_timeout_interval_us);
+	return _last;
 }
 
 void

--- a/validation/data_validator_group.h
+++ b/validation/data_validator_group.h
@@ -133,7 +133,8 @@ public:
 
 
 private:
-	DataValidator *_first;		/**< sibling in the group */
+	DataValidator *_first;		/**< first node in the group */
+	DataValidator *_last;		/**< last node in the group */
 	uint32_t _timeout_interval_us; /**< currently set timeout */
 	int _curr_best;		/**< currently best index */
 	int _prev_best;		/**< the previous best index */


### PR DESCRIPTION
This brings back https://github.com/PX4/ecl/pull/377, which got reverted in https://github.com/PX4/ecl/pull/382, because of a CI failure (a variable shadowing problem).