### PR TITLE
TECS refactor to respect vehicle limits and avoid unnecessary state

### DIFF
--- a/tecs/tecs.cpp
+++ b/tecs/tecs.cpp
@@ -306,25 +306,36 @@ void TECS::_update_throttle_setpoint(const float throttle_cruise, const matrix::
 	// Calculate total energy error
 	_STE_error = _SPE_setpoint - _SPE_estimate + _SKE_setpoint - _SKE_estimate;
 
-	// Calculate demanded rate of change of total energy, respecting vehicle limits
-	float STE_rate_setpoint = constrain((_SPE_rate_setpoint + _SKE_rate_setpoint), _STE_rate_min, _STE_rate_max);
+	// Calculate demanded rate of change of total energy
+	float STE_rate_setpoint = _SPE_rate_setpoint + _SKE_rate_setpoint;
+
+	// Adjust the demanded total energy rate to compensate for induced drag rise in turns.
+	// Assume induced drag scales linearly with normal load factor.
+	// The additional normal load factor is given by (1/cos(bank angle) - 1)
+	if (_load_factor_correction > 0.0f) {
+		float cosPhi = sqrtf((rotMat(0, 1) * rotMat(0, 1)) + (rotMat(1, 1) * rotMat(1, 1)));
+		STE_rate_setpoint += _load_factor_correction * (1.0f / constrain(cosPhi, 0.1f, 1.0f) - 1.0f);
+	}
+
+	// constrain STE rate setpoint respecting vehicle limits
+	STE_rate_setpoint = constrain(STE_rate_setpoint, _STE_rate_min, _STE_rate_max);
 
 	// Calculate the total energy rate error, applying a first order IIR filter
 	// to reduce the effect of accelerometer noise
 	_STE_rate_error = 0.2f * (STE_rate_setpoint - _SPE_rate - _SKE_rate) + 0.8f * _STE_rate_error;
 
+	// Rate limit the throttle demand
+	float throttle_inc_limit = 1.0f;
+
+	if (_throttle_slewrate > 0.0f) {
+		throttle_inc_limit = _dt * (_throttle_setpoint_max - _throttle_setpoint_min) * _throttle_slewrate;
+	}
+
+	// always use full throttle to recover from an underspeed condition
+	float throttle_sp = 1.0f;
+
 	// Calculate the throttle demand
-	if (_underspeed_detected) {
-		// always use full throttle to recover from an underspeed condition
-		_throttle_setpoint = 1.0f;
-
-	} else {
-		// Adjust the demanded total energy rate to compensate for induced drag rise in turns.
-		// Assume induced drag scales linearly with normal load factor.
-		// The additional normal load factor is given by (1/cos(bank angle) - 1)
-		float cosPhi = sqrtf((rotMat(0, 1) * rotMat(0, 1)) + (rotMat(1, 1) * rotMat(1, 1)));
-		STE_rate_setpoint = STE_rate_setpoint + _load_factor_correction * (1.0f / constrain(cosPhi, 0.1f, 1.0f) - 1.0f);
-
+	if (!_underspeed_detected) {
 		// Calculate a predicted throttle from the demanded rate of change of energy, using the cruise throttle
 		// as the starting point. Assume:
 		// Specific total energy rate = _STE_rate_max is achieved when throttle is set to _throttle_setpoint_max
@@ -339,61 +350,58 @@ void TECS::_update_throttle_setpoint(const float throttle_cruise, const matrix::
 		} else {
 			// throttle is between cruise and minimum
 			throttle_predicted = throttle_cruise + STE_rate_setpoint / _STE_rate_min * (_throttle_setpoint_min - throttle_cruise);
-
 		}
 
-		// Calculate gain scaler from specific energy error to throttle
-		float STE_to_throttle = 1.0f / (_throttle_time_constant * (_STE_rate_max - _STE_rate_min));
-
-		// Add proportional and derivative control feedback to the predicted throttle and constrain to throttle limits
-		_throttle_setpoint = (_STE_error + _STE_rate_error * _throttle_damping_gain) * STE_to_throttle + throttle_predicted;
-		_throttle_setpoint = constrain(_throttle_setpoint, _throttle_setpoint_min, _throttle_setpoint_max);
-
-		// Rate limit the throttle demand
-		if (fabsf(_throttle_slewrate) > 0.01f) {
-			float throttle_increment_limit = _dt * (_throttle_setpoint_max - _throttle_setpoint_min) * _throttle_slewrate;
-			_throttle_setpoint = constrain(_throttle_setpoint, _last_throttle_setpoint - throttle_increment_limit,
-						       _last_throttle_setpoint + throttle_increment_limit);
-		}
-
-		_last_throttle_setpoint = _throttle_setpoint;
-
-		if (_integrator_gain > 0.0f) {
-			// Calculate throttle integrator state upper and lower limits with allowance for
-			// 10% throttle saturation to accommodate noise on the demand.
-			float integ_state_max = _throttle_setpoint_max - _throttle_setpoint + 0.1f;
-			float integ_state_min = _throttle_setpoint_min - _throttle_setpoint - 0.1f;
-
-			// Calculate a throttle demand from the integrated total energy error
-			// This will be added to the total throttle demand to compensate for steady state errors
-			_throttle_integ_state = _throttle_integ_state + (_STE_error * _integrator_gain) * _dt * STE_to_throttle;
-
-			if (_climbout_mode_active) {
-				// During climbout, set the integrator to maximum throttle to prevent transient throttle drop
-				// at end of climbout when we transition to closed loop throttle control
-				_throttle_integ_state = integ_state_max;
-
-			} else {
-				// Respect integrator limits during closed loop operation.
-				_throttle_integ_state = constrain(_throttle_integ_state, integ_state_min, integ_state_max);
-			}
-
-		} else {
-			_throttle_integ_state = 0.0f;
-		}
+		// updated throttle setpoint
+		// when flying without an airspeed sensor, use the predicted throttle only
+		throttle_sp = throttle_predicted;
 
 		if (airspeed_sensor_enabled()) {
-			// Add the integrator feedback during closed loop operation with an airspeed sensor
-			_throttle_setpoint = _throttle_setpoint + _throttle_integ_state;
 
-		} else {
-			// when flying without an airspeed sensor, use the predicted throttle only
-			_throttle_setpoint = throttle_predicted;
+			// Calculate gain scaler from specific energy error to throttle
+			const float STE_to_throttle = 1.0f / (_throttle_time_constant * (_STE_rate_max - _STE_rate_min));
 
+			// Add proportional and derivative control feedback to the predicted throttle
+			throttle_sp += (_STE_error + _STE_rate_error * _throttle_damping_gain) * STE_to_throttle;
+
+			if (_integrator_gain > 0.0f) {
+				// constrain new throttle_sp to throttle limits for calculating integrator limits
+				throttle_sp = constrain(throttle_sp, _throttle_setpoint - throttle_inc_limit, _throttle_setpoint + throttle_inc_limit);
+				throttle_sp = constrain(throttle_sp, _throttle_setpoint_min, _throttle_setpoint_max);
+
+				// Calculate throttle integrator state upper and lower limits with allowance for
+				// 10% throttle saturation to accommodate noise on the demand.
+				const float integ_state_min = _throttle_setpoint_min - throttle_sp - 0.1f;
+				const float integ_state_max = _throttle_setpoint_max - throttle_sp + 0.1f;
+
+				if (_climbout_mode_active) {
+					// During climbout, set the integrator to maximum throttle to prevent transient throttle drop
+					// at end of climbout when we transition to closed loop throttle control
+					_throttle_integ_state = integ_state_max;
+
+				} else {
+					// Calculate a throttle demand from the integrated total energy error
+					// This will be added to the total throttle demand to compensate for steady state errors
+					float integ_state_update = _throttle_integ_state + (_STE_error * _integrator_gain) * _dt * STE_to_throttle;
+
+					// Respect integrator limits during closed loop operation.
+					_throttle_integ_state = constrain(integ_state_update, integ_state_min, integ_state_max);
+				}
+
+				// Add the integrator feedback during closed loop operation with an airspeed sensor
+				throttle_sp += _throttle_integ_state;
+
+			} else {
+				_throttle_integ_state = 0.0f;
+			}
 		}
-
-		_throttle_setpoint = constrain(_throttle_setpoint, _throttle_setpoint_min, _throttle_setpoint_max);
 	}
+
+	// apply slew, final constraint, and update throttle setpoint
+	throttle_sp = constrain(throttle_sp, _throttle_setpoint - throttle_inc_limit, _throttle_setpoint + throttle_inc_limit);
+	throttle_sp = constrain(throttle_sp, _throttle_setpoint_min, _throttle_setpoint_max);
+
+	_throttle_setpoint = throttle_sp;
 }
 
 void TECS::_detect_uncommanded_descent()
@@ -528,7 +536,7 @@ void TECS::_initialize_states(float pitch, float throttle_cruise, float baro_alt
 		_tas_state = _EAS * EAS2TAS;
 		_throttle_integ_state =  0.0f;
 		_pitch_integ_state = 0.0f;
-		_last_throttle_setpoint = (_in_air ? throttle_cruise : 0.0f);;
+		_throttle_setpoint = (_in_air ? throttle_cruise : 0.0f);;
 		_last_pitch_setpoint = constrain(pitch, _pitch_setpoint_min, _pitch_setpoint_max);
 		_pitch_setpoint_unc = _last_pitch_setpoint;
 		_hgt_setpoint_adj_prev = baro_altitude;

--- a/tecs/tecs.h
+++ b/tecs/tecs.h
@@ -217,7 +217,6 @@ private:
 	// controller states
 	float _throttle_integ_state{0.0f};				///< throttle integrator state
 	float _pitch_integ_state{0.0f};					///< pitch integrator state (rad)
-	float _last_throttle_setpoint{0.0f};				///< throttle demand rate limiter state (1/sec)
 	float _last_pitch_setpoint{0.0f};				///< pitch demand rate limiter state (rad/sec)
 	float _speed_derivative{0.0f};					///< rate of change of speed along X axis (m/sec**2)
 

--- a/tecs/tecs.h
+++ b/tecs/tecs.h
@@ -217,7 +217,6 @@ private:
 	// controller states
 	float _throttle_integ_state{0.0f};				///< throttle integrator state
 	float _pitch_integ_state{0.0f};					///< pitch integrator state (rad)
-	float _last_pitch_setpoint{0.0f};				///< pitch demand rate limiter state (rad/sec)
 	float _speed_derivative{0.0f};					///< rate of change of speed along X axis (m/sec**2)
 
 	// speed demand calculations


### PR DESCRIPTION
When reviewing https://github.com/PX4/ecl/pull/467 I noticed a few things in TECS.

* vehicle limits weren't being respected with the load factor correction
* the airspeed less mode is hard to follow because it goes through all the same integrator logic, but then ignores the result
* the throttle slew rate was also only respected in non-climbout airspeed mode
* it's not necessary to store the previous throttle setpoint.

@philipoe would you mind reviewing?

