### PR TITLE
Updated pitch and throttle control algorithms

### DIFF
--- a/tecs/tecs.cpp
+++ b/tecs/tecs.cpp
@@ -346,7 +346,7 @@ void TECS::_update_throttle_setpoint(const float throttle_cruise, const matrix::
 
 		// Add proportional and derivative control feedback to kinetic energy error.
 		// Question: Should this be compensated for the pitch-driven kinetic energy control?
-		float SKE_feedback = (SKE_error + SKE_rate_error * _throttle_damping_gain) * STE_to_throttle;
+		float SKE_feedback = (SKE_error + _SKE_rate_error * _throttle_damping_gain) * STE_to_throttle;
 
 		// Calculate throttle and constrain to throttle limits.
 		_throttle_setpoint = sqrtf(constrain(turn_compensation + _SPE_rate_setpoint_pitch + SKE_feedback - _STE_rate_min, 0.01f, _STE_rate_max - _STE_rate_min)

--- a/tecs/tecs.cpp
+++ b/tecs/tecs.cpp
@@ -373,7 +373,7 @@ void TECS::_update_throttle_setpoint(const float throttle_cruise, const matrix::
 
 			// Calculate a throttle demand from the integrated total energy error
 			// This will be added to the total throttle demand to compensate for steady state errors
-			_throttle_integ_state = _throttle_integ_state + (_STE_error * _integrator_gain) * _dt * STE_to_throttle;
+			_throttle_integ_state = _throttle_integ_state + (_STE_error * _throttle_integrator_gain) * _dt * STE_to_throttle;
 
 			if (_climbout_mode_active) {
 				// During climbout, set the integrator to maximum throttle to prevent transient throttle drop

--- a/tecs/tecs.cpp
+++ b/tecs/tecs.cpp
@@ -269,7 +269,7 @@ void TECS::_detect_underspeed()
 	}
 
 	if (((_tas_state < _TAS_min * 0.9f) && (_throttle_setpoint >= _throttle_setpoint_max * 0.95f))
-		    || ((_vert_pos_state < _hgt_setpoint_adj) && _underspeed_detected)) {
+	    || ((_vert_pos_state < _hgt_setpoint_adj) && _underspeed_detected)) {
 
 		_underspeed_detected = true;
 

--- a/tecs/tecs.cpp
+++ b/tecs/tecs.cpp
@@ -303,14 +303,14 @@ void TECS::_update_throttle_setpoint(const float throttle_cruise, const matrix::
 	_STE_error = _SPE_setpoint - _SPE_estimate + _SKE_setpoint - _SKE_estimate;
 
 	// Calculate demanded rate of change of total energy, taking the SPE rate setpoint
-	// from the actual pitch setpoint.
+	// from the actual pitch setpoint
 	float STE_rate_setpoint = _SPE_rate_setpoint_pitch + _SKE_rate_setpoint;
 
 	// Calculate the total energy rate error, applying a first order IIR filter
-	// to reduce the effect of accelerometer noise.
+	// to reduce the effect of accelerometer noise
 	_STE_rate_error = 0.2f * (STE_rate_setpoint - _SPE_rate - _SKE_rate) + 0.8f * _STE_rate_error;
 
-	// Calculate the kinetic energy rate error.
+	// Calculate the kinetic energy rate error
 	_SKE_rate_error = 0.2f * (_SKE_rate_setpoint - _SKE_rate) + 0.8f * _SKE_rate_error;
 
 	// Calculate the throttle demand

--- a/tecs/tecs.cpp
+++ b/tecs/tecs.cpp
@@ -268,7 +268,8 @@ void TECS::_detect_underspeed()
 		return;
 	}
 
-	if (_tas_state < _TAS_min * 0.9f || ((_vert_pos_state < _hgt_setpoint_adj) && _underspeed_detected)) {
+	if (((_tas_state < _TAS_min * 0.9f) && (_throttle_setpoint >= _throttle_setpoint_max * 0.95f))
+		    || ((_vert_pos_state < _hgt_setpoint_adj) && _underspeed_detected)) {
 
 		_underspeed_detected = true;
 

--- a/tecs/tecs.h
+++ b/tecs/tecs.h
@@ -102,7 +102,8 @@ public:
 
 	// setters for controller parameters
 	void set_time_const(float time_const) { _pitch_time_constant = time_const; }
-	void set_integrator_gain(float gain) { _integrator_gain = gain; }
+	void set_throttle_integrator_gain(float gain) { _throttle_integrator_gain = gain; }
+	void set_pitch_integrator_gain(float gain) { _pitch_integrator_gain = gain; }
 
 	void set_min_sink_rate(float rate) { _min_sink_rate = rate; }
 	void set_max_sink_rate(float sink_rate) { _max_sink_rate = sink_rate; }
@@ -138,7 +139,7 @@ public:
 	float TAS_setpoint_adj() { return _TAS_setpoint_adj; }
 	float tas_state() { return _tas_state; }
 
-	float hgt_rate_setpoint() { return _hgt_rate_setpoint; }
+	float hgt_rate_setpoint() { return _hgt_rate_setpoint_actual; }
 	float vert_vel_state() { return _vert_vel_state; }
 
 	float TAS_rate_setpoint() { return _TAS_rate_setpoint; }
@@ -192,7 +193,8 @@ private:
 	float _throttle_time_constant{8.0f};				///< control time constant used by the throttle demand calculation (sec)
 	float _pitch_damping_gain{0.0f};				///< damping gain of the pitch demand calculation (sec)
 	float _throttle_damping_gain{0.0f};				///< damping gain of the throttle demand calculation (sec)
-	float _integrator_gain{0.0f};					///< integrator gain used by the throttle and pitch demand calculation
+	float _throttle_integrator_gain{0.0f};				///< integrator gain used by the throttle demand calculation
+	float _pitch_integrator_gain{0.0f};				///< integrator gain used by the pitch demand calculation
 	float _vert_accel_limit{0.0f};					///< magnitude of the maximum vertical acceleration allowed (m/sec**2)
 	float _load_factor_correction{0.0f};				///< gain from normal load factor increase to total energy rate demand (m**2/sec**3)
 	float _pitch_speed_weight{1.0f};				///< speed control weighting used by pitch demand calculation
@@ -238,6 +240,7 @@ private:
 	float _hgt_setpoint_adj{0.0f};					///< demanded height used by the control loops after all filtering has been applied (m)
 	float _hgt_setpoint_adj_prev{0.0f};				///< value of _hgt_setpoint_adj from previous frame (m)
 	float _hgt_rate_setpoint{0.0f};					///< demanded climb rate tracked by the TECS algorithm
+	float _hgt_rate_setpoint_actual{0.0f};				///< demanded climb rate calculated from pitch setpoint.
 
 	// vehicle physical limits
 	float _pitch_setpoint_unc{0.0f};				///< pitch demand before limiting (rad)
@@ -257,12 +260,16 @@ private:
 	float _SKE_estimate{0.0f};					///< specific kinetic energy estimate (m**2/sec**2)
 	float _SPE_rate{0.0f};						///< specific potential energy rate estimate (m**2/sec**3)
 	float _SKE_rate{0.0f};						///< specific kinetic energy rate estimate (m**2/sec**3)
+	float _SKE_rate_setpoint_pitch{0.0f};				///< specific kinetic energy rate demand used for pitch control (m**2/sec**3)
+	float _SPE_rate_setpoint_pitch{0.0f};				///< specific potential energy rate demand used for pitch control (m**2/sec**3)
 
 	// specific energy error quantities
 	float _STE_error{0.0f};						///< specific total energy error (m**2/sec**2)
 	float _STE_rate_error{0.0f};					///< specific total energy rate error (m**2/sec**3)
 	float _SEB_error{0.0f};						///< specific energy balance error (m**2/sec**2)
 	float _SEB_rate_error{0.0f};					///< specific energy balance rate error (m**2/sec**3)
+	float _SKE_rate_error{0.0f};					///< specific kinetic energy rate error (m**2/sec**3)
+	float _STE_error_prev_abs{0.0f};				///< specific total energy previous iteration absolute error (m**2/sec**3)
 
 	// time steps (non-fixed)
 	float _dt{DT_DEFAULT};						///< Time since last update of main TECS loop (sec)


### PR DESCRIPTION
**Major changes to:**

1. Throttle integrator: only adding to the integrator if the absolute STE error is increasing. This is to prevent overshoots when the airspeed setpoint changes. 
In the log below this happens at T=41s: The integrator would normally start decreasing the throttle, but as we can see at T=45s, the real need is to actually increase the integrator value. 

     Also, limiting the integrator term from becoming very large in eg. quick descends where the airspeed 
     will build up even if the throttle is set to 0 (similar decaying system as with the pitch integrator). 

2. Replacing FW_T_INTEG_GAIN with FW_T_INTEG_GAIN_P (for pitch control) and FW_T_INTEG_GAIN_T for throttle control. This is for more accurate control of the gains.

3. Limiting SKE_weighting and SPE_weighting to the maximum of 1 instead of 2. The calculated control variables (for example the _SPE_rate_setpoint from _hgt_rate_setpoint) are directly proportional to these values and I find it more intuitive to increase the PID parameters instead of hiddenly scaling up the errors. This is also why the _hgt_rate_setpoint will be limited to 2 times the maximum/minimum climb and sink rates.

4. Changes to the throttle setpoint calculation: Assuming that the required throttle is proportional to the square root of the desired  STE rate. Source: https://www.grc.nasa.gov/www/k-12/airplane/propanl.html . Edit: There might be better ways to estimate the required `throttle_cruise` setting at different airspeeds, need to have a look at them.  

5. Not using STE_rate_setpoint as the starting point of throttle setpoint calculation, but instead using the SKE and SKE rate errors for proportional and derivative control and the _SPE_rate_setpoint_pitch derived from the part of the pitch setpoint that is controlling the SPE rate (as defined by the values of SKE_weighting and SPE_weighting). This gives a much sharper throttle response eg. when starting a climb as the throttle will increase with the pitch setpoint.
This can be seen in the log below at T=33s when the throttle is increased radically as the pitch setpoint is increased.  

Log with the above changes (has been tested >10 flights):
![image](https://user-images.githubusercontent.com/5569656/50337430-c6414b80-0519-11e9-8ffc-6551045c1de3.png)

**Other Considerations**
1. Replacing/removing FW_T_INTEG_GAIN means no backwards compatibility.
2. The parameter FW_THR_CRUISE will be obsolete. This can have effects elsewhere, such as in FW autoland where the flare throttle is limited by reducing the cruise throttle.
3. The way of calculating the throttle setpoint with the square root of demanded STE rate is not any scientific method, but seems to work ok with various airspeeds. In my test setup.
4. This has not been tested without an airspeed sensor.
5. This branch has a lot of change, should this be divided?

**Other context**
The commit having the Firmware changes: https://github.com/PX4/Firmware/commit/e597fb453ef80da82c6fcc31e6e3ae6236e47304