### PR TITLE
Reset baro datum to current state when switching out of range aiding

### DIFF
--- a/EKF/control.cpp
+++ b/EKF/control.cpp
@@ -934,7 +934,8 @@ void Ekf::controlHeightFusion()
 			setControlBaroHeight();
 			_fuse_height = true;
 
-			// we have just switched to using baro height, we don't need to set a height sensor offset
+			// we have just switched to using baro height, use current estimate to recalculate the height offset
+			resetBaroDatum();
 			// since we track a separate _baro_hgt_offset
 			if (_control_status_prev.flags.baro_hgt != _control_status.flags.baro_hgt) {
 				_hgt_sensor_offset = 0.0f;
@@ -1083,12 +1084,11 @@ void Ekf::rangeAidConditionsMet()
 {
 	// if the parameter for range aid is enabled we allow to switch from using the primary height source to using range finder as height source
 	// under the following conditions
-	// 1) Vehicle is in-air
-	// 2) Range data is valid
-	// 3) Vehicle is no further than max_hagl_for_range_aid away from the ground
-	// 4) Ground speed is not higher than max_vel_for_range_aid
-	// 5) Terrain estimate is stable (needs better checks)
-	if (_control_status.flags.in_air && !_rng_hgt_faulty) {
+	// 1) Range data is valid
+	// 2) Vehicle is no further than max_hagl_for_range_aid away from the ground
+	// 3) Ground speed is not higher than max_vel_for_range_aid
+	// 4) Terrain estimate is stable (needs better checks)
+	if (!_rng_hgt_faulty) {
 		// check if we can use range finder measurements to estimate height, use hysteresis to avoid rapid switching
 		bool can_use_range_finder;
 		if (_range_aid_mode_enabled) {
@@ -1176,6 +1176,13 @@ void Ekf::checkRangeDataValidity()
 			_range_sample_delayed.rng = _params.rng_gnd_clearance;
 			return;
 		}
+	}
+
+	// If landed, check to make sure current measurements are within 10cm of the ground clearance value (EKF2_MIN_RNG).
+	if(! _control_status.flags.in_air) {
+		float acceptable_error = 0.1f; // 10cm of acceptable measurement error when landed
+		_rng_hgt_faulty = _range_sample_delayed.rng < (_params.rng_gnd_clearance + acceptable_error) 
+				&& _range_sample_delayed.rng > (_params.rng_gnd_clearance - acceptable_error);
 	}
 
 	// Check for "stuck" range finder measurements when range was not valid for certain period

--- a/EKF/ekf.h
+++ b/EKF/ekf.h
@@ -531,6 +531,9 @@ private:
 	// reset height state of the ekf
 	void resetHeight();
 
+	// reset baro datum to current state estimate
+	void resetBaroDatum();
+
 	// modify output filter to match the the EKF state at the fusion time horizon
 	void alignOutputFilter();
 

--- a/EKF/ekf_helper.cpp
+++ b/EKF/ekf_helper.cpp
@@ -199,6 +199,14 @@ bool Ekf::resetPosition()
 	return true;
 }
 
+// Reset baro datum when another high accuracy source is available (i.e high resolution rangefinder)
+void Ekf::resetBaroDatum()
+{
+	// reset the baro offset which is subtracted from the baro reading if we need to use it as a backup
+	const baroSample &baro_newest = _baro_buffer.get_newest();
+	_baro_hgt_offset = baro_newest.hgt + _state.pos(2);
+}
+
 // Reset height state using the last height measurement
 void Ekf::resetHeight()
 {
@@ -236,8 +244,7 @@ void Ekf::resetHeight()
 			vert_pos_reset = true;
 
 			// reset the baro offset which is subtracted from the baro reading if we need to use it as a backup
-			const baroSample &baro_newest = _baro_buffer.get_newest();
-			_baro_hgt_offset = baro_newest.hgt + _state.pos(2);
+			resetBaroDatum();
 
 		} else {
 			// TODO: reset to last known range based estimate
@@ -278,9 +285,7 @@ void Ekf::resetHeight()
 
 			vert_pos_reset = true;
 
-			// reset the baro offset which is subtracted from the baro reading if we need to use it as a backup
-			const baroSample &baro_newest = _baro_buffer.get_newest();
-			_baro_hgt_offset = baro_newest.hgt + _state.pos(2);
+			resetBaroDatum();
 
 		} else {
 			// TODO: reset to last known gps based estimate


### PR DESCRIPTION
This PR introduces 2 changes with respect to **range aiding**.
1. New function `Ekf::resetBaroDatum`. This function simply resets the datum so that the current baro measurements match the predicted state. I replaced two instances of this behavior and added one new one. The new instance of this resetting of baro datum occurs when switching back to the barometer from rangefinder in **range aid** mode. I have flight tested this and collected some data at the estimator level with some custom topic logging. 
![baro_hgt_reset](https://user-images.githubusercontent.com/37091262/43855173-0b508894-9b02-11e8-8a53-f53c00c89b73.png)
![rng_aiding](https://user-images.githubusercontent.com/37091262/43855207-2343431a-9b02-11e8-8f1c-bab16a473a4e.png)

2. Allow range sensor measurements to be used while `landed` as long as the measurements are within +/-10cm of the expected `rng_gnd_clearance` which is defined by **EKF2_MIN_RNG**

https://review.px4.io/plot_app?log=95753bfa-f112-4f9b-9d01-54c9ba92152e