### PR TITLE
EKF: Fix bug that prevents use of flow sensors without gyros

### DIFF
--- a/EKF/estimator_interface.cpp
+++ b/EKF/estimator_interface.cpp
@@ -375,7 +375,7 @@ void EstimatorInterface::setOpticalFlowData(uint64_t time_usec, flow_message *fl
 		bool flow_quality_good = (flow->quality >= _params.flow_qual_min);
 
 		// Check data validity and write to buffers
-		// Use a zero velocity assumption to constrain drift when on-ground if necessary
+		// Invalid flow data is allowed when on ground and is handled as a special case in controlOpticalFlowFusion()
 		bool use_flow_data_to_navigate = delta_time_good && flow_quality_good && (flow_magnitude_good || relying_on_flow);
 		if (use_flow_data_to_navigate || (!_control_status.flags.in_air && relying_on_flow)) {
 			flowSample optflow_sample_new;
@@ -389,16 +389,7 @@ void EstimatorInterface::setOpticalFlowData(uint64_t time_usec, flow_message *fl
 			// NOTE: the EKF uses the reverse sign convention to the flow sensor. EKF assumes positive LOS rate
 			// is produced by a RH rotation of the image about the sensor axis.
 			optflow_sample_new.gyroXYZ = - flow->gyrodata;
-
-			// If flow quality checks are failed, then we are on ground without another method of navigation
-			// and can use a zero velocity assumption to constrain drift
-			if (!use_flow_data_to_navigate) {
-				// set flow rates to value consistent with pure rotational motion
-				optflow_sample_new.flowRadXY(0) = - flow->gyrodata(0);
-				optflow_sample_new.flowRadXY(1) = - flow->gyrodata(1);
-			} else {
-				optflow_sample_new.flowRadXY = -flow->flowdata;
-			}
+			optflow_sample_new.flowRadXY = -flow->flowdata;
 
 			// convert integration interval to seconds
 			optflow_sample_new.dt = delta_time;


### PR DESCRIPTION
The handling of invalid flow data when on ground is performed in controlOpticalFlowFusion() where it is able to handle the case of flow sensors that don't publish gyro data. By handling the on-ground with invalid flow data case in the interface before data is pushed into the buffer, the change introduced by commit a53ad9c removed the ability to handle flow sensors that publish NAN for gyro data. This was not picked up in testing because the SITL model does nor simulate that type of sensor.

**Testing**

Testing performed was on SITL with 'make posix gazebo_iris_opt_flow' target

Default test log with flow sensor gyro data: https://logs.px4.io/plot_app?log=ca849660-3d78-4a60-833e-84d1ad9dd63e

The simulator_mavlink.cpp file was then modified to set the published flow gyro integral data to NAN

	//rotate_3f(flow_rot, flow.gyro_x_rate_integral, flow.gyro_y_rate_integral, flow.gyro_z_rate_integral);
	flow.gyro_x_rate_integral = NAN;
	flow.gyro_y_rate_integral = NAN;
	flow.gyro_z_rate_integral = NAN;

 https://logs.px4.io/plot_app?log=0dbf3ee3-cf69-4094-b305-1862f5c145ba

![screen shot 2018-09-03 at 9 00 28 am](https://user-images.githubusercontent.com/3596952/44961675-60c05380-af58-11e8-92b6-8fe0a673afca.png)