### PR TITLE
Pr no gyro opt flow

### DIFF
--- a/EKF/common.h
+++ b/EKF/common.h
@@ -71,8 +71,8 @@ struct gps_message {
 
 struct flow_message {
 	uint8_t quality;	///< Quality of Flow data
-	Vector2f flowdata;	///< Optical flow rates about the X and Y body axes (rad/sec)
-	Vector3f gyrodata;	///< Gyro rates about the XYZ body axes (rad/sec)
+	Vector2f flowdata;	///< Optical flow delta angles about the X and Y body axes (rad)
+	Vector3f gyrodata;	///< Gyro delta angle about the XYZ body axes (rad)
 	uint32_t dt;		///< integration time of flow samples (sec)
 };
 

--- a/EKF/estimator_interface.cpp
+++ b/EKF/estimator_interface.cpp
@@ -391,8 +391,6 @@ void EstimatorInterface::setOpticalFlowData(uint64_t time_usec, flow_message *fl
 
 			// NOTE: the EKF uses the reverse sign convention to the flow sensor. EKF assumes positive LOS rate is produced by a RH rotation of the image about the sensor axis.
 			// copy the optical and gyro measured delta angles
-
-			bool no_gyro = false;
 			imuSample matching_imu_sample;
 			Vector3f matching_gyro_sample;
 
@@ -401,46 +399,24 @@ void EstimatorInterface::setOpticalFlowData(uint64_t time_usec, flow_message *fl
 			 * convert it into a rate before removing it from the flow to remove the rotation component. This is done to prevent errors when the flow
 			 * and gyro data are integrated over different times */
 			if (!ISFINITE(flow->gyrodata(0)) && !ISFINITE(flow->gyrodata(1)) && !ISFINITE(flow->gyrodata(2))) {
-				no_gyro = true;
 				_imu_buffer.read_first_older_than(optflow_sample_new.time_us, &matching_imu_sample);
-				matching_gyro_sample = matching_imu_sample.delta_ang / matching_imu_sample.delta_ang_dt;
-				optflow_sample_new.gyroXYZ = matching_gyro_sample;
-			} else {
-				optflow_sample_new.gyroXYZ = - flow->gyrodata;
+				flow->gyrodata = matching_imu_sample.delta_ang / matching_imu_sample.delta_ang_dt * delta_time;
 			}
+
+			optflow_sample_new.gyroXYZ = - flow->gyrodata;
 
 
 			if (flow_quality_good) {
-				if (no_gyro) {
-					optflow_sample_new.flowRadXY = flow->flowdata / delta_time;
-				} else {
-
 					optflow_sample_new.flowRadXY = - flow->flowdata;
-				}
 
 			} else {
 				// when on the ground with poor flow quality, assume zero ground relative velocity
-				if (no_gyro) {
-					optflow_sample_new.flowRadXY(0) = - matching_gyro_sample(0);
-					optflow_sample_new.flowRadXY(1) = - matching_gyro_sample(1);
-				} else {
-					optflow_sample_new.flowRadXY(0) = - flow->gyrodata(0);
-					optflow_sample_new.flowRadXY(1) = - flow->gyrodata(1);
-				}
+				optflow_sample_new.flowRadXY(0) = - flow->gyrodata(0);
+				optflow_sample_new.flowRadXY(1) = - flow->gyrodata(1);
 			}
 
-			// compensate for body motion to give a LOS rate
-			if (no_gyro) {
-				optflow_sample_new.flowRadXYcomp(0) = (optflow_sample_new.flowRadXY(0) + optflow_sample_new.gyroXYZ(0)) * delta_time;
-				optflow_sample_new.flowRadXYcomp(1) = (optflow_sample_new.flowRadXY(1) + optflow_sample_new.gyroXYZ(1)) * delta_time;
-
-				// convert gyro back from rate to delta angle
-				optflow_sample_new.gyroXYZ(0) *= matching_imu_sample.delta_ang_dt;
-				optflow_sample_new.gyroXYZ(1) *= matching_imu_sample.delta_ang_dt;
-			} else {
-				optflow_sample_new.flowRadXYcomp(0) = optflow_sample_new.flowRadXY(0) - optflow_sample_new.gyroXYZ(0);
-				optflow_sample_new.flowRadXYcomp(1) = optflow_sample_new.flowRadXY(1) - optflow_sample_new.gyroXYZ(1);
-			}
+			optflow_sample_new.flowRadXYcomp(0) = optflow_sample_new.flowRadXY(0) - optflow_sample_new.gyroXYZ(0);
+			optflow_sample_new.flowRadXYcomp(1) = optflow_sample_new.flowRadXY(1) - optflow_sample_new.gyroXYZ(1);
 
 			// convert integration interval to seconds
 			optflow_sample_new.dt = delta_time;

--- a/EKF/estimator_interface.cpp
+++ b/EKF/estimator_interface.cpp
@@ -415,6 +415,7 @@ void EstimatorInterface::setOpticalFlowData(uint64_t time_usec, flow_message *fl
 				optflow_sample_new.flowRadXY(1) = - flow->gyrodata(1);
 			}
 
+			// compensate for body motion to give a LOS delta angle
 			optflow_sample_new.flowRadXYcomp(0) = optflow_sample_new.flowRadXY(0) - optflow_sample_new.gyroXYZ(0);
 			optflow_sample_new.flowRadXYcomp(1) = optflow_sample_new.flowRadXY(1) - optflow_sample_new.gyroXYZ(1);
 


### PR DESCRIPTION
@DanielePettenuzzo I tried to change the logic so that we can remove multiple checks for no_gyro flag.
Basically I think if we figure out that we have no gyro data from the flow sensor we can get a gyro sample from the buffer, convert it into a gyro rate, and then back to a delta angle using the dt from the flow sensor.
I hope I did not oversee something here.
@priseborough FYI, I corrected the units in the comment for the flow message (common.h)

