### PR TITLE
Underspeed protection fix

### DIFF
--- a/tecs/tecs.cpp
+++ b/tecs/tecs.cpp
@@ -221,6 +221,11 @@ void TECS::_update_speed_setpoint()
 
 void TECS::_update_height_setpoint(float desired, float state)
 {
+        // Don't try to change the altitude if underspeed.
+        if (_underspeed_detected) {
+                desired = state;
+        }
+
 	// Detect first time through and initialize previous value to demand
 	if (ISFINITE(desired) && fabsf(_hgt_setpoint_in_prev) < 0.1f) {
 		_hgt_setpoint_in_prev = desired;
@@ -316,7 +321,7 @@ void TECS::_update_throttle_setpoint(const float throttle_cruise, const matrix::
 	// Calculate the throttle demand
 	if (_underspeed_detected) {
 		// always use full throttle to recover from an underspeed condition
-		_throttle_setpoint = 1.0f;
+                _throttle_setpoint = _throttle_setpoint_max;
 
 	} else {
 		// Adjust the demanded total energy rate to compensate for induced drag rise in turns.

--- a/tecs/tecs.cpp
+++ b/tecs/tecs.cpp
@@ -272,7 +272,7 @@ void TECS::_detect_underspeed()
 		return;
 	}
 
-        if (_tas_state < _TAS_min || ((_STE_error > 0) && _underspeed_detected)) {
+        if (_tas_state < _TAS_min * 0.9f || ((_vert_pos_state < _hgt_setpoint_adj) && _underspeed_detected)) {
 
 		_underspeed_detected = true;
 

--- a/tecs/tecs.cpp
+++ b/tecs/tecs.cpp
@@ -314,7 +314,7 @@ void TECS::_update_throttle_setpoint(const float throttle_cruise, const matrix::
 
 	// Calculate the throttle demand
 	if (_underspeed_detected) {
-		// always use full throttle to recover from an underspeed condition
+		// always use max throttle to recover from an underspeed condition
 		_throttle_setpoint = _throttle_setpoint_max;
 
 	} else {

--- a/tecs/tecs.cpp
+++ b/tecs/tecs.cpp
@@ -272,7 +272,7 @@ void TECS::_detect_underspeed()
 		return;
 	}
 
-	if (_tas_state < _TAS_min * 0.9f || ((_vert_pos_state < _hgt_setpoint_adj) && _underspeed_detected)) {
+	if (_tas_state < _TAS_min || ((_vert_pos_state < _hgt_setpoint_adj) && _underspeed_detected)) {
 
 		_underspeed_detected = true;
 

--- a/tecs/tecs.cpp
+++ b/tecs/tecs.cpp
@@ -201,7 +201,7 @@ void TECS::_update_speed_setpoint()
 	// Set the airspeed demand to the minimum value if an underspeed or
 	// or a uncontrolled descent condition exists to maximise climb rate
 	if ((_uncommanded_descent_recovery) || (_underspeed_detected)) {
-		_TAS_setpoint = _TAS_min;
+		_TAS_setpoint = 1.1f * _TAS_min;
 	}
 
 	_TAS_setpoint = constrain(_TAS_setpoint, _TAS_min, _TAS_max);
@@ -272,7 +272,7 @@ void TECS::_detect_underspeed()
 		return;
 	}
 
-	if (_tas_state < _TAS_min || ((_vert_pos_state < _hgt_setpoint_adj) && _underspeed_detected)) {
+	if (_tas_state < 0.9f * _TAS_min || ((_vert_pos_state < _hgt_setpoint_adj || _tas_state < _TAS_min) && _underspeed_detected)) {
 
 		_underspeed_detected = true;
 

--- a/tecs/tecs.cpp
+++ b/tecs/tecs.cpp
@@ -277,8 +277,7 @@ void TECS::_detect_underspeed()
 		return;
 	}
 
-	if (((_tas_state < _TAS_min * 0.9f) && (_throttle_setpoint >= _throttle_setpoint_max * 0.95f))
-	    || ((_vert_pos_state < _hgt_setpoint_adj) && _underspeed_detected)) {
+        if (_tas_state < _TAS_min || ((_STE_error > 0) && _underspeed_detected)) {
 
 		_underspeed_detected = true;
 

--- a/tecs/tecs.cpp
+++ b/tecs/tecs.cpp
@@ -272,7 +272,7 @@ void TECS::_detect_underspeed()
 		return;
 	}
 
-        if (_tas_state < _TAS_min * 0.9f || ((_vert_pos_state < _hgt_setpoint_adj) && _underspeed_detected)) {
+	if (_tas_state < _TAS_min * 0.9f || ((_vert_pos_state < _hgt_setpoint_adj) && _underspeed_detected)) {
 
 		_underspeed_detected = true;
 
@@ -315,7 +315,7 @@ void TECS::_update_throttle_setpoint(const float throttle_cruise, const matrix::
 	// Calculate the throttle demand
 	if (_underspeed_detected) {
 		// always use full throttle to recover from an underspeed condition
-                _throttle_setpoint = _throttle_setpoint_max;
+		_throttle_setpoint = _throttle_setpoint_max;
 
 	} else {
 		// Adjust the demanded total energy rate to compensate for induced drag rise in turns.

--- a/tecs/tecs.cpp
+++ b/tecs/tecs.cpp
@@ -198,9 +198,9 @@ void TECS::_update_speed_states(float airspeed_setpoint, float indicated_airspee
 
 void TECS::_update_speed_setpoint()
 {
-	// Set the airspeed demand to the minimum value if an underspeed or
-	// or a uncontrolled descent condition exists to maximise climb rate
-	if ((_uncommanded_descent_recovery) || (_underspeed_detected)) {
+	// Set the airspeed demand to the minimum value if an
+	// uncontrolled descent condition exists to maximise climb rate
+	if (_uncommanded_descent_recovery){
 		_TAS_setpoint = 1.1f * _TAS_min;
 	}
 

--- a/tecs/tecs.cpp
+++ b/tecs/tecs.cpp
@@ -221,6 +221,11 @@ void TECS::_update_speed_setpoint()
 
 void TECS::_update_height_setpoint(float desired, float state)
 {
+        // Don't try to change the altitude if underspeed.
+        if (_underspeed_detected) {
+                desired = state;
+        }
+
 	// Detect first time through and initialize previous value to demand
 	if (ISFINITE(desired) && fabsf(_hgt_setpoint_in_prev) < 0.1f) {
 		_hgt_setpoint_in_prev = desired;
@@ -314,6 +319,7 @@ void TECS::_update_throttle_setpoint(const float throttle_cruise, const matrix::
 
 	// Calculate the throttle demand
 	if (_underspeed_detected) {
+
 		// always use max throttle to recover from an underspeed condition
 		_throttle_setpoint = _throttle_setpoint_max;
 

--- a/tecs/tecs.cpp
+++ b/tecs/tecs.cpp
@@ -272,7 +272,7 @@ void TECS::_detect_underspeed()
 		return;
 	}
 
-	if (_tas_state < 0.9f * _TAS_min || ((_vert_pos_state < _hgt_setpoint_adj || _tas_state < _TAS_min) && _underspeed_detected)) {
+	if (_tas_state < 0.9f * _TAS_min || ((_vert_pos_state < _hgt_setpoint_adj || _tas_state < (0.5f * (_TAS_setpoint + _TAS_min))) && _underspeed_detected)) {
 
 		_underspeed_detected = true;
 

--- a/tecs/tecs.cpp
+++ b/tecs/tecs.cpp
@@ -221,11 +221,6 @@ void TECS::_update_speed_setpoint()
 
 void TECS::_update_height_setpoint(float desired, float state)
 {
-        // Don't try to change the altitude if underspeed.
-        if (_underspeed_detected) {
-                desired = state;
-        }
-
 	// Detect first time through and initialize previous value to demand
 	if (ISFINITE(desired) && fabsf(_hgt_setpoint_in_prev) < 0.1f) {
 		_hgt_setpoint_in_prev = desired;


### PR DESCRIPTION
Changed the criteria for underspeed detection: 
- Ignored the throttle setting. Underspeed condition can occur even at low throttle values. Why? If the set airspeed is close to the minimum speed, it is possible that the P term in the throttle PID doesn't increase the throttle enough for it to reach 0.95 * max throttle.

Also changed the throttle setpoint in underspeed conditions from 100% to the user defined max value. No more burnt ESCs.