### PR TITLE
In realignYawGPS() reset the wind estimate and dont use it for t…

### DIFF
--- a/EKF/ekf_helper.cpp
+++ b/EKF/ekf_helper.cpp
@@ -398,14 +398,11 @@ bool Ekf::realignYawGPS()
 				euler321(2) += courseYawError;
 				_flt_mag_align_complete = true;
 
-			} else if (_control_status.flags.wind) {
-				// we have previously aligned yaw in-flight and have wind estimates so set the yaw such that the vehicle nose is
-				// aligned with the wind relative GPS velocity vector
-				euler321(2) = atan2f((_gps_sample_delayed.vel(1) - _state.wind_vel(1)) , (_gps_sample_delayed.vel(0) - _state.wind_vel(0)));
-
 			} else {
-				// we don't have wind estimates, so align yaw to the GPS velocity vector
+				// The wind estimate might be bad, so align yaw to the GPS velocity vector disregarding wind
 				euler321(2) = atan2f(_gps_sample_delayed.vel(1) , _gps_sample_delayed.vel(0));
+				resetWindStates();
+				resetWindCovariance();
 
 			}
 


### PR DESCRIPTION
…he yaw align

If a fixed wing experiences a bad heading estimate in cruise flight the wind estimate will most likely be very bad, (due to sideslip and airspeed fusion during the period from the bad heading estimate to the reset). Using this bad wind estimate to re-align the heading is thus risky and should be avoided.

@priseborough interested to hear your opinion