### PR TITLE
Ekf opt flow fixes poor flow quality

### DIFF
--- a/EKF/common.h
+++ b/EKF/common.h
@@ -291,7 +291,7 @@ struct parameters {
 	float flow_noise_qual_min{0.5f};	///< observation noise for optical flow LOS rate measurements when flow sensor quality is at the minimum useable (rad/sec)
 	int32_t flow_qual_min{1};		///< minimum acceptable quality integer required once fusion of data has commenced
 	int32_t flow_qual_min_init{128};	///< minimum acceptable quality integer required to commence fusion
-	int32_t flow_qual_min_check{0};		///< enable minimum acceptable quality integer check on the ground required to commence fusion
+	int32_t flow_qual_check_on_ground{1};	///< enable minimum acceptable quality integer check on the ground required to commence fusion
 	float flow_innov_gate{3.0f};		///< optical flow fusion innovation consistency gate size (STD)
 	float flow_rate_max{2.5f};		///< maximum valid optical flow rate (rad/sec)
 

--- a/EKF/common.h
+++ b/EKF/common.h
@@ -291,6 +291,7 @@ struct parameters {
 	float flow_noise_qual_min{0.5f};	///< observation noise for optical flow LOS rate measurements when flow sensor quality is at the minimum useable (rad/sec)
 	int32_t flow_qual_min{1};		///< minimum acceptable quality integer required once fusion of data has commenced
 	int32_t flow_qual_min_init{128};	///< minimum acceptable quality integer required to commence fusion
+	int32_t flow_qual_min_check{0};		///< enable minimum acceptable quality integer check on the ground required to commence fusion
 	float flow_innov_gate{3.0f};		///< optical flow fusion innovation consistency gate size (STD)
 	float flow_rate_max{2.5f};		///< maximum valid optical flow rate (rad/sec)
 

--- a/EKF/common.h
+++ b/EKF/common.h
@@ -291,7 +291,7 @@ struct parameters {
 	float flow_noise_qual_min{0.5f};	///< observation noise for optical flow LOS rate measurements when flow sensor quality is at the minimum useable (rad/sec)
 	int32_t flow_qual_min{1};		///< minimum acceptable quality integer required once fusion of data has commenced
 	int32_t flow_qual_min_init{128};	///< minimum acceptable quality integer required to commence fusion
-	int32_t flow_qual_check_on_ground{1};	///< enable minimum acceptable quality integer check on the ground required to commence fusion
+	int32_t flow_qual_check_on_ground{1};	///< set to 1 to enable, 0 to disable application of the flow_qual_min_init threshhold check when the vehicle is on ground
 	float flow_innov_gate{3.0f};		///< optical flow fusion innovation consistency gate size (STD)
 	float flow_rate_max{2.5f};		///< maximum valid optical flow rate (rad/sec)
 

--- a/EKF/control.cpp
+++ b/EKF/control.cpp
@@ -426,7 +426,7 @@ void Ekf::controlOpticalFlowFusion()
 
 				}
 			}
-		} else if (!(_params.fusion_mode & MASK_USE_OF)) {
+		} else if (!(_params.fusion_mode & MASK_USE_OF) || (_params.fusion_mode & MASK_USE_OF && !flow_quality_ok)) {
 			_control_status.flags.opt_flow = false;
 
 		}

--- a/EKF/control.cpp
+++ b/EKF/control.cpp
@@ -393,7 +393,7 @@ void Ekf::controlOpticalFlowFusion()
 		_delta_time_of += _imu_sample_delayed.delta_ang_dt;
 
 		// optical flow fusion mode selection logic
-		bool flow_quality_ok = _flow_sample_delayed.quality >= _params.flow_qual_min_init;
+		bool flow_quality_ok = (_flow_sample_delayed.quality >= _params.flow_qual_min_init) || (!_control_status.flags.in_air && _params.flow_qual_min_check);
 		if (!flow_quality_ok) {
 			_time_bad_flow_qual = _imu_sample_delayed.time_us;
 		}

--- a/EKF/ekf.h
+++ b/EKF/ekf.h
@@ -360,6 +360,7 @@ private:
 	uint64_t _time_good_motion_us{0};	///< last system time that on-ground motion was within limits (uSec)
 	bool _inhibit_flow_use{false};	///< true when use of optical flow and range finder is being inhibited
 	uint64_t _time_bad_flow_qual{0};	///< last system time that optical flow data quality was below start of use check limit (uSec)
+	uint64_t _time_takeoff{0};	///< record the takeoff time when in_air flag is true (uSec)
 
 	float _mag_declination{0.0f};	///< magnetic declination used by reset and fusion functions (rad)
 

--- a/EKF/ekf.h
+++ b/EKF/ekf.h
@@ -360,7 +360,7 @@ private:
 	uint64_t _time_good_motion_us{0};	///< last system time that on-ground motion was within limits (uSec)
 	bool _inhibit_flow_use{false};	///< true when use of optical flow and range finder is being inhibited
 	uint64_t _time_bad_flow_qual{0};	///< last system time that optical flow data quality was below start of use check limit (uSec)
-	uint64_t _time_takeoff{0};	///< record the takeoff time when in_air flag is true (uSec)
+	uint64_t _time_takeoff{0};	///< record the takeoff time once we are in-air (uSec)
 
 	float _mag_declination{0.0f};	///< magnetic declination used by reset and fusion functions (rad)
 


### PR DESCRIPTION
1.Disable optical flow fuse when the flow quality is poor, it will also use poor flow data in altitude mode which will cause velocity to diverge and out of control.

this issue will occurs with EKF2_OF_QMIN value of 1 and poor flow quality, tesing with EKF2_OF_QMIN value of 100 and 40, I found that the optical flow data was used in altitude mode when it is poor quality.

issue log link: https://logs.px4.io/plot_app?log=3d21e384-6bf1-4009-a605-a8d8a3063af2 (EKF2_OF_QMIN = 100)
             https://logs.px4.io/plot_app?log=13445020-c395-480d-aaf7-de21d58d33fd (EKF2_OF_QMIN = 40)
             https://logs.px4.io/plot_app?log=4546e851-5584-4449-8138-79174aebe51b (EKF2_OF_QMIN = 1)
![flow-bad3](https://user-images.githubusercontent.com/24579906/42434097-662c3582-8384-11e8-9fed-0fb8505b98c0.png)

log with fixs: https://logs.px4.io/plot_app?log=3b1def27-95e5-489f-bc07-36a18df14ac4

2. Add a variable to enable or disable the check of minimum acceptable quality integer from the flow sensor on the ground to start using optical flow, because of the flow sensor may be close to the ground and invalid before takeoff.

@priseborough can you have a look? thanks, Issue:https://github.com/YUNEEC/Firmware/issues/2239