### PR TITLE
EKF: Protect against bad yaw immediately after a yaw reset.

### DIFF
--- a/EKF/ekf.h
+++ b/EKF/ekf.h
@@ -412,7 +412,9 @@ private:
 	float _last_on_ground_posD{0.0f};	///< last vertical position when the in_air status was false (m)
 	bool _flt_mag_align_complete{false};	///< true when the in-flight mag field alignment has been completed
 	bool _flt_mag_align_converging{false};	///< true when the in-flight mag field post alignment convergence is being performd
+	bool _flt_yaw_align_converging{false};	///< true when the in-flight yaw alignment convergence is being performd
 	uint64_t _flt_mag_align_start_time{0};	///< time that inflight magnetic field alignment started (uSec)
+	uint64_t _flt_yaw_align_start_time{0};	///< time that inflight yaw alignment started (uSec)
 	uint64_t _time_last_movement{0};	///< last system time that sufficient movement to use 3-axis magnetometer fusion was detected (uSec)
 	float _saved_mag_variance[6] {};	///< magnetic field state variances that have been saved for use at the next initialisation (Gauss**2)
 	bool _velpos_reset_request{false};	///< true when a large yaw error has been fixed and a velocity and position state reset is required

--- a/EKF/ekf_helper.cpp
+++ b/EKF/ekf_helper.cpp
@@ -722,6 +722,9 @@ bool Ekf::resetMagHeading(Vector3f &mag_init)
 		// reset the quaternion covariances using the rotation vector variances
 		initialiseQuatCovariances(angle_err_var_vec);
 
+		// record the start time for the yaw alignment
+		_flt_yaw_align_start_time = _imu_sample_delayed.time_us;
+
 		// add the reset amount to the output observer buffered data
 		for (uint8_t i = 0; i < _output_buffer.get_length(); i++) {
 			// Note q1 *= q2 is equivalent to q1 = q2 * q1

--- a/EKF/mag_fusion.cpp
+++ b/EKF/mag_fusion.cpp
@@ -474,7 +474,7 @@ void Ekf::fuseHeading()
 		predicted_hdg = euler321(2); // we will need the predicted heading to calculate the innovation
 
 		// calculate the observed yaw angle
-		if (_control_status.flags.mag_hdg) {
+		if (_control_status.flags.mag_hdg || _flt_yaw_align_converging) {
 			// Set the yaw angle to zero and rotate the measurements into earth frame using the zero yaw angle
 			euler321(2) = 0.0f;
 			Dcmf R_to_earth(euler321);
@@ -550,7 +550,7 @@ void Ekf::fuseHeading()
 		predicted_hdg = yaw; // we will need the predicted heading to calculate the innovation
 
 		// calculate the observed yaw angle
-		if (_control_status.flags.mag_hdg) {
+		if (_control_status.flags.mag_hdg || _flt_yaw_align_converging) {
 			// Set the first rotation (yaw) to zero and rotate the measurements into earth frame
 			yaw = 0.0f;
 
@@ -599,7 +599,7 @@ void Ekf::fuseHeading()
 	}
 
 	// Calculate the observation variance
-	if (_control_status.flags.mag_hdg) {
+	if (_control_status.flags.mag_hdg || _flt_yaw_align_converging) {
 		// using magnetic heading tuning parameter
 		R_YAW = sq(fmaxf(_params.mag_heading_noise, 1.0e-2f));
 


### PR DESCRIPTION
**Bug Description**

A loss of navigation following takeoff from a surface with high levels of magnetic interference was reported. This can be verified by plotting the magnetic heading innovation (the EKF uses this up to 5m where it switches to using 3-axis mag fusion), integrated z gyro, baro alt and measured body axis yaw of xy mag data.

![screen shot 2018-09-11 at 8 13 21 am](https://user-images.githubusercontent.com/3596952/45389917-bc799380-b660-11e8-9d06-11e8384fb62c.png)

The magnetic yaw change with height was extremely large in this instance and about 2 radians or 115 degrees. What is also noticeable this instance is that there is very little change in magnetic field strength with initial height gain.

The EKF is supposed to perform a reset of the heading at 5 metres altitude before it switches to using 3-axis fusion. This reset was performed, but the NE earth field estimates collapse immediately. This is correlated to a yaw transient that occurs at the same time. This transient appears to to be the combination of residual uncompensated yaw reset where the yaw setpoint does not precisely match the change in yaw estimate and a closed loop interaction between the EKF and the yaw controller. When the EKF has to a yaw reset of > 15 degrees it also resets the quaternion covariances in addition to those for the magnetic field states.

![screen shot 2018-09-11 at 8 32 31 am](https://user-images.githubusercontent.com/3596952/45389985-f2b71300-b660-11e8-9562-06e524e2c5f0.png)

The code prevents the 3-axis fusion from modifying states other than the NED and XYZ mag field estimates during the first 5 seconds after a reset to prevent small variations in roll/pitch that were perceptible to operators. The unintended consequence of this is that if the yaw reset is large and covariances are modified, GPS and inertial sensing errors can result in a bad yaw estimate being formed before the quaternion covariance values stabilise.

**Fix Description**

This PR introduces logic that when a quaternion covariance reset has been performed, causes the heading fusion to be performed in addition to 3-axis fusion until the 3-axis fusion starts constraining heading drift.

**Testing**

Used the following procedure:  

1. Place the vehicle on the ground and locate a magnet near the body that causes the compass heading to rotate by over 90 degrees.
2. Ensure logging of replay data from boot is enabled
3. Ensure ALTCTL mode can be selected
4. Repower the vehicle and wait for checks to pass
5. Takeoff in POSCTL mode and continue the climb to above 3m. Be ready to switch to ALTCTL if the position diverges.

Step 5. was varied by including yaw rotations to coincide with the yaw reset.

See comment below for list of log files and analysis.