### PR TITLE
Add vision height covariance passthrough

### DIFF
--- a/EKF/common.h
+++ b/EKF/common.h
@@ -81,8 +81,8 @@ struct ext_vision_message {
 	Vector3f posNED;	///< measured NED position relative to the local origin (m)
 	Quatf quat;		///< measured quaternion orientation defining rotation from NED to body frame
 	float posErr;		///< 1-Sigma horizontal position accuracy (m)
+	float hgtErr;		///< 1-Sigma height accuracy (m)
 	float angErr;		///< 1-Sigma angular error (rad)
-	float hgtErr;		///< 1-Sigma height error (rad)
 };
 
 struct outputSample {
@@ -150,8 +150,8 @@ struct extVisionSample {
 	Vector3f posNED;	///< measured NED position relative to the local origin (m)
 	Quatf quat;		///< measured quaternion orientation defining rotation from NED to body frame
 	float posErr;		///< 1-Sigma horizontal position accuracy (m)
+	float hgtErr;		///< 1-Sigma height accuracy (m)
 	float angErr;		///< 1-Sigma angular error (rad)
-	float hgtErr;		///< 1-Sigma height error (rad)
 	uint64_t time_us;	///< timestamp of the measurement (uSec)
 };
 

--- a/EKF/common.h
+++ b/EKF/common.h
@@ -80,8 +80,9 @@ struct flow_message {
 struct ext_vision_message {
 	Vector3f posNED;	///< measured NED position relative to the local origin (m)
 	Quatf quat;		///< measured quaternion orientation defining rotation from NED to body frame
-	float posErr;		///< 1-Sigma spherical position accuracy (m)
+	float posErr;		///< 1-Sigma horizontal position accuracy (m)
 	float angErr;		///< 1-Sigma angular error (rad)
+	float hgtErr;		///< 1-Sigma height error (rad)
 };
 
 struct outputSample {
@@ -148,8 +149,9 @@ struct flowSample {
 struct extVisionSample {
 	Vector3f posNED;	///< measured NED position relative to the local origin (m)
 	Quatf quat;		///< measured quaternion orientation defining rotation from NED to body frame
-	float posErr;		///< 1-Sigma spherical position accuracy (m)
+	float posErr;		///< 1-Sigma horizontal position accuracy (m)
 	float angErr;		///< 1-Sigma angular error (rad)
+	float hgtErr;		///< 1-Sigma height error (rad)
 	uint64_t time_us;	///< timestamp of the measurement (uSec)
 };
 

--- a/EKF/estimator_interface.cpp
+++ b/EKF/estimator_interface.cpp
@@ -436,6 +436,7 @@ void EstimatorInterface::setExtVisionData(uint64_t time_usec, ext_vision_message
 		// copy required data
 		ev_sample_new.angErr = evdata->angErr;
 		ev_sample_new.posErr = evdata->posErr;
+		ev_sample_new.hgtErr = evdata->hgtErr;
 		ev_sample_new.quat = evdata->quat;
 		ev_sample_new.posNED = evdata->posNED;
 

--- a/EKF/vel_pos_fusion.cpp
+++ b/EKF/vel_pos_fusion.cpp
@@ -149,7 +149,7 @@ void Ekf::fuseVelPosHeight()
 			// calculate the innovation assuming the external vision observaton is in local NED frame
 			innovation[5] = _state.pos(2) - _ev_sample_delayed.posNED(2);
 			// observation variance - defined externally
-			R[5] = fmaxf(_ev_sample_delayed.posErr, 0.01f);
+			R[5] = fmaxf(_ev_sample_delayed.hgtErr, 0.01f);
 			R[5] = R[5] * R[5];
 			// innovation gate size
 			gate_size[5] = fmaxf(_params.ev_innov_gate, 1.0f);


### PR DESCRIPTION
For the vision input to the ekf there is only single variance figure used (`posErr` in the structs) for position representing a spherical error around said position. Some companion computer sensor systems have different errors on horizontal and vertical positions. I guess this is one of the reasons you can set the height mode independently via the `EKF2_HGT_MODE` flag. 
I came across the issue where I wanted to influence the horizontal position accurately, but influence the vertical position only a little (or varying variances). 

I've expanded the struct in this repo and included a separate `hgtErr` which is used on this line instead. I've also modified `Firmware` to extract it from the mavlink message and pass it through. It's all tested and working with the variance correctly influencing the EKF. If this is wanted I can issue a PR in Firmware also with the change.
