### PR TITLE
tecs.cpp: tecs initialisation fixes

### DIFF
--- a/tecs/tecs.cpp
+++ b/tecs/tecs.cpp
@@ -522,9 +522,9 @@ void TECS::_initialize_states(float pitch, float throttle_cruise, float baro_alt
 		_vert_pos_state = baro_altitude;
 		_tas_rate_state = 0.0f;
 		_tas_state = _EAS * EAS2TAS;
-		_throttle_integ_state = (_in_air ? throttle_cruise : 0.0f);
+		_throttle_integ_state =  0.0f;
 		_pitch_integ_state = 0.0f;
-		_last_throttle_setpoint = throttle_cruise;
+		_last_throttle_setpoint = (_in_air ? throttle_cruise : 0.0f);;
 		_last_pitch_setpoint = constrain(pitch, _pitch_setpoint_min, _pitch_setpoint_max);
 		_pitch_setpoint_unc = _last_pitch_setpoint;
 		_hgt_setpoint_adj_prev = baro_altitude;


### PR DESCRIPTION
When initialised in air the throttle integrator was set to cruise throttle which does not make any sense.
The cruise throttle value is separately added to the throttle value and does not need to be part of the integrator.
However, for the last throttle value variable (used for slew rate limiting) it makes sense to initialise it with cruise throttle when TECS is initialised in air. 