### PR TITLE
EKF: fix bug causing height offset when GPS use stops

### DIFF
--- a/EKF/vel_pos_fusion.cpp
+++ b/EKF/vel_pos_fusion.cpp
@@ -183,7 +183,7 @@ void Ekf::fuseVelPosHeight()
 	innov_check_pass_map[5] = (_vel_pos_test_ratio[5] <= 1.0f) || !_control_status.flags.tilt_align;
 
 	// record the successful velocity fusion event
-	if ((_fuse_hor_vel || _fuse_hor_vel_aux) && vel_check_pass) {
+	if ((_fuse_hor_vel || _fuse_hor_vel_aux || _fuse_vert_vel) && vel_check_pass) {
 		_time_last_vel_fuse = _time_last_imu;
 		_innov_check_fail_status.flags.reject_vel_NED = false;
 
@@ -191,7 +191,7 @@ void Ekf::fuseVelPosHeight()
 		_innov_check_fail_status.flags.reject_vel_NED = true;
 	}
 
-	_fuse_hor_vel = _fuse_hor_vel_aux = false;
+	_fuse_hor_vel = _fuse_hor_vel_aux = _fuse_vert_vel = false;
 
 	// record the successful position fusion event
 	if (pos_check_pass && _fuse_pos) {


### PR DESCRIPTION
This bug causes the last vertical velocity observation to be continuously fused after GPS use stops unless the EKF reverts non aiding mode. The symptons are persistent height innovation offsets if GPS use stops and navigation continues with use of optical flow or external vision observations. The following plot shows the behaviour before the fix for a flight where navigation continues using optical flow after GPS becomes obscured. Note the significant change in baro height innovation.

![screen shot 2018-05-10 at 1 53 36 pm](https://user-images.githubusercontent.com/3596952/39851370-ce2d628c-5459-11e8-9856-28f433711902.png)

The same test performed after the fix:

![screen shot 2018-05-10 at 1 55 40 pm](https://user-images.githubusercontent.com/3596952/39851390-e0c70b32-5459-11e8-8df1-6536f3bb02ed.png)
