### PR TITLE
EKF: Ensure yaw gets reset when declination is set

### DIFF
--- a/EKF/control.cpp
+++ b/EKF/control.cpp
@@ -1356,6 +1356,13 @@ void Ekf::controlMagFusion()
 	// check for new magnetometer data that has fallen behind the fusion time horizon
 	// If we are using external vision data for heading then no magnetometer fusion is used
 	if (!_control_status.flags.ev_yaw && _mag_data_ready) {
+		// perform a yaw reset if requested by other functions
+		if (_mag_yaw_reset_req) {
+			if (!_mag_use_inhibit ) {
+				resetMagHeading(_mag_sample_delayed.mag);
+			}
+			_mag_yaw_reset_req = false;
+		}
 
 		// Determine if we should use simple magnetic heading fusion which works better when there are large external disturbances
 		// or the more accurate 3-axis fusion

--- a/EKF/ekf.cpp
+++ b/EKF/ekf.cpp
@@ -257,6 +257,8 @@ bool Ekf::initialiseFilter()
 		Vector3f mag_init = _mag_filt_state;
 
 		// calculate the initial magnetic field and yaw alignment
+		// Get the magnetic declination
+		calcMagDeclination();
 		_control_status.flags.yaw_align = resetMagHeading(mag_init);
 
 		if (_control_status.flags.rng_hgt) {

--- a/EKF/ekf.h
+++ b/EKF/ekf.h
@@ -339,6 +339,7 @@ private:
 	bool _mag_inhibit_yaw_reset_req{false};	///< true when magnetomer inhibit has been active for long enough to require a yaw reset when conditons improve.
 	float _last_static_yaw{0.0f};		///< last yaw angle recorded when on ground motion checks were passing (rad)
 	bool _vehicle_at_rest_prev{false};	///< true when the vehicle was at rest the previous time the status was checked
+	bool _mag_yaw_reset_req{false};		///< true when a reset of the yaw using the magnetomer data has been requested
 
 	float P[_k_num_states][_k_num_states] {};	///< state covariance matrix
 

--- a/EKF/ekf_helper.cpp
+++ b/EKF/ekf_helper.cpp
@@ -545,7 +545,7 @@ bool Ekf::realignYawGPS()
 // Reset heading and magnetic field states
 bool Ekf::resetMagHeading(Vector3f &mag_init)
 {
-	// don't reseet twice on the same frame
+	// prevent a reset being performed more than once on the same frame
 	if (_imu_sample_delayed.time_us == _flt_mag_align_start_time) {
 		return true;
 	}

--- a/EKF/gps_checks.cpp
+++ b/EKF/gps_checks.cpp
@@ -79,6 +79,8 @@ bool Ekf::collect_gps(uint64_t time_usec, struct gps_message *gps)
 		_last_gps_origin_time_us = _time_last_imu;
 		// set the magnetic declination returned by the geo library using the current GPS position
 		_mag_declination_gps = math::radians(get_mag_declination(lat, lon));
+		// request a reset of the yaw using the new declination
+		_mag_yaw_reset_req = true;
 		// save the horizontal and vertical position uncertainty of the origin
 		_gps_origin_eph = gps->eph;
 		_gps_origin_epv = gps->epv;


### PR DESCRIPTION
Fixes issue reported here: https://github.com/PX4/ecl/issues/519

**TESTING**

Testing performed in SITL with gazebo_gps_plugin.h modified to use following WGS-84 position

  // Seattle downtown (15 deg declination): 47.592182, -122.316031
   double lat_home = 47.592182 * M_PI / 180;    // rad
   double lon_home = -122.316031 * M_PI / 180;  // rad
   double alt_home = 86.0;                      // meters

and SDLOG_MODE = 1 to start logging from boot.

Before Changes Log: https://logs.px4.io/plot_app?log=479aba4f-d2f1-4fb3-b31d-8da8b4422f36

![before](https://user-images.githubusercontent.com/3596952/48381667-22ea6300-e731-11e8-8eab-51628b03f567.png)

After Changes Log: https://logs.px4.io/plot_app?log=24a35542-4512-4342-b8cb-a49c3f6a3607

![after](https://user-images.githubusercontent.com/3596952/48381671-254cbd00-e731-11e8-91b1-fd0c205eb820.png)

Because this does enforce reset the quaternion states for small angle changes less than 15 degrees that were previously ignored, flight testing is required to ensure that the filter stability and attitude controller handling of the resets is still OK. The alternative to doing this is to limit the scope of the small angle (<15 deg yaw change) quaternion state resets to on ground only, however this will lose the benefit of the more stable yaw gyro bias estimate following small yaw change in-air resets.