### PR TITLE
EKF : introduce new architechture for navigation limits

### DIFF
--- a/EKF/common.h
+++ b/EKF/common.h
@@ -291,7 +291,6 @@ struct parameters {
 	float flow_noise_qual_min{0.5f};	///< observation noise for optical flow LOS rate measurements when flow sensor quality is at the minimum useable (rad/sec)
 	int32_t flow_qual_min{1};		///< minimum acceptable quality integer from  the flow sensor
 	float flow_innov_gate{3.0f};		///< optical flow fusion innovation consistency gate size (STD)
-	float flow_rate_max{2.5f};		///< maximum valid optical flow rate (rad/sec)
 
 	// these parameters control the strictness of GPS quality checks used to determine if the GPS is
 	// good enough to set a local origin and commence aiding

--- a/EKF/control.cpp
+++ b/EKF/control.cpp
@@ -343,7 +343,7 @@ void Ekf::controlOpticalFlowFusion()
 		float accel_norm = _accel_vec_filt.norm();
 		bool motion_is_excessive = ((accel_norm > 14.7f) // accel greater than 1.5g
 					    || (accel_norm < 4.9f) // accel less than 0.5g
-					    || (_ang_rate_mag_filt > _params.flow_rate_max) // angular rate exceeds flow sensor limit
+					    || (_ang_rate_mag_filt > _flow_max_rate) // angular rate exceeds flow sensor limit
 					    || (_R_to_earth(2,2) < 0.866f)); // tilted more than 30 degrees
 		if (motion_is_excessive) {
 			_time_bad_motion_us = _imu_sample_delayed.time_us;

--- a/EKF/ekf.h
+++ b/EKF/ekf.h
@@ -140,12 +140,8 @@ public:
 	// get the 1-sigma horizontal and vertical velocity uncertainty
 	void get_ekf_vel_accuracy(float *ekf_evh, float *ekf_evv);
 
-	/*
-	Returns the following vehicle control limits required by the estimator.
-	vxy_max : Maximum ground relative horizontal speed (metres/sec). NaN when no limiting required.
-	tilt_rate_max : maximum allowed tilt rate against the direction of travel (rad/sec). NaN when no limiting required.
-	*/
-	void get_ekf_ctrl_limits(float *vxy_max, bool *limit_hagl);
+	// get the vehicle control limits required by the estimator to keep within sensor limitations
+	void get_ekf_ctrl_limits(float *vxy_max, float *vz_max, float *hagl_min, float *hagl_max);
 
 	/*
 	Reset all IMU bias states and covariances to initial alignment values.

--- a/EKF/estimator_interface.cpp
+++ b/EKF/estimator_interface.cpp
@@ -369,7 +369,7 @@ void EstimatorInterface::setOpticalFlowData(uint64_t time_usec, flow_message *fl
 		bool flow_magnitude_good = true;
 		if (delta_time_good) {
 			flow_rate_magnitude = flow->flowdata.norm() / delta_time;
-			flow_magnitude_good = (flow_rate_magnitude <= _params.flow_rate_max);
+			flow_magnitude_good = (flow_rate_magnitude <= _flow_max_rate);
 		}
 
 		bool relying_on_flow =  _control_status.flags.opt_flow

--- a/EKF/optflow_fusion.cpp
+++ b/EKF/optflow_fusion.cpp
@@ -95,7 +95,7 @@ void Ekf::fuseOptFlow()
 	opt_flow_rate(0) = _flow_sample_delayed.flowRadXYcomp(0) / _flow_sample_delayed.dt + _flow_gyro_bias(0);
 	opt_flow_rate(1) = _flow_sample_delayed.flowRadXYcomp(1) / _flow_sample_delayed.dt + _flow_gyro_bias(1);
 
-	if (opt_flow_rate.norm() < _params.flow_rate_max) {
+	if (opt_flow_rate.norm() < _flow_max_rate) {
 		_flow_innov[0] =  vel_body(1) / range - opt_flow_rate(0); // flow around the X axis
 		_flow_innov[1] = -vel_body(0) / range - opt_flow_rate(1); // flow around the Y axis
 


### PR DESCRIPTION
This reworks the navigation limits architecture to be more flexible in terms of sensing sources, and does not require the estimator to access sensor-specific parameters. Instead, the ekf2 frontend gets it from the sensor drivers directly, allowing for more advanced limiting for flow and visual odometry e.g based on scene texture.

PX4 branch : https://github.com/PX4/Firmware/commits/pr-optFlowFixes
Testing : Untested, WIP