### PR TITLE
EKF: Fix bug in use of gps velocity noise parameter

### DIFF
--- a/EKF/control.cpp
+++ b/EKF/control.cpp
@@ -525,7 +525,7 @@ void Ekf::controlGpsFusion()
 			float lower_limit = fmaxf(_params.gps_pos_noise, 0.01f);
 			float upper_limit = fmaxf(_params.pos_noaid_noise, lower_limit);
 			_posObsNoiseNE = math::constrain(_gps_sample_delayed.hacc, lower_limit, upper_limit);
-			_velObsVarNE(1) = _velObsVarNE(0) = sq(fmaxf(_params.gps_vel_noise, 0.01f));
+			_velObsVarNE(1) = _velObsVarNE(0) = sq(fmaxf(_gps_sample_delayed.sacc, _params.gps_vel_noise));
 
 			// calculate innovations
 			_vel_pos_innov[0] = _state.vel(0) - _gps_sample_delayed.vel(0);


### PR DESCRIPTION
This fixes a bug introduced by an earlier feature request PR. The noise parameter is supposed to define the lower limit on the observation noise.

Bug spotted by Deon Blaauw https://px4.slack.com/archives/C643UJTB7/p1519744752000030