### PR TITLE
EKF : Fix divergence when optical flow is not fused for a long time

### DIFF
--- a/EKF/control.cpp
+++ b/EKF/control.cpp
@@ -420,7 +420,7 @@ void Ekf::controlOpticalFlowFusion()
 			       _control_status.flags.opt_flow = false;
 			       _time_last_of_fuse = 0;
 
-			} else if (_time_last_imu - _flow_sample_delayed.time_us > (uint64_t)_params.no_gps_timeout_max) {
+			} else if (_time_last_imu - _time_last_of_fuse > (uint64_t)_params.no_gps_timeout_max) {
 				_control_status.flags.opt_flow = false;
 
 			}

--- a/EKF/terrain_estimator.cpp
+++ b/EKF/terrain_estimator.cpp
@@ -206,7 +206,7 @@ void Ekf::checkRangeDataContinuity()
 	/* Apply a 2.0 sec low pass filter to the time delta from the last range finder updates */
 	float alpha = 0.5f * _dt_update;
 	_dt_last_range_update_filt_us = _dt_last_range_update_filt_us * (1.0f - alpha) + alpha *
-					(_time_last_imu - _time_last_range);
+					(_imu_sample_delayed.time_us - _range_sample_delayed.time_us);
 
 	_dt_last_range_update_filt_us = fminf(_dt_last_range_update_filt_us, 4e6f);
 


### PR DESCRIPTION
The EKF would not correctly detect when it stopped fusing optical flow due to failing checks (e.g motion  excessive, or invalid terrain estimate), and eventually diverge without any aiding source. 

Commits : 
1. Fixes a corner case in the terrain estimator, where range data newer than the IMU sample would cause an overflow due to unsigned math, similar to https://github.com/PX4/ecl/pull/462. This is still a problem in some other places in ECL, and I will be fixing them incrementally.
2. Fixes the flow  aiding timeout check to use the last time optical flow was fused instead of the time the last sample is from.

Testing  :  
https://logs.px4.io/plot_app?log=ea18fc88-8ce5-4382-ab62-35a9a0d015f3
The log was replayed without this fix, and then with this fix. The estimator does not diverge in the second  case and correctly detects no flow fusion and stops navigation.