### PR TITLE
EKF: Enable use of flow sensors that do not have gyros

### DIFF
--- a/EKF/common.h
+++ b/EKF/common.h
@@ -141,7 +141,7 @@ struct flowSample {
 	Vector2f flowRadXY;	///< measured delta angle of the image about the X and Y body axes (rad), RH rotaton is positive
 	Vector3f gyroXYZ;	///< measured delta angle of the inertial frame about the body axes obtained from rate gyro measurements (rad), RH rotation is positive
 	float    dt;		///< amount of integration time (sec)
-	uint64_t time_us;	///< timestamp of the integration period mid-point (uSec)
+	uint64_t time_us;	///< timestamp of the integration period leading edge (uSec)
 };
 
 struct extVisionSample {

--- a/EKF/common.h
+++ b/EKF/common.h
@@ -139,7 +139,6 @@ struct airspeedSample {
 struct flowSample {
 	uint8_t  quality;	///< quality indicator between 0 and 255
 	Vector2f flowRadXY;	///< measured delta angle of the image about the X and Y body axes (rad), RH rotaton is positive
-	Vector2f flowRadXYcomp;	///< measured delta angle of the image about the X and Y body axes after removal of body rotation (rad), RH rotation is positive
 	Vector3f gyroXYZ;	///< measured delta angle of the inertial frame about the body axes obtained from rate gyro measurements (rad), RH rotation is positive
 	float    dt;		///< amount of integration time (sec)
 	uint64_t time_us;	///< timestamp of the integration period mid-point (uSec)

--- a/EKF/ekf.h
+++ b/EKF/ekf.h
@@ -282,7 +282,7 @@ private:
 	bool _mag_data_ready{false};	///< true when new magnetometer data has fallen behind the fusion time horizon and is available to be fused
 	bool _baro_data_ready{false};	///< true when new baro height data has fallen behind the fusion time horizon and is available to be fused
 	bool _range_data_ready{false};	///< true when new range finder data has fallen behind the fusion time horizon and is available to be fused
-	bool _flow_data_ready{false};	///< true when new optical flow data has fallen behind the fusion time horizon and is available to be fused
+	bool _flow_data_ready{false};	///< true when the leading edge of the optical flow integration period has fallen behind the fusion time horizon
 	bool _ev_data_ready{false};	///< true when new external vision system data has fallen behind the fusion time horizon and is available to be fused
 	bool _tas_data_ready{false};	///< true when new true airspeed data has fallen behind the fusion time horizon and is available to be fused
 

--- a/EKF/ekf.h
+++ b/EKF/ekf.h
@@ -355,6 +355,7 @@ private:
 	uint64_t _time_bad_motion_us{0};	///< last system time that on-ground motion exceeded limits (uSec)
 	uint64_t _time_good_motion_us{0};	///< last system time that on-ground motion was within limits (uSec)
 	bool _inhibit_flow_use{false};	///< true when use of optical flow and range finder is being inhibited
+	Vector2f _flowRadXYcomp;	///< measured delta angle of the image about the X and Y body axes after removal of body rotation (rad), RH rotation is positive
 
 	float _mag_declination{0.0f};	///< magnetic declination used by reset and fusion functions (rad)
 
@@ -486,8 +487,9 @@ private:
 	// fuse optical flow line of sight rate measurements
 	void fuseOptFlow();
 
-	// calculate optical flow bias errors
-	void calcOptFlowBias();
+	// calculate optical flow body angular rate compensation
+	// returns false if bias corrected body rate data is unavailable
+	bool calcOptFlowBodyRateComp();
 
 	// initialise the terrain vertical position estimator
 	// return true if the initialisation is successful

--- a/EKF/ekf_helper.cpp
+++ b/EKF/ekf_helper.cpp
@@ -71,8 +71,8 @@ bool Ekf::resetVelocity()
 			// we should have reliable OF measurements so
 			// calculate X and Y body relative velocities from OF measurements
 			Vector3f vel_optflow_body;
-			vel_optflow_body(0) = - range * _flow_sample_delayed.flowRadXYcomp(1) / _flow_sample_delayed.dt;
-			vel_optflow_body(1) =   range * _flow_sample_delayed.flowRadXYcomp(0) / _flow_sample_delayed.dt;
+			vel_optflow_body(0) = - range * _flowRadXYcomp(1) / _flow_sample_delayed.dt;
+			vel_optflow_body(1) =   range * _flowRadXYcomp(0) / _flow_sample_delayed.dt;
 			vel_optflow_body(2) = 0.0f;
 
 			// rotate from body to earth frame

--- a/EKF/estimator_interface.cpp
+++ b/EKF/estimator_interface.cpp
@@ -405,20 +405,7 @@ void EstimatorInterface::setOpticalFlowData(uint64_t time_usec, flow_message *fl
 			// NOTE: the EKF uses the reverse sign convention to the flow sensor. EKF assumes positive LOS rate is produced by a RH rotation of the image about the sensor axis.
 			// copy the optical and gyro measured delta angles
 			optflow_sample_new.gyroXYZ = - flow->gyrodata;
-
-			if (flow_quality_good) {
-				optflow_sample_new.flowRadXY = - flow->flowdata;
-
-			} else {
-				// when on the ground with poor flow quality, assume zero ground relative velocity
-				optflow_sample_new.flowRadXY(0) = - flow->gyrodata(0);
-				optflow_sample_new.flowRadXY(1) = - flow->gyrodata(1);
-
-			}
-
-			// compensate for body motion to give a LOS rate
-			optflow_sample_new.flowRadXYcomp(0) = optflow_sample_new.flowRadXY(0) - optflow_sample_new.gyroXYZ(0);
-			optflow_sample_new.flowRadXYcomp(1) = optflow_sample_new.flowRadXY(1) - optflow_sample_new.gyroXYZ(1);
+			optflow_sample_new.flowRadXY = - flow->flowdata;
 
 			// convert integration interval to seconds
 			optflow_sample_new.dt = delta_time;

--- a/EKF/estimator_interface.cpp
+++ b/EKF/estimator_interface.cpp
@@ -396,8 +396,8 @@ void EstimatorInterface::setOpticalFlowData(uint64_t time_usec, flow_message *fl
 		// If flow quality fails checks on ground, assume zero flow rate after body rate compensation
 		if ((delta_time_good && flow_quality_good && (flow_magnitude_good || relying_on_flow)) || !_control_status.flags.in_air) {
 			flowSample optflow_sample_new;
-			// calculate the system time-stamp for the mid point of the integration period
-			optflow_sample_new.time_us = time_usec - _params.flow_delay_ms * 1000 - flow->dt / 2;
+			// calculate the system time-stamp for the leading edge of the flow data integration period
+			optflow_sample_new.time_us = time_usec - _params.flow_delay_ms * 1000;
 
 			// copy the quality metric returned by the PX4Flow sensor
 			optflow_sample_new.quality = flow->quality;

--- a/EKF/estimator_interface.h
+++ b/EKF/estimator_interface.h
@@ -180,6 +180,7 @@ public:
 	void setRangeData(uint64_t time_usec, float data);
 
 	// set optical flow data
+	// if optical flow sensor gyro delta angles are not available, set gyroXYZ vector fields to NaN and the EKF will use its internal delta angle data instead
 	void setOpticalFlowData(uint64_t time_usec, flow_message *flow);
 
 	// set external vision position and attitude data

--- a/EKF/optflow_fusion.cpp
+++ b/EKF/optflow_fusion.cpp
@@ -564,7 +564,8 @@ bool Ekf::calcOptFlowBodyRateComp()
 
 	} else {
 		// Use the EKF gyro data if optical flow sensor gyro data is not available
-		_flow_sample_delayed.gyroXYZ = _imu_del_ang_of;
+		// for clarification of the sign see definition of flowSample and imuSample in common.h
+		_flow_sample_delayed.gyroXYZ = - _imu_del_ang_of;
 		_flow_gyro_bias.zero();
 	}
 


### PR DESCRIPTION
Replaces https://github.com/PX4/ecl/pull/453

If optical flow gyro delta angles are set to NAN, then the EKF's internal IMU sample will be used.

TODO testing 