### PR TITLE
3D only mag fusion: use declination calculated from magnetic field states

### DIFF
--- a/EKF/control.cpp
+++ b/EKF/control.cpp
@@ -1495,11 +1495,11 @@ void Ekf::controlMagFusion()
 		} else if (_params.mag_fusion_type == MAG_FUSE_TYPE_3D) {
 			// if transitioning into 3-axis fusion mode, we need to initialise the yaw angle and field states
 			if (!_control_status.flags.mag_3D || !_flt_mag_align_complete) {
-				_flt_mag_align_complete= resetMagHeading(_mag_sample_delayed.mag);
+				_flt_mag_align_complete = resetMagHeading(_mag_sample_delayed.mag);
 				_control_status.flags.yaw_align = _control_status.flags.yaw_align || _flt_mag_align_complete;
 			}
 
-			// always use 3-axis mag fusion
+			// use 3-axis mag fusion if reset was successful
 			_control_status.flags.mag_3D = _flt_mag_align_complete;
 			_control_status.flags.mag_hdg = false;
 

--- a/EKF/control.cpp
+++ b/EKF/control.cpp
@@ -1494,13 +1494,14 @@ void Ekf::controlMagFusion()
 
 		} else if (_params.mag_fusion_type == MAG_FUSE_TYPE_3D) {
 			// if transitioning into 3-axis fusion mode, we need to initialise the yaw angle and field states
-			if (!_control_status.flags.mag_3D) {
-				_control_status.flags.yaw_align = resetMagHeading(_mag_sample_delayed.mag) || _control_status.flags.yaw_align;
+			if (!_control_status.flags.mag_3D || !_flt_mag_align_complete) {
+				_flt_mag_align_complete= resetMagHeading(_mag_sample_delayed.mag);
+				_control_status.flags.yaw_align = _control_status.flags.yaw_align || _flt_mag_align_complete;
 			}
 
 			// always use 3-axis mag fusion
+			_control_status.flags.mag_3D = _flt_mag_align_complete;
 			_control_status.flags.mag_hdg = false;
-			_control_status.flags.mag_3D = true;
 
 		} else {
 			// do no magnetometer fusion at all


### PR DESCRIPTION
When using 3D mag fusion only I noticed that the magnetic declination was not calculated from the actual magnetic field states. So basically the code would never step into this if statement:
https://github.com/PX4/ecl/blob/master/EKF/ekf_helper.cpp#L756

I realized that this was because the _flt_mag_align_complete flag was never set when using 3D mag fusion only.
