### PR TITLE
Pr bitcraze optical flow ekf interface

### DIFF
--- a/EKF/RingBuffer.h
+++ b/EKF/RingBuffer.h
@@ -158,6 +158,29 @@ public:
 		return false;
 	}
 
+	bool read_first_older_than(const uint64_t& timestamp, data_type *sample)
+	{
+		// start looking from newest observation data
+		for (uint8_t i = 0; i < _size; i++) {
+			int index = (_head - i);
+			index = index < 0 ? _size + index : index;
+
+			if (timestamp >= _buffer[index].time_us && timestamp - _buffer[index].time_us < (uint64_t)1e5) {
+
+				*sample = _buffer[index];
+
+				return true;
+			}
+
+			if (index == _tail) {
+				// we have reached the tail and haven't got a match
+				return false;
+			}
+		}
+
+		return false;
+	}
+
 	int get_total_size() { return sizeof(*this) + sizeof(data_type) * _size; }
 
 private:

--- a/EKF/common.h
+++ b/EKF/common.h
@@ -71,8 +71,8 @@ struct gps_message {
 
 struct flow_message {
 	uint8_t quality;	///< Quality of Flow data
-	Vector2f flowdata;	///< Optical flow rates about the X and Y body axes (rad/sec)
-	Vector3f gyrodata;	///< Gyro rates about the XYZ body axes (rad/sec)
+	Vector2f flowdata;	///< Optical flow delta angles about the X and Y body axes (rad)
+	Vector3f gyrodata;	///< Gyro delta angle about the XYZ body axes (rad)
 	uint32_t dt;		///< integration time of flow samples (sec)
 };
 

--- a/EKF/estimator_interface.cpp
+++ b/EKF/estimator_interface.cpp
@@ -421,6 +421,9 @@ void EstimatorInterface::setOpticalFlowData(uint64_t time_usec, flow_message *fl
 			optflow_sample_new.flowRadXYcomp(0) = (optflow_sample_new.flowRadXY(0) - optflow_sample_new.gyroXYZ(0)) * delta_time;
 			optflow_sample_new.flowRadXYcomp(1) = (optflow_sample_new.flowRadXY(1) - optflow_sample_new.gyroXYZ(1)) * delta_time;
 
+			optflow_sample_new.gyroXYZ(0) *= matching_imu_sample.delta_ang_dt;
+			optflow_sample_new.gyroXYZ(1) *= matching_imu_sample.delta_ang_dt;
+
 			// convert integration interval to seconds
 			optflow_sample_new.dt = delta_time;
 			_time_last_optflow = time_usec;

--- a/EKF/estimator_interface.cpp
+++ b/EKF/estimator_interface.cpp
@@ -418,8 +418,8 @@ void EstimatorInterface::setOpticalFlowData(uint64_t time_usec, flow_message *fl
 			}
 
 			// compensate for body motion to give a LOS rate
-			optflow_sample_new.flowRadXYcomp(0) = (optflow_sample_new.flowRadXY(0) - optflow_sample_new.gyroXYZ(0)) * delta_time;
-			optflow_sample_new.flowRadXYcomp(1) = (optflow_sample_new.flowRadXY(1) - optflow_sample_new.gyroXYZ(1)) * delta_time;
+			optflow_sample_new.flowRadXYcomp(0) = (optflow_sample_new.flowRadXY(0) + optflow_sample_new.gyroXYZ(0)) * delta_time;
+			optflow_sample_new.flowRadXYcomp(1) = (optflow_sample_new.flowRadXY(1) + optflow_sample_new.gyroXYZ(1)) * delta_time;
 
 			optflow_sample_new.gyroXYZ(0) *= matching_imu_sample.delta_ang_dt;
 			optflow_sample_new.gyroXYZ(1) *= matching_imu_sample.delta_ang_dt;

--- a/EKF/estimator_interface.cpp
+++ b/EKF/estimator_interface.cpp
@@ -393,61 +393,54 @@ void EstimatorInterface::setOpticalFlowData(uint64_t time_usec, flow_message *fl
 			// copy the optical and gyro measured delta angles
 
 			bool no_gyro = false;
-			Vector3f matching_gyro_sample;
 			imuSample matching_imu_sample;
+			Vector3f matching_gyro_sample;
 
-			if( !PX4_ISFINITE(flow->gyrodata(0)) && !PX4_ISFINITE(flow->gyrodata(1)) && !PX4_ISFINITE(flow->gyrodata(2)) ) {
-
+			/* for optical flow boards with no gyro. The driver will set the gyro x, y and z fields in the optical_flow message to NAN so that  
+			 * we can check this here and get the gyro data with the matching timestamp from the imu buffer. The gyro data is divided by dt to 
+			 * convert it into a rate before removing it from the flow to remove the rotation component. This is done to prevent errors when the flow
+			 * and gyro data are integrated over different times */
+			if (!PX4_ISFINITE(flow->gyrodata(0)) && !PX4_ISFINITE(flow->gyrodata(1)) && !PX4_ISFINITE(flow->gyrodata(2))) {
 				no_gyro = true;
 				_imu_buffer.read_first_older_than(optflow_sample_new.time_us, &matching_imu_sample);
 				matching_gyro_sample = matching_imu_sample.delta_ang / matching_imu_sample.delta_ang_dt;
 				optflow_sample_new.gyroXYZ = matching_gyro_sample;
 			} else {
-
 				optflow_sample_new.gyroXYZ = - flow->gyrodata;
 			}
 
 
 			if (flow_quality_good) {
-
-				if( no_gyro ) {
-
+				if (no_gyro) {
 					optflow_sample_new.flowRadXY = flow->flowdata / delta_time;
 				} else {
 
 					optflow_sample_new.flowRadXY = - flow->flowdata;
 				}
 
-
 			} else {
 				// when on the ground with poor flow quality, assume zero ground relative velocity
-
-				if( no_gyro ) {
-
+				if (no_gyro) {
 					optflow_sample_new.flowRadXY(0) = - matching_gyro_sample(0);
 					optflow_sample_new.flowRadXY(1) = - matching_gyro_sample(1);
 				} else {
-
 					optflow_sample_new.flowRadXY(0) = - flow->gyrodata(0);
 					optflow_sample_new.flowRadXY(1) = - flow->gyrodata(1);
 				}
-
 			}
 
 			// compensate for body motion to give a LOS rate
-			if( no_gyro ){
-
+			if (no_gyro) {
 				optflow_sample_new.flowRadXYcomp(0) = (optflow_sample_new.flowRadXY(0) + optflow_sample_new.gyroXYZ(0)) * delta_time;
 				optflow_sample_new.flowRadXYcomp(1) = (optflow_sample_new.flowRadXY(1) + optflow_sample_new.gyroXYZ(1)) * delta_time;
 
+				// convert gyro back from rate to delta angle
 				optflow_sample_new.gyroXYZ(0) *= matching_imu_sample.delta_ang_dt;
 				optflow_sample_new.gyroXYZ(1) *= matching_imu_sample.delta_ang_dt;
 			} else {
-
 				optflow_sample_new.flowRadXYcomp(0) = optflow_sample_new.flowRadXY(0) - optflow_sample_new.gyroXYZ(0);
 				optflow_sample_new.flowRadXYcomp(1) = optflow_sample_new.flowRadXY(1) - optflow_sample_new.gyroXYZ(1);
 			}
-
 
 			// convert integration interval to seconds
 			optflow_sample_new.dt = delta_time;

--- a/EKF/estimator_interface.cpp
+++ b/EKF/estimator_interface.cpp
@@ -404,8 +404,6 @@ void EstimatorInterface::setOpticalFlowData(uint64_t time_usec, flow_message *fl
 
 			// NOTE: the EKF uses the reverse sign convention to the flow sensor. EKF assumes positive LOS rate is produced by a RH rotation of the image about the sensor axis.
 			// copy the optical and gyro measured delta angles
-
-			bool no_gyro = false;
 			imuSample matching_imu_sample;
 			Vector3f matching_gyro_sample;
 
@@ -414,46 +412,25 @@ void EstimatorInterface::setOpticalFlowData(uint64_t time_usec, flow_message *fl
 			 * convert it into a rate before removing it from the flow to remove the rotation component. This is done to prevent errors when the flow
 			 * and gyro data are integrated over different times */
 			if (!ISFINITE(flow->gyrodata(0)) && !ISFINITE(flow->gyrodata(1)) && !ISFINITE(flow->gyrodata(2))) {
-				no_gyro = true;
 				_imu_buffer.read_first_older_than(optflow_sample_new.time_us, &matching_imu_sample);
-				matching_gyro_sample = matching_imu_sample.delta_ang / matching_imu_sample.delta_ang_dt;
-				optflow_sample_new.gyroXYZ = matching_gyro_sample;
-			} else {
-				optflow_sample_new.gyroXYZ = - flow->gyrodata;
+				flow->gyrodata = matching_imu_sample.delta_ang / matching_imu_sample.delta_ang_dt * delta_time;
 			}
+
+			optflow_sample_new.gyroXYZ = - flow->gyrodata;
 
 
 			if (flow_quality_good) {
-				if (no_gyro) {
-					optflow_sample_new.flowRadXY = flow->flowdata / delta_time;
-				} else {
-
 					optflow_sample_new.flowRadXY = - flow->flowdata;
-				}
 
 			} else {
 				// when on the ground with poor flow quality, assume zero ground relative velocity
-				if (no_gyro) {
-					optflow_sample_new.flowRadXY(0) = - matching_gyro_sample(0);
-					optflow_sample_new.flowRadXY(1) = - matching_gyro_sample(1);
-				} else {
-					optflow_sample_new.flowRadXY(0) = - flow->gyrodata(0);
-					optflow_sample_new.flowRadXY(1) = - flow->gyrodata(1);
-				}
+				optflow_sample_new.flowRadXY(0) = - flow->gyrodata(0);
+				optflow_sample_new.flowRadXY(1) = - flow->gyrodata(1);
 			}
 
-			// compensate for body motion to give a LOS rate
-			if (no_gyro) {
-				optflow_sample_new.flowRadXYcomp(0) = (optflow_sample_new.flowRadXY(0) + optflow_sample_new.gyroXYZ(0)) * delta_time;
-				optflow_sample_new.flowRadXYcomp(1) = (optflow_sample_new.flowRadXY(1) + optflow_sample_new.gyroXYZ(1)) * delta_time;
-
-				// convert gyro back from rate to delta angle
-				optflow_sample_new.gyroXYZ(0) *= matching_imu_sample.delta_ang_dt;
-				optflow_sample_new.gyroXYZ(1) *= matching_imu_sample.delta_ang_dt;
-			} else {
-				optflow_sample_new.flowRadXYcomp(0) = optflow_sample_new.flowRadXY(0) - optflow_sample_new.gyroXYZ(0);
-				optflow_sample_new.flowRadXYcomp(1) = optflow_sample_new.flowRadXY(1) - optflow_sample_new.gyroXYZ(1);
-			}
+			// compensate for body motion to give a LOS delta angle
+			optflow_sample_new.flowRadXYcomp(0) = optflow_sample_new.flowRadXY(0) - optflow_sample_new.gyroXYZ(0);
+			optflow_sample_new.flowRadXYcomp(1) = optflow_sample_new.flowRadXY(1) - optflow_sample_new.gyroXYZ(1);
 
 			// convert integration interval to seconds
 			optflow_sample_new.dt = delta_time;

--- a/EKF/estimator_interface.cpp
+++ b/EKF/estimator_interface.cpp
@@ -403,14 +403,15 @@ void EstimatorInterface::setOpticalFlowData(uint64_t time_usec, flow_message *fl
 				optflow_sample_new.gyroXYZ = - flow->gyrodata;
 			}
 
+			Vector3f matching_gyro_sample;
+			imuSample matching_imu_sample;
+
 			if (flow_quality_good) {
 
 				if( no_gyro ) {
 
-					imuSample matching_imu_sample;
-
 					_imu_buffer.read_first_older_than(optflow_sample_new.time_us, &matching_imu_sample);
-					Vector3f matching_gyro_sample = matching_imu_sample.delta_ang / matching_imu_sample.delta_ang_dt;
+					matching_gyro_sample = matching_imu_sample.delta_ang / matching_imu_sample.delta_ang_dt;
 					optflow_sample_new.gyroXYZ = matching_gyro_sample;
 					optflow_sample_new.flowRadXY = flow->flowdata / delta_time;
 

--- a/EKF/estimator_interface.cpp
+++ b/EKF/estimator_interface.cpp
@@ -400,7 +400,7 @@ void EstimatorInterface::setOpticalFlowData(uint64_t time_usec, flow_message *fl
 			 * we can check this here and get the gyro data with the matching timestamp from the imu buffer. The gyro data is divided by dt to 
 			 * convert it into a rate before removing it from the flow to remove the rotation component. This is done to prevent errors when the flow
 			 * and gyro data are integrated over different times */
-			if (!PX4_ISFINITE(flow->gyrodata(0)) && !PX4_ISFINITE(flow->gyrodata(1)) && !PX4_ISFINITE(flow->gyrodata(2))) {
+			if (!ISFINITE(flow->gyrodata(0)) && !ISFINITE(flow->gyrodata(1)) && !ISFINITE(flow->gyrodata(2))) {
 				no_gyro = true;
 				_imu_buffer.read_first_older_than(optflow_sample_new.time_us, &matching_imu_sample);
 				matching_gyro_sample = matching_imu_sample.delta_ang / matching_imu_sample.delta_ang_dt;

--- a/EKF/estimator_interface.cpp
+++ b/EKF/estimator_interface.cpp
@@ -392,29 +392,27 @@ void EstimatorInterface::setOpticalFlowData(uint64_t time_usec, flow_message *fl
 			// NOTE: the EKF uses the reverse sign convention to the flow sensor. EKF assumes positive LOS rate is produced by a RH rotation of the image about the sensor axis.
 			// copy the optical and gyro measured delta angles
 
-			// flow_quality_good = true;
 			bool no_gyro = false;
+			Vector3f matching_gyro_sample;
+			imuSample matching_imu_sample;
 
-			if( flow->gyrodata(0)==NAN && flow->gyrodata(1)==NAN && flow->gyrodata(2)==NAN ) {
+			if( !PX4_ISFINITE(flow->gyrodata(0)) && !PX4_ISFINITE(flow->gyrodata(1)) && !PX4_ISFINITE(flow->gyrodata(2)) ) {
 
 				no_gyro = true;
-
+				_imu_buffer.read_first_older_than(optflow_sample_new.time_us, &matching_imu_sample);
+				matching_gyro_sample = matching_imu_sample.delta_ang / matching_imu_sample.delta_ang_dt;
+				optflow_sample_new.gyroXYZ = matching_gyro_sample;
 			} else {
+
 				optflow_sample_new.gyroXYZ = - flow->gyrodata;
 			}
 
-			Vector3f matching_gyro_sample;
-			imuSample matching_imu_sample;
 
 			if (flow_quality_good) {
 
 				if( no_gyro ) {
 
-					_imu_buffer.read_first_older_than(optflow_sample_new.time_us, &matching_imu_sample);
-					matching_gyro_sample = matching_imu_sample.delta_ang / matching_imu_sample.delta_ang_dt;
-					optflow_sample_new.gyroXYZ = matching_gyro_sample;
 					optflow_sample_new.flowRadXY = flow->flowdata / delta_time;
-
 				} else {
 
 					optflow_sample_new.flowRadXY = - flow->flowdata;
@@ -425,9 +423,11 @@ void EstimatorInterface::setOpticalFlowData(uint64_t time_usec, flow_message *fl
 				// when on the ground with poor flow quality, assume zero ground relative velocity
 
 				if( no_gyro ) {
+
 					optflow_sample_new.flowRadXY(0) = - matching_gyro_sample(0);
 					optflow_sample_new.flowRadXY(1) = - matching_gyro_sample(1);
 				} else {
+
 					optflow_sample_new.flowRadXY(0) = - flow->gyrodata(0);
 					optflow_sample_new.flowRadXY(1) = - flow->gyrodata(1);
 				}

--- a/EKF/estimator_interface.cpp
+++ b/EKF/estimator_interface.cpp
@@ -391,38 +391,62 @@ void EstimatorInterface::setOpticalFlowData(uint64_t time_usec, flow_message *fl
 
 			// NOTE: the EKF uses the reverse sign convention to the flow sensor. EKF assumes positive LOS rate is produced by a RH rotation of the image about the sensor axis.
 			// copy the optical and gyro measured delta angles
-			//optflow_sample_new.gyroXYZ = - flow->gyrodata;
 
-			imuSample matching_imu_sample;
+			// flow_quality_good = true;
+			bool no_gyro = false;
 
-			_imu_buffer.read_first_older_than(optflow_sample_new.time_us, &matching_imu_sample);
+			if( flow->gyrodata(0)==NAN && flow->gyrodata(1)==NAN && flow->gyrodata(2)==NAN ) {
 
-			Vector3f matching_gyro_sample = matching_imu_sample.delta_ang / matching_imu_sample.delta_ang_dt;
+				no_gyro = true;
 
-			optflow_sample_new.gyroXYZ = matching_gyro_sample;
-
-			flow_quality_good = true;
+			} else {
+				optflow_sample_new.gyroXYZ = - flow->gyrodata;
+			}
 
 			if (flow_quality_good) {
-				//optflow_sample_new.flowRadXY = - flow->flowdata;
-				optflow_sample_new.flowRadXY = flow->flowdata / delta_time;
+
+				if( no_gyro ) {
+
+					imuSample matching_imu_sample;
+
+					_imu_buffer.read_first_older_than(optflow_sample_new.time_us, &matching_imu_sample);
+					Vector3f matching_gyro_sample = matching_imu_sample.delta_ang / matching_imu_sample.delta_ang_dt;
+					optflow_sample_new.gyroXYZ = matching_gyro_sample;
+					optflow_sample_new.flowRadXY = flow->flowdata / delta_time;
+
+				} else {
+
+					optflow_sample_new.flowRadXY = - flow->flowdata;
+				}
+
 
 			} else {
 				// when on the ground with poor flow quality, assume zero ground relative velocity
-				//optflow_sample_new.flowRadXY(0) = - flow->gyrodata(0);
-				//optflow_sample_new.flowRadXY(1) = - flow->gyrodata(1);
 
-				optflow_sample_new.flowRadXY(0) = - matching_gyro_sample(0);
-				optflow_sample_new.flowRadXY(1) = - matching_gyro_sample(1);
+				if( no_gyro ) {
+					optflow_sample_new.flowRadXY(0) = - matching_gyro_sample(0);
+					optflow_sample_new.flowRadXY(1) = - matching_gyro_sample(1);
+				} else {
+					optflow_sample_new.flowRadXY(0) = - flow->gyrodata(0);
+					optflow_sample_new.flowRadXY(1) = - flow->gyrodata(1);
+				}
 
 			}
 
 			// compensate for body motion to give a LOS rate
-			optflow_sample_new.flowRadXYcomp(0) = (optflow_sample_new.flowRadXY(0) + optflow_sample_new.gyroXYZ(0)) * delta_time;
-			optflow_sample_new.flowRadXYcomp(1) = (optflow_sample_new.flowRadXY(1) + optflow_sample_new.gyroXYZ(1)) * delta_time;
+			if( no_gyro ){
 
-			optflow_sample_new.gyroXYZ(0) *= matching_imu_sample.delta_ang_dt;
-			optflow_sample_new.gyroXYZ(1) *= matching_imu_sample.delta_ang_dt;
+				optflow_sample_new.flowRadXYcomp(0) = (optflow_sample_new.flowRadXY(0) + optflow_sample_new.gyroXYZ(0)) * delta_time;
+				optflow_sample_new.flowRadXYcomp(1) = (optflow_sample_new.flowRadXY(1) + optflow_sample_new.gyroXYZ(1)) * delta_time;
+
+				optflow_sample_new.gyroXYZ(0) *= matching_imu_sample.delta_ang_dt;
+				optflow_sample_new.gyroXYZ(1) *= matching_imu_sample.delta_ang_dt;
+			} else {
+
+				optflow_sample_new.flowRadXYcomp(0) = optflow_sample_new.flowRadXY(0) - optflow_sample_new.gyroXYZ(0);
+				optflow_sample_new.flowRadXYcomp(1) = optflow_sample_new.flowRadXY(1) - optflow_sample_new.gyroXYZ(1);
+			}
+
 
 			// convert integration interval to seconds
 			optflow_sample_new.dt = delta_time;

--- a/EKF/optflow_fusion.cpp
+++ b/EKF/optflow_fusion.cpp
@@ -84,6 +84,7 @@ void Ekf::fuseOptFlow()
 
 	// rotate into body frame
 	Vector3f vel_body = earth_to_body * vel_rel_earth;
+	vel_body *= 1.0f;
 
 	// calculate range from focal point to centre of image
 	float range = heightAboveGndEst / earth_to_body(2, 2); // absolute distance to the frame region in view
@@ -92,11 +93,11 @@ void Ekf::fuseOptFlow()
 	// correct for gyro bias errors in the data used to do the motion compensation
 	// Note the sign convention used: A positive LOS rate is a RH rotaton of the scene about that axis.
 	Vector2f opt_flow_rate;
-	opt_flow_rate(0) = _flow_sample_delayed.flowRadXYcomp(0) / _flow_sample_delayed.dt + _flow_gyro_bias(0);
-	opt_flow_rate(1) = _flow_sample_delayed.flowRadXYcomp(1) / _flow_sample_delayed.dt + _flow_gyro_bias(1);
+	opt_flow_rate(0) = -_flow_sample_delayed.flowRadXYcomp(0) / _flow_sample_delayed.dt;// + _flow_gyro_bias(0);
+	opt_flow_rate(1) = -_flow_sample_delayed.flowRadXYcomp(1) / _flow_sample_delayed.dt;// + _flow_gyro_bias(1);
 
-	if (opt_flow_rate.norm() < _params.flow_rate_max) {
-		_flow_innov[0] =  vel_body(1) / range - opt_flow_rate(0); // flow around the X axis
+	if (true) {
+		_flow_innov[0] = vel_body(1) / range - opt_flow_rate(0); // flow around the X axis
 		_flow_innov[1] = -vel_body(0) / range - opt_flow_rate(1); // flow around the Y axis
 
 	} else {

--- a/EKF/optflow_fusion.cpp
+++ b/EKF/optflow_fusion.cpp
@@ -93,8 +93,8 @@ void Ekf::fuseOptFlow()
 	// correct for gyro bias errors in the data used to do the motion compensation
 	// Note the sign convention used: A positive LOS rate is a RH rotaton of the scene about that axis.
 	Vector2f opt_flow_rate;
-	opt_flow_rate(0) = -_flow_sample_delayed.flowRadXYcomp(0) / _flow_sample_delayed.dt;// + _flow_gyro_bias(0);
-	opt_flow_rate(1) = -_flow_sample_delayed.flowRadXYcomp(1) / _flow_sample_delayed.dt;// + _flow_gyro_bias(1);
+	opt_flow_rate(0) = _flow_sample_delayed.flowRadXYcomp(0) / _flow_sample_delayed.dt;// + _flow_gyro_bias(0);
+	opt_flow_rate(1) = _flow_sample_delayed.flowRadXYcomp(1) / _flow_sample_delayed.dt;// + _flow_gyro_bias(1);
 
 	if (true) {
 		_flow_innov[0] = vel_body(1) / range - opt_flow_rate(0); // flow around the X axis

--- a/EKF/optflow_fusion.cpp
+++ b/EKF/optflow_fusion.cpp
@@ -84,7 +84,6 @@ void Ekf::fuseOptFlow()
 
 	// rotate into body frame
 	Vector3f vel_body = earth_to_body * vel_rel_earth;
-	vel_body *= 1.0f;
 
 	// calculate range from focal point to centre of image
 	float range = heightAboveGndEst / earth_to_body(2, 2); // absolute distance to the frame region in view
@@ -93,11 +92,11 @@ void Ekf::fuseOptFlow()
 	// correct for gyro bias errors in the data used to do the motion compensation
 	// Note the sign convention used: A positive LOS rate is a RH rotaton of the scene about that axis.
 	Vector2f opt_flow_rate;
-	opt_flow_rate(0) = _flow_sample_delayed.flowRadXYcomp(0) / _flow_sample_delayed.dt;// + _flow_gyro_bias(0);
-	opt_flow_rate(1) = _flow_sample_delayed.flowRadXYcomp(1) / _flow_sample_delayed.dt;// + _flow_gyro_bias(1);
+	opt_flow_rate(0) = _flow_sample_delayed.flowRadXYcomp(0) / _flow_sample_delayed.dt + _flow_gyro_bias(0);
+	opt_flow_rate(1) = _flow_sample_delayed.flowRadXYcomp(1) / _flow_sample_delayed.dt + _flow_gyro_bias(1);
 
-	if (true) {
-		_flow_innov[0] = vel_body(1) / range - opt_flow_rate(0); // flow around the X axis
+	if (opt_flow_rate.norm() < _params.flow_rate_max) {
+		_flow_innov[0] =  vel_body(1) / range - opt_flow_rate(0); // flow around the X axis
 		_flow_innov[1] = -vel_body(0) / range - opt_flow_rate(1); // flow around the Y axis
 
 	} else {


### PR DESCRIPTION
This PR enables optical flow on crazyflie. The optical flow deck doesn't have a gyroscope therefore the gyro data should be taken from the imu data in the estimator interface. The pmw3901 driver (optical flow for crazyflie) will publish gyro data equal to NAN to make this check in the ekf.

Had to add a read function in the ringbuffer to read imu data without deleting any older data from it.