### PR TITLE
EKF: do not consider synthetic sideslip fusion as air data aiding

### DIFF
--- a/EKF/ekf_helper.cpp
+++ b/EKF/ekf_helper.cpp
@@ -1326,7 +1326,7 @@ void Ekf::update_deadreckoning_status()
 				|| (_time_last_imu - _time_last_vel_fuse <= _params.no_aid_timeout_max)
 				|| (_time_last_imu - _time_last_delpos_fuse <= _params.no_aid_timeout_max));
 	bool optFlowAiding = _control_status.flags.opt_flow && (_time_last_imu - _time_last_of_fuse <= _params.no_aid_timeout_max);
-	bool airDataAiding = _control_status.flags.wind && (_time_last_imu - _time_last_arsp_fuse <= _params.no_aid_timeout_max) && (_time_last_imu - _time_last_beta_fuse <= _params.no_aid_timeout_max);
+	bool airDataAiding = _control_status.flags.wind && (_time_last_imu - _time_last_arsp_fuse <= _params.no_aid_timeout_max);
 
 	_is_wind_dead_reckoning = !velPosAiding && !optFlowAiding && airDataAiding;
 	_is_dead_reckoning = !velPosAiding && !optFlowAiding && !airDataAiding;


### PR DESCRIPTION
Fixes https://github.com/PX4/ecl/issues/527

Before merging it would be good to get @priseborough opinion on the usefulness of synthetic sideslip fusion to constrain drift in the case when the velocity and position measurements are being rejected