### PR TITLE
add GPS dropout case

### DIFF
--- a/EKF/control.cpp
+++ b/EKF/control.cpp
@@ -676,6 +676,11 @@ void Ekf::controlGpsFusion()
 	} else if (_control_status.flags.gps && (_imu_sample_delayed.time_us - _gps_sample_delayed.time_us > (uint64_t)10e6)) {
 		_control_status.flags.gps = false;
 		ECL_WARN("EKF GPS data stopped");
+	}  else if (_control_status.flags.gps && (_imu_sample_delayed.time_us - _gps_sample_delayed.time_us > (uint64_t)1e6) && (_control_status.flags.opt_flow || _control_status.flags.ev_pos)) {
+		// Handle the case where we are fusing another position source along GPS, 
+		// stop waiting for GPS after 1 s of lost signal
+		_control_status.flags.gps = false;
+		ECL_WARN("EKF GPS data stopped, using only EV or OF");
 	}
 }
 

--- a/EKF/estimator_interface.cpp
+++ b/EKF/estimator_interface.cpp
@@ -351,8 +351,8 @@ void EstimatorInterface::setOpticalFlowData(uint64_t time_usec, flow_message *fl
 
 	// Allocate the required buffer size if not previously done
 	// Do not retry if allocation has failed previously
-	if (_flow_buffer.get_length() < _obs_buffer_length) {
-		_flow_buffer_fail = !_flow_buffer.allocate(_obs_buffer_length);
+	if (_flow_buffer.get_length() < _imu_buffer_length) {
+		_flow_buffer_fail = !_flow_buffer.allocate(_imu_buffer_length);
 
 		if (_flow_buffer_fail) {
 			ECL_ERR("EKF optical flow buffer allocation failed");


### PR DESCRIPTION
EKF waits 10s after GPS signal is lost before setting GPS control status flag to false. As the position information given by the alternative position sources drifts from the last GPS position, the controller over corrects.
With this update, the time horizon until GPS control flag set to false is reduced to 1s , if an alternative position source is available such as optical flow or external vision.

Tested with optical flow as position source
-  log from as is https://review.px4.io/plot_app?log=d624af5e-dde4-40ab-ba5b-a693a49f5a36 
-  log with update https://review.px4.io/plot_app?log=13ed6dc3-22dd-43f8-b898-4add41d60439

Also increase optical flow buffer length.
@priseborough 