### PR TITLE
Pr tecs front trans

### DIFF
--- a/tecs/tecs.cpp
+++ b/tecs/tecs.cpp
@@ -361,14 +361,6 @@ void TECS::_update_throttle_setpoint(const float throttle_cruise, const matrix::
 		_throttle_setpoint = (_STE_error + _STE_rate_error * _throttle_damping_gain) * STE_to_throttle + throttle_predicted;
 		_throttle_setpoint = constrain(_throttle_setpoint, _throttle_setpoint_min, _throttle_setpoint_max);
 
-		// Rate limit the throttle demand
-		if (fabsf(_throttle_slewrate) > 0.01f) {
-			float throttle_increment_limit = _dt * (_throttle_setpoint_max - _throttle_setpoint_min) * _throttle_slewrate;
-			_throttle_setpoint = constrain(_throttle_setpoint, _last_throttle_setpoint - throttle_increment_limit,
-						       _last_throttle_setpoint + throttle_increment_limit);
-		}
-
-		_last_throttle_setpoint = _throttle_setpoint;
 
 		if (_integrator_gain > 0.0f) {
 			// Calculate throttle integrator state upper and lower limits with allowance for
@@ -404,7 +396,16 @@ void TECS::_update_throttle_setpoint(const float throttle_cruise, const matrix::
 
 		}
 
+		// Rate limit the throttle demand
+		if (fabsf(_throttle_slewrate) > 0.01f) {
+			float throttle_increment_limit = _dt * (_throttle_setpoint_max - _throttle_setpoint_min) * _throttle_slewrate;
+			_throttle_setpoint = constrain(_throttle_setpoint, _last_throttle_setpoint - throttle_increment_limit,
+						       _last_throttle_setpoint + throttle_increment_limit);
+		}
+
 		_throttle_setpoint = constrain(_throttle_setpoint, _throttle_setpoint_min, _throttle_setpoint_max);
+
+		_last_throttle_setpoint = _throttle_setpoint;
 	}
 }
 

--- a/tecs/tecs.cpp
+++ b/tecs/tecs.cpp
@@ -541,9 +541,7 @@ void TECS::_initialize_states(float pitch, float throttle_cruise, float baro_alt
 		_tas_state = _EAS * EAS2TAS;
 		_throttle_integ_state =  0.0f;
 		_pitch_integ_state = 0.0f;
-
 		_last_throttle_setpoint = (_in_air ? throttle_cruise : 0.0f);
-
 		_last_pitch_setpoint = constrain(pitch, _pitch_setpoint_min, _pitch_setpoint_max);
 		_pitch_setpoint_unc = _last_pitch_setpoint;
 		_hgt_setpoint_adj_prev = baro_altitude;
@@ -601,6 +599,11 @@ void TECS::update_pitch_throttle(const matrix::Dcmf &rotMat, float pitch, float 
 	// Calculate the time since last update (seconds)
 	uint64_t now = ecl_absolute_time();
 	_dt = constrain((now - _pitch_update_timestamp) * 1e-6f, DT_MIN, DT_MAX);
+
+	// if this is the first time we run the loop, set _dt to default value
+	if (_pitch_update_timestamp == 0) {
+		_dt = DT_DEFAULT;
+	}
 
 	// Set class variables from inputs
 	_throttle_setpoint_max = throttle_max;

--- a/tecs/tecs.h
+++ b/tecs/tecs.h
@@ -59,7 +59,7 @@ public:
 	 *
 	 * @return true if airspeed is enabled for control
 	 */
-	bool airspeed_sensor_enabled() { return _airspeed_enabled; }
+	bool airspeed_sensor_enabled() { return _airspeed_enabled && !_in_front_transition; }
 
 	/**
 	 * Set the airspeed enable state
@@ -95,7 +95,8 @@ public:
 		ECL_TECS_MODE_NORMAL = 0,
 		ECL_TECS_MODE_UNDERSPEED,
 		ECL_TECS_MODE_BAD_DESCENT,
-		ECL_TECS_MODE_CLIMBOUT
+		ECL_TECS_MODE_CLIMBOUT,
+		ECL_TECS_MODE_VTOL_FRONT_TRANSITION
 	};
 
 	void set_detect_underspeed_enabled(bool enabled) { _detect_underspeed_enabled = enabled; }
@@ -152,6 +153,23 @@ public:
 
 	float throttle_integ_state() { return _throttle_integ_state; }
 	float pitch_integ_state() { return _pitch_integ_state; }
+
+	/**
+	 * Activate front transition for VTOL
+	 *
+	 * If active, TECS will ramp up the throttle and try to hold the altitude setpoint.
+	 * Airspeed is not controlled, only height.
+	 *
+	 */
+	void activate_front_transition() {
+		_in_front_transition = true;
+	}
+
+	void deactivate_front_transition() {
+		_in_front_transition = false;
+	}
+
+	bool in_front_transition() {return _in_front_transition;}
 
 	/**
 	 * Handle the altitude reset
@@ -276,6 +294,8 @@ private:
 	bool _airspeed_enabled{false};					///< true when airspeed use has been enabled
 	bool _states_initalized{false};					///< true when TECS states have been iniitalized
 	bool _in_air{false};						///< true when the vehicle is flying
+
+	bool _in_front_transition{false};			///< vehicle is doing a front transition
 
 	/**
 	 * Update the airspeed internal state using a second order complementary filter


### PR DESCRIPTION
This PR adds a mode to TECS for assisting in VTOL (standard & tiltrotor) front transitions.
The idea is that TECS can already during the front transition start to control altitude using pitch.
The transition happens in non-airspeed control mode and throttle is ramped up in an open loop manner.
This concept has been tested (on an earlier branch) both in simulation and on a vehicle (delta quad).
It seemed to improve the altitude hold performance during transitions without any previous hacks and also allows a seamless transition to pure fixed wing flight (no jumps in pitch or throttle setpoint).
Obviously this is unusable for tailsitters.

I will provide logs of simulation and real flights which demonstrate the functionality of this PR.
Although this has not been necessary until now we may need to add special constraints on the pitch setpoint in positive direction as this could lead to unwanted drag created by the multirotor lift system.