### PR TITLE
EKF: Correct documentation and function name for declination accessor

### DIFF
--- a/EKF/estimator_interface.h
+++ b/EKF/estimator_interface.h
@@ -315,8 +315,9 @@ public:
 		*time_us = _time_last_imu;
 	}
 
-	// Copy the magnetic declination that we wish to save to the EKF2_MAG_DECL parameter for the next startup
-	void copy_mag_decl_deg(float *val)
+	// Get the value of magnetic declination in degrees to be saved for use at the next startup
+	// At the next startup, set param.mag_declination_deg to the value saved
+	void get_mag_decl_deg(float *val)
 	{
 		*val = _mag_declination_to_save_deg;
 	}

--- a/EKF/estimator_interface.h
+++ b/EKF/estimator_interface.h
@@ -316,10 +316,12 @@ public:
 	}
 
 	// Get the value of magnetic declination in degrees to be saved for use at the next startup
+	// Returns true when the declination can be saved
 	// At the next startup, set param.mag_declination_deg to the value saved
-	void get_mag_decl_deg(float *val)
+	bool get_mag_decl_deg(float *val)
 	{
 		*val = _mag_declination_to_save_deg;
+		return _NED_origin_initialised && (_params.mag_declination_source & MASK_SAVE_GEO_DECL);
 	}
 
 	virtual void get_accel_bias(float bias[3]) = 0;


### PR DESCRIPTION
Refer to https://github.com/PX4/Firmware/issues/10023

The function name and documentation are misleading given the function is only a getter.
This change makes the usage clearer.
The function is not currently used by PX4/Firmware.