### PR TITLE
EKF: Fix timestamp comparison issue

### DIFF
--- a/EKF/control.cpp
+++ b/EKF/control.cpp
@@ -612,7 +612,7 @@ void Ekf::controlGpsFusion()
 			_hvelInnovGate = fmaxf(_params.vel_innov_gate, 1.0f);
 		}
 
-	} else if (_control_status.flags.gps && (_time_last_imu - _time_last_gps > (uint64_t)10e6)) {
+	} else if (_control_status.flags.gps && (_imu_sample_delayed.time_us - _gps_sample_delayed.time_us > (uint64_t)10e6)) {
 		_control_status.flags.gps = false;
 		ECL_WARN("EKF GPS data stopped");
 	}


### PR DESCRIPTION
Minimum change fix to address https://github.com/PX4/Firmware/issues/9527

Replaces https://github.com/PX4/ecl/pull/461

This fixes a error condition that occurs if _time_last_gps is greater than _time_last_imu.

By checking time stamps at the fusion time horizon, we guarantee that this cannot happen because all observations must have a time stamp smaller or equal to _imu_sample_delayed.time_us before they are retrieved from the buffers.

There are other instances in code where this type of error could occur for other observation types. These will be addressed as part of a separate PR following a more thorough code review.