### PR TITLE
Optical flow fusion control improvements

### DIFF
--- a/EKF/control.cpp
+++ b/EKF/control.cpp
@@ -588,7 +588,6 @@ void Ekf::controlGpsFusion()
 
 					if (_control_status.flags.gps) {
 						ECL_INFO("EKF commencing GPS fusion");
-						_time_last_gps = _time_last_imu;
 					}
 				}
 			}

--- a/EKF/control.cpp
+++ b/EKF/control.cpp
@@ -119,8 +119,7 @@ void Ekf::controlFusionModes()
 	// We don't fuse flow data immediately because we have to wait for the mid integration point to fall behind the fusion time horizon.
 	// This means we stop looking for new data until the old data has been fused.
 	if (!_flow_data_ready) {
-		_flow_data_ready = _flow_buffer.pop_first_older_than(_imu_sample_delayed.time_us, &_flow_sample_delayed)
-				   && (_R_to_earth(2, 2) > _params.range_cos_max_tilt);
+		_flow_data_ready = _flow_buffer.pop_first_older_than(_imu_sample_delayed.time_us, &_flow_sample_delayed);
 	}
 
 	_ev_data_ready = _ext_vision_buffer.pop_first_older_than(_imu_sample_delayed.time_us, &_ev_sample_delayed);

--- a/EKF/control.cpp
+++ b/EKF/control.cpp
@@ -446,10 +446,6 @@ void Ekf::controlOpticalFlowFusion()
 				if (!_control_status.flags.gps || !_control_status.flags.ev_pos) {
 					resetVelocity();
 					resetPosition();
-
-					// align the output observer to the EKF states
-					alignOutputFilter();
-
 				}
 			}
 


### PR DESCRIPTION
Brings in some fixes and improvements in optical flow fusion control. Includes https://github.com/PX4/ecl/pull/502 as it was needed for flight testing. Most of these corner cases are more visible on platforms running optical flow algorithms offboard. (e.g Aero,  Snapdragon Flight)

Functional changes : 
1. Add protection against large dts, which can put the fusion control into a bad state (if fusion stops, it never starts again) due to float overflows and unsigned integer checks.
 (https://github.com/PX4/ecl/blob/master/EKF/control.cpp#L496)
2. Remove unnecessary check for tilt angle when popping new data from flow buffer. There is a similar check downstream, and this one was interfering with correct fusion inhibition detection.
3. Handle flow data timeouts correctly (fusion timeouts != data stopped)
4. Remove state predictor alignment which doesn't seem to be used for any of the other aiding sources.  
5. Add 2 minor `ECL_INFO` statements which go a long way in figuring out what went wrong in logs.

Log :
https://logs.px4.io/plot_app?log=a13404d3-078e-4f04-94e0-19a1f287bc72
 