### PR TITLE
l1 position control: added roll angle setpoint slew rate limiting

### DIFF
--- a/l1/ecl_l1_pos_controller.cpp
+++ b/l1/ecl_l1_pos_controller.cpp
@@ -58,11 +58,7 @@ void ECL_L1_Pos_Controller::update_roll_setpoint()
 	}
 
 	// slew rate limiting active
-	if ((roll_new - _roll_setpoint) / _dt > _roll_slew_rate) {
-		roll_new = _roll_setpoint + _roll_slew_rate * _dt;
-	} else if ((roll_new - _roll_setpoint) / _dt < -_roll_slew_rate) {
-		roll_new = _roll_setpoint - _roll_slew_rate * _dt;
-	}
+	roll_new = math::constrain(roll_new, _roll_setpoint - _roll_slew_rate * _dt, _roll_setpoint + _roll_slew_rate * _dt);
 
 	_roll_setpoint = roll_new;
 

--- a/l1/ecl_l1_pos_controller.h
+++ b/l1/ecl_l1_pos_controller.h
@@ -105,7 +105,7 @@ public:
 	 *
 	 * @return Roll angle (in NED frame)
 	 */
-	float nav_roll();
+	float get_roll_setpoint(){ return _roll_setpoint; }
 
 	/**
 	 * Get the current crosstrack error.
@@ -195,6 +195,16 @@ public:
 	 */
 	void set_l1_roll_limit(float roll_lim_rad) { _roll_lim_rad = roll_lim_rad; }
 
+	/**
+	 * Set roll angle slew rate. Set to zero to deactivate.
+	 */
+	void set_roll_slew_rate(float roll_slew_rate) { _roll_slew_rate = roll_slew_rate; }
+
+	/**
+	 * Set control loop dt. The value will be used to apply roll angle setpoint slew rate limiting.
+	 */
+	void set_dt(float dt) { _dt = dt;}
+
 private:
 
 	float _lateral_accel{0.0f};		///< Lateral acceleration setpoint in m/s^2
@@ -211,7 +221,10 @@ private:
 	float _K_L1{2.0f};			///< L1 control gain for _L1_damping
 	float _heading_omega{1.0f};		///< Normalized frequency
 
-	float _roll_lim_rad{math::radians(30.0f)};  ///<maximum roll angle
+	float _roll_lim_rad{math::radians(30.0f)};  ///<maximum roll angle in radians
+	float _roll_setpoint{0.0f};	///< current roll angle setpoint in radians
+	float _roll_slew_rate{0.0f};	///< roll angle setpoint slew rate limit in rad/s
+	float _dt{0};				///< control loop time in seconds
 
 	/**
 	 * Convert a 2D vector from WGS84 to planar coordinates.
@@ -225,6 +238,12 @@ private:
 	 * @return The vector in meters pointing from the reference position to the coordinates
 	 */
 	matrix::Vector2f get_local_planar_vector(const matrix::Vector2f &origin, const matrix::Vector2f &target) const;
+
+	/**
+	 * Update roll angle setpoint. This will also apply slew rate limits if set.
+	 *
+	 */
+	void update_roll_setpoint();
 
 };
 


### PR DESCRIPTION
This adds slew rate limiting of the roll angle setpoint to the l1 controller.
It also implements a private method to calculate the roll setpoint (update_roll_setpoint) and a public method to get the roll setpoint (get_roll_setpoint). Previously the roll setpoint was calculated more than one time during one control cycle.

The aim of this is to avoid sudden steps in roll angle setpoint which can occur if there is a switch in waypoints.

Signed-off-by: Roman <bapstroman@gmail.com>