### PR TITLE
Fix invisible ceiling when using range aiding

### DIFF
--- a/EKF/ekf_helper.cpp
+++ b/EKF/ekf_helper.cpp
@@ -1091,7 +1091,7 @@ void Ekf::get_ekf_ctrl_limits(float *vxy_max, float *vz_max, float *hagl_min, fl
 
 	// TODO : calculate visual odometry limits
 
-	bool relying_on_rangefinder = _control_status.flags.rng_hgt;
+	bool relying_on_rangefinder = _control_status.flags.rng_hgt && !_params.range_aid;
 
 	bool relying_on_optical_flow = _control_status.flags.opt_flow && !(_control_status.flags.gps || _control_status.flags.ev_pos);
 


### PR DESCRIPTION
This PR adds a check for **range aiding** to determine if we are `relying_on_rangefinder`. This fixes the bug we are experiencing where we are limited to the range finders max height above ground when using it in aiding mode. If range aiding is not enabled, and thus the range finder _is_ intended to be the sole source of height observation, then this check will evaluate true and the controller will still properly limit the height above ground.

Let me know if you have any questions or concerns, thanks!
Jake