### PR TITLE
l1 position controller: protect against NAN

### DIFF
--- a/l1/ecl_l1_pos_controller.cpp
+++ b/l1/ecl_l1_pos_controller.cpp
@@ -51,16 +51,14 @@ void ECL_L1_Pos_Controller::update_roll_setpoint()
 	float roll_new = atanf(_lateral_accel * 1.0f / CONSTANTS_ONE_G);
 	roll_new = math::constrain(roll_new, -_roll_lim_rad, _roll_lim_rad);
 
-	// no slew rate limiting active
-	if (_dt <= 0.0f || _roll_slew_rate <= 0.0f) {
-		_roll_setpoint = roll_new;
-		return;
+	if (_dt > 0.0f && _roll_slew_rate > 0.0f) {
+		// slew rate limiting active
+		roll_new = math::constrain(roll_new, _roll_setpoint - _roll_slew_rate * _dt, _roll_setpoint + _roll_slew_rate * _dt);
 	}
 
-	// slew rate limiting active
-	roll_new = math::constrain(roll_new, _roll_setpoint - _roll_slew_rate * _dt, _roll_setpoint + _roll_slew_rate * _dt);
-
-	_roll_setpoint = roll_new;
+	if (ISFINITE(roll_new)) {
+		_roll_setpoint = roll_new;
+	}
 
 }
 


### PR DESCRIPTION
@eyeam3 mentioned that under certain circumstances the the l1 position controller can produce a NAN roll setpoint. If we don't protect the slew rate limit logic against this the state will not be able to recover.

@eyeam3 Thanks for your input! Do you want to review? :-)

Signed-off-by: Roman <bapstroman@gmail.com>