### PR TITLE
EKF: Add missing reset for output observer vertical position derivative

### DIFF
--- a/EKF/ekf_helper.cpp
+++ b/EKF/ekf_helper.cpp
@@ -300,11 +300,23 @@ void Ekf::resetHeight()
 	for (uint8_t i = 0; i < _output_buffer.get_length(); i++) {
 		if (vert_pos_reset) {
 			_output_buffer[i].pos(2) += _state_reset_status.posD_change;
+			_output_vert_buffer[i].vel_d_integ += _state_reset_status.posD_change;
 		}
 
 		if (vert_vel_reset) {
 			_output_buffer[i].vel(2) += _state_reset_status.velD_change;
+			_output_vert_buffer[i].vel_d += _state_reset_status.velD_change;
 		}
+	}
+
+	// add the reset amount to the output observer vertical position state
+	if (vert_pos_reset) {
+		_output_vert_delayed.vel_d_integ = _state.pos(2);
+		_output_vert_new.vel_d_integ = _state.pos(2);
+	}
+	if (vert_vel_reset) {
+		_output_vert_delayed.vel_d = _state.vel(2);
+		_output_vert_new.vel_d = _state.vel(2);
 	}
 }
 


### PR DESCRIPTION
Required to prevent large transients in value returned by get_pos_d_deriv accessor following a vertical state reset event.

Fixes https://github.com/PX4/ecl/issues/390.

Bench tested by adding a time based baro offset of +100m at 50 seconds in ekf2_main.cpp. vertical derivative estimate now resets to same value as velocity following a reset.

![screen shot 2018-01-31 at 11 59 48 am](https://user-images.githubusercontent.com/3596952/35599791-9b8897da-067e-11e8-9c86-4c4f1d5f244a.png)
m