### PR TITLE
EKF: fuse EV with offset instead of incrementally

### DIFF
--- a/EKF/ekf.h
+++ b/EKF/ekf.h
@@ -273,8 +273,7 @@ private:
 
 	// variables used when position data is being fused using a relative position odometry model
 	bool _fuse_hpos_as_odom{false};		///< true when the NE position data is being fused using an odometry assumption
-	Vector3f _pos_meas_prev;		///< previous value of NED position measurement fused using odometry assumption (m)
-	Vector2f _hpos_pred_prev;		///< previous value of NE position state used by odometry fusion (m)
+	Vector3f _pos_ev_offset;		///< position offset from EV frame to estimation frame (m)
 	bool _hpos_prev_available{false};	///< true when previous values of the estimate and measurement are available for use
 	Vector3f _ev_rot_vec_filt;		///< filtered rotation vector defining the rotation from EKF to EV reference (rad)
 	Dcmf _ev_rot_mat;			///< transformation matrix that rotates observations from the EV to the EKF navigation frame


### PR DESCRIPTION
@priseborough Why can't we fuse EV like in this PR? Specially when EV is in NED and we use EV and GPS. In that case the frame is the one from the EV anyways, right?

The reason I want to change it is that the performance with the incremental fusion isn't very good. You can test it by hardcoding https://github.com/PX4/ecl/blob/master/EKF/control.cpp#L262 to `true` and use the simulation `make posix_sitl_default gazebo_iris_opt_flow` with `EKF2_AID_MASK` set to 24. It is drifting heavily.