### PR TITLE
EKF:  enable optical flow use to bootstrap when quality poor

### DIFF
--- a/EKF/estimator_interface.cpp
+++ b/EKF/estimator_interface.cpp
@@ -369,9 +369,7 @@ void EstimatorInterface::setOpticalFlowData(uint64_t time_usec, flow_message *fl
 			flow_magnitude_good = (flow_rate_magnitude <= _flow_max_rate);
 		}
 
-		bool relying_on_flow =  _control_status.flags.opt_flow
-				&& !_control_status.flags.gps
-				&& !_control_status.flags.ev_pos;
+		bool relying_on_flow = !_control_status.flags.gps && !_control_status.flags.ev_pos;
 
 		// check quality metric
 		bool flow_quality_good = (flow->quality >= _params.flow_qual_min);


### PR DESCRIPTION
Fixes potential fault condition whereby if optical flow sensor started out of focus with quality below startup minimum, then optical flow fusion would never start.

May be relevant to issue reported here: https://github.com/PX4/ecl/pull/498#issuecomment-417810912

Log of successful  SITL test here: https://logs.px4.io/plot_app?log=03ecea26-9024-4f7f-8377-977cb63fdc32

Flow Innovations:
<img width="1098" alt="screen shot 2018-09-01 at 9 26 24 pm" src="https://user-images.githubusercontent.com/3596952/44945479-daa7ee00-ae2d-11e8-8b0d-044fc161985a.png">

Flow Quality - note it starts at zero when simulated sensor is close to ground
<img width="1120" alt="screen shot 2018-09-01 at 9 26 47 pm" src="https://user-images.githubusercontent.com/3596952/44945480-dda2de80-ae2d-11e8-90fe-60e58b5adb85.png">

