### PR TITLE
EKF: Fix handling of distance sensor data timeouts

### DIFF
--- a/EKF/control.cpp
+++ b/EKF/control.cpp
@@ -110,17 +110,15 @@ void Ekf::controlFusionModes()
 	// Get range data from buffer and check validity
 	_range_data_ready = _range_buffer.pop_first_older_than(_imu_sample_delayed.time_us, &_range_sample_delayed);
 
-	if (_range_data_ready) {
-		checkRangeDataValidity();
+	checkRangeDataValidity();
 
-		if (_range_data_ready && !_rng_hgt_faulty) {
-			// correct the range data for position offset relative to the IMU
-			Vector3f pos_offset_body = _params.rng_pos_body - _params.imu_pos_body;
-			Vector3f pos_offset_earth = _R_to_earth * pos_offset_body;
-			_range_sample_delayed.rng += pos_offset_earth(2) / _R_rng_to_earth_2_2;
-		}
+	if (_range_data_ready && !_rng_hgt_faulty) {
+		// correct the range data for position offset relative to the IMU
+		Vector3f pos_offset_body = _params.rng_pos_body - _params.imu_pos_body;
+		Vector3f pos_offset_earth = _R_to_earth * pos_offset_body;
+		_range_sample_delayed.rng += pos_offset_earth(2) / _R_rng_to_earth_2_2;
 	}
-
+	
 	// We don't fuse flow data immediately because we have to wait for the mid integration point to fall behind the fusion time horizon.
 	// This means we stop looking for new data until the old data has been fused.
 	if (!_flow_data_ready) {

--- a/EKF/control.cpp
+++ b/EKF/control.cpp
@@ -1138,13 +1138,18 @@ void Ekf::rangeAidConditionsMet()
 
 void Ekf::checkRangeDataValidity()
 {
-	// reset fault status
-	_rng_hgt_faulty = false;
-
 	// check if out of date
 	if ((_imu_sample_delayed.time_us - _range_sample_delayed .time_us) > 2 * RNG_MAX_INTERVAL) {
 		_rng_hgt_faulty = true;
 		return;
+	}
+
+	// Don't run the checks after this unless we have retrieved new data from the buffer
+	if (!_range_data_ready) {
+		return;
+	} else {
+		// reset fault status when we get new data
+		_rng_hgt_faulty = false;
 	}
 
 	// Check if excessively tilted

--- a/EKF/ekf.h
+++ b/EKF/ekf.h
@@ -431,7 +431,7 @@ private:
 	// height sensor fault status
 	bool _baro_hgt_faulty{false};		///< true if valid baro data is unavailable for use
 	bool _gps_hgt_faulty{false};		///< true if valid gps height data is unavailable for use
-	bool _rng_hgt_faulty{false};		///< true if valid rnage finder height data is unavailable for use
+	bool _rng_hgt_faulty{false};		///< true if valid range finder height data is unavailable for use
 	int _primary_hgt_source{VDIST_SENSOR_BARO};	///< specifies primary source of height data
 
 	// imu fault status

--- a/EKF/terrain_estimator.cpp
+++ b/EKF/terrain_estimator.cpp
@@ -94,7 +94,7 @@ void Ekf::runTerrainEstimator()
 		_terrain_var = math::constrain(_terrain_var, 0.0f, 1e4f);
 
 		// Fuse range finder data if available
-		if (_range_data_ready && !_control_status.flags.rng_stuck) {
+		if (_range_data_ready && !_rng_hgt_faulty) {
 			fuseHagl();
 
 			// update range sensor angle parameters in case they have changed


### PR DESCRIPTION
Fixes https://github.com/PX4/ecl/issues/478

**Tests Required**

These tests could be performed using SITL with modification of the ekf2_main.cpp file to perform the necessary distance_sensor data manipulation.

1) EKF2_RNG_AID = 1 and EKF2_HGT_MODE = 0

Place vehicle in hover at height that activates range finder use. Stop publication of range data for at least 1 second before resuming and verify that baro fusion commences after 0.4 seconds and range finder fusion re-commences when data returns.

2)  EKF2_RNG_AID = 0 and EKF2_HGT_MODE = 0

Set the distance sensor out of range for over 10 seconds and then set to a constant value within range. Verify that the stuck value check prevents the data from being used.