### PR TITLE
ekf: force 3D fusion for a short time right after takeoff

### DIFF
--- a/EKF/control.cpp
+++ b/EKF/control.cpp
@@ -1350,6 +1350,7 @@ void Ekf::controlMagFusion()
 	if (!_control_status.flags.in_air) {
 		_last_on_ground_posD = _state.pos(2);
 		_flt_mag_align_complete = false;
+		_height_achieved_once = false;
 		_num_bad_flight_yaw_events = 0;
 	}
 

--- a/EKF/control.cpp
+++ b/EKF/control.cpp
@@ -1414,6 +1414,12 @@ void Ekf::controlMagFusion()
 				_time_last_movement = _imu_sample_delayed.time_us;
 			}
 
+			// Force 3D fusion after takeoff for a short time to make sure we reset the heading
+			if (height_achieved && !_height_achieved_once) {
+				_height_achieved_once = true;
+				_time_last_movement = _imu_sample_delayed.time_us;
+			}
+
 			// decide whether 3-axis magnetomer fusion can be used
 			bool use_3D_fusion = _control_status.flags.tilt_align && // Use of 3D fusion requires valid tilt estimates
 					_control_status.flags.in_air && // don't use when on the ground becasue of magnetic anomalies

--- a/EKF/ekf.h
+++ b/EKF/ekf.h
@@ -331,6 +331,7 @@ private:
 	float _yaw_rate_lpf_ef{0.0f};		///< Filtered angular rate about earth frame D axis (rad/sec)
 	bool _mag_bias_observable{false};	///< true when there is enough rotation to make magnetometer bias errors observable
 	bool _yaw_angle_observable{false};	///< true when there is enough horizontal acceleration to make yaw observable
+	bool _height_achieved_once{false};  ///< true when 1.5 meter altitude has been achieved once
 	uint64_t _time_yaw_started{0};		///< last system time in usec that a yaw rotation moaneouvre was detected
 	uint8_t _num_bad_flight_yaw_events{0};	///< number of times a bad heading has been detected in flight and required a yaw reset
 	uint64_t _mag_use_not_inhibit_us{0};	///< last system time in usec before magnetomer use was inhibited


### PR DESCRIPTION
Currently we reset the heading the first time we are above 1.5 meter altitude and declare the mag biases or the yaw angle observable. For a quad this is fine, but for a VTOL this can cause problems. If the vehicle ascends without changing orientation and then the forward transition finishes before the horizontal acceleration is above ```EKF2_MAG_ACCLIM```, then the heading and earth magnetic field states will be reset based on the assumption that the measured horizontal velocity is aligned with the vehicle heading. If this happens right after forward transition in a lot of sidewind it can cause the earth magnetic field states to be initialized to values far from reality.

E.g. here is the estimated magnetic declination from a flight in Zurich
![image](https://user-images.githubusercontent.com/7795133/49432613-6411e800-f7b0-11e8-9445-06eebf62e0c9.png)

This PR forces the use of 3D axis fusion for 2 seconds the first time the vehicle reaches 1.5 meter altitude. This makes sure that the earth magnetic field states are initialized based on the magnetometer as soon as the vehicle is away from magnetic interference close to the ground.