### PR TITLE
ekf_helper: add more useful methods to interface with the covariances

### DIFF
--- a/EKF/ekf.h
+++ b/EKF/ekf.h
@@ -122,8 +122,28 @@ public:
 	// get the true airspeed in m/s
 	void get_true_airspeed(float *tas);
 
-	// get the diagonal elements of the covariance matrix
+	void propagate_covariances_from_quat_to_euler(matrix::SquareMatrix<float, 3> &euler_cov);
+
+	// get the full covariance matrix
 	void get_covariances(float *covariances);
+
+	// get the diagonal elements of the covariance matrix
+	void get_covariances_diagonal(float *covariances);
+
+	// get the position covariances
+	void get_position_covariances(float *covariances);
+
+	// get the quaternion covariances
+	void get_quaternion_covariances(float *covariances);
+
+	// get the euler angles covariances
+	void get_euler_covariances(float *covariances);
+
+	// get the pose covariances (position + orientation in euler angles)
+	void get_pose_covariances(float *covariances);
+
+	// get the linear velocity covariances
+	void get_velocity_covariances(float *covariances);
 
 	// ask estimator for sensor data collection decision and do any preprocessing if required, returns true if not defined
 	bool collect_gps(const gps_message &gps);

--- a/EKF/ekf.h
+++ b/EKF/ekf.h
@@ -123,19 +123,19 @@ public:
 	void get_true_airspeed(float *tas);
 
 	// get the full covariance matrix
-	const matrix::SquareMatrix<float, 24> covariances() const;
+	matrix::SquareMatrix<float, 24> covariances() const;
 
 	// get the diagonal elements of the covariance matrix
-	const matrix::Vector<float, 24> covariances_diagonal() const;
+	matrix::Vector<float, 24> covariances_diagonal() const;
 
 	// get the position covariances
-	const matrix::SquareMatrix<float, 3> position_covariances() const;
+	matrix::SquareMatrix<float, 3> position_covariances() const;
 
 	// get the orientation (quaternion) covariances
-	const matrix::SquareMatrix<float, 4> orientation_covariances() const;
+	matrix::SquareMatrix<float, 4> orientation_covariances() const;
 
 	// get the linear velocity covariances
-	const matrix::SquareMatrix<float, 3> velocity_covariances() const;
+	matrix::SquareMatrix<float, 3> velocity_covariances() const;
 
 	// ask estimator for sensor data collection decision and do any preprocessing if required, returns true if not defined
 	bool collect_gps(const gps_message &gps);

--- a/EKF/ekf.h
+++ b/EKF/ekf.h
@@ -123,19 +123,19 @@ public:
 	void get_true_airspeed(float *tas);
 
 	// get the full covariance matrix
-	matrix::SquareMatrix<float, 24> covariances() const;
+	matrix::SquareMatrix<float, 24> covariances() const { return matrix::SquareMatrix<float, _k_num_states>(P); }
 
 	// get the diagonal elements of the covariance matrix
-	matrix::Vector<float, 24> covariances_diagonal() const;
+	matrix::Vector<float, 24> covariances_diagonal() const { return covariances().diag(); }
 
-	// get the position covariances
-	matrix::SquareMatrix<float, 3> position_covariances() const;
-
-	// get the orientation (quaternion) covariances
-	matrix::SquareMatrix<float, 4> orientation_covariances() const;
+	// get the orientation (quaterion) covariances
+	matrix::SquareMatrix<float, 4> orientation_covariances() const { return covariances().slice<4, 4>(0, 0); }
 
 	// get the linear velocity covariances
-	matrix::SquareMatrix<float, 3> velocity_covariances() const;
+	matrix::SquareMatrix<float, 3> velocity_covariances() const { return covariances().slice<3, 3>(4, 4); }
+
+	// get the position covariances
+	matrix::SquareMatrix<float, 3> position_covariances() const { return covariances().slice<3, 3>(7, 7); }
 
 	// ask estimator for sensor data collection decision and do any preprocessing if required, returns true if not defined
 	bool collect_gps(const gps_message &gps);

--- a/EKF/ekf.h
+++ b/EKF/ekf.h
@@ -122,9 +122,6 @@ public:
 	// get the true airspeed in m/s
 	void get_true_airspeed(float *tas);
 
-	// covariance propagation from quaternions to euler angles using the covariance law
-	const matrix::SquareMatrix<float, 3> propagate_covariances_from_quat_to_euler() const;
-
 	// get the full covariance matrix
 	const matrix::SquareMatrix<float, 24> covariances() const;
 
@@ -136,12 +133,6 @@ public:
 
 	// get the quaternion covariances
 	const matrix::SquareMatrix<float, 4> quaternion_covariances() const;
-
-	// get the euler angles covariances
-	const matrix::SquareMatrix<float, 3> euler_covariances() const;
-
-	// get the pose covariances (position + orientation in euler angles)
-	const matrix::SquareMatrix<float, 6> pose_covariances() const;
 
 	// get the linear velocity covariances
 	const matrix::SquareMatrix<float, 3> velocity_covariances() const;

--- a/EKF/ekf.h
+++ b/EKF/ekf.h
@@ -49,7 +49,7 @@ class Ekf : public EstimatorInterface
 public:
 
 	Ekf() = default;
-	~Ekf() = default;
+	virtual ~Ekf() = default;
 
 	// initialise variables to sane values (also interface class)
 	bool init(uint64_t timestamp);
@@ -122,28 +122,29 @@ public:
 	// get the true airspeed in m/s
 	void get_true_airspeed(float *tas);
 
-	void propagate_covariances_from_quat_to_euler(matrix::SquareMatrix<float, 3> &euler_cov);
+	// covariance propagation from quaternions to euler angles using the covariance law
+	const matrix::SquareMatrix<float, 3> propagate_covariances_from_quat_to_euler() const;
 
 	// get the full covariance matrix
-	void get_covariances(float *covariances);
+	const matrix::SquareMatrix<float, 24> covariances() const;
 
 	// get the diagonal elements of the covariance matrix
-	void get_covariances_diagonal(float *covariances);
+	const matrix::Vector<float, 24> covariances_diagonal() const;
 
 	// get the position covariances
-	void get_position_covariances(float *covariances);
+	const matrix::SquareMatrix<float, 3> position_covariances() const;
 
 	// get the quaternion covariances
-	void get_quaternion_covariances(float *covariances);
+	const matrix::SquareMatrix<float, 4> quaternion_covariances() const;
 
 	// get the euler angles covariances
-	void get_euler_covariances(float *covariances);
+	const matrix::SquareMatrix<float, 3> euler_covariances() const;
 
 	// get the pose covariances (position + orientation in euler angles)
-	void get_pose_covariances(float *covariances);
+	const matrix::SquareMatrix<float, 6> pose_covariances() const;
 
 	// get the linear velocity covariances
-	void get_velocity_covariances(float *covariances);
+	const matrix::SquareMatrix<float, 3> velocity_covariances() const;
 
 	// ask estimator for sensor data collection decision and do any preprocessing if required, returns true if not defined
 	bool collect_gps(const gps_message &gps);

--- a/EKF/ekf.h
+++ b/EKF/ekf.h
@@ -131,8 +131,8 @@ public:
 	// get the position covariances
 	const matrix::SquareMatrix<float, 3> position_covariances() const;
 
-	// get the quaternion covariances
-	const matrix::SquareMatrix<float, 4> quaternion_covariances() const;
+	// get the orientation (quaternion) covariances
+	const matrix::SquareMatrix<float, 4> orientation_covariances() const;
 
 	// get the linear velocity covariances
 	const matrix::SquareMatrix<float, 3> velocity_covariances() const;

--- a/EKF/ekf_helper.cpp
+++ b/EKF/ekf_helper.cpp
@@ -982,21 +982,6 @@ void Ekf::get_gyro_bias(float bias[3])
 	memcpy(bias, temp, 3 * sizeof(float));
 }
 
-// get the full covariance matrix
-matrix::SquareMatrix<float, 24> Ekf::covariances() const { return matrix::SquareMatrix<float, _k_num_states>(P); }
-
-// get the diagonal elements of the covariance matrix
-matrix::Vector<float, 24> Ekf::covariances_diagonal() const { return covariances().diag(); }
-
-// get the position covariances
-matrix::SquareMatrix<float, 3> Ekf::position_covariances() const { return covariances().slice<3, 3>(7, 7); }
-
-// get the orientation (quaterion) covariances
-matrix::SquareMatrix<float, 4> Ekf::orientation_covariances() const { return covariances().slice<4, 4>(0, 0); }
-
-// get the linear velocity covariances
-matrix::SquareMatrix<float, 3> Ekf::velocity_covariances() const { return covariances().slice<3, 3>(4, 4); }
-
 // get the position and height of the ekf origin in WGS-84 coordinates and time the origin was set
 // return true if the origin is valid
 bool Ekf::get_ekf_origin(uint64_t *origin_time, map_projection_reference_s *origin_pos, float *origin_alt)

--- a/EKF/ekf_helper.cpp
+++ b/EKF/ekf_helper.cpp
@@ -983,62 +983,19 @@ void Ekf::get_gyro_bias(float bias[3])
 }
 
 // get the full covariance matrix
-matrix::SquareMatrix<float, 24> Ekf::covariances() const
-{
-	matrix::SquareMatrix<float, 24> cov;
-	for (unsigned n = 0; n < _k_num_states; n++) {
-		for (unsigned m = 0; m < _k_num_states; m++) {
-			cov(n, m) = P[n][m];
-		}
-	}
-	return cov;
-}
+matrix::SquareMatrix<float, 24> Ekf::covariances() const { return matrix::SquareMatrix<float, _k_num_states>(P); }
 
 // get the diagonal elements of the covariance matrix
-matrix::Vector<float, 24> Ekf::covariances_diagonal() const
-{
-	matrix::Vector<float, 24> diag;
-	for (unsigned i = 0; i < _k_num_states; i++) {
-		diag(i) = P[i][i];
-	}
-	return diag;
-}
+matrix::Vector<float, 24> Ekf::covariances_diagonal() const { return covariances().diag(); }
 
 // get the position covariances
-matrix::SquareMatrix<float, 3> Ekf::position_covariances() const
-{
-	matrix::SquareMatrix<float, 3> cov;
-	for (unsigned n = 0; n < 3; n++) {
-		for (unsigned m = 0; m < 3; m++) {
-			cov(n, m) = P[n + 7][m + 7];
-		}
-	}
-	return cov;
-}
+matrix::SquareMatrix<float, 3> Ekf::position_covariances() const { return covariances().slice<3, 3>(7, 7); }
 
 // get the orientation (quaterion) covariances
-matrix::SquareMatrix<float, 4> Ekf::orientation_covariances() const
-{
-	matrix::SquareMatrix<float, 4> cov;
-	for (unsigned n = 0; n < 4; n++) {
-		for (unsigned m = 0; m < 4; m++) {
-			cov(n, m) = P[n][m];
-		}
-	}
-	return cov;
-}
+matrix::SquareMatrix<float, 4> Ekf::orientation_covariances() const { return covariances().slice<4, 4>(0, 0); }
 
 // get the linear velocity covariances
-matrix::SquareMatrix<float, 3> Ekf::velocity_covariances() const
-{
-	matrix::SquareMatrix<float, 3> cov;
-	for (unsigned n = 0; n < 3; n++) {
-		for (unsigned m = 0; m < 3; m++) {
-			cov(n, m) = P[n + 4][m + 4];
-		}
-	}
-	return cov;
-}
+matrix::SquareMatrix<float, 3> Ekf::velocity_covariances() const { return covariances().slice<3, 3>(4, 4); }
 
 // get the position and height of the ekf origin in WGS-84 coordinates and time the origin was set
 // return true if the origin is valid

--- a/EKF/ekf_helper.cpp
+++ b/EKF/ekf_helper.cpp
@@ -1016,8 +1016,8 @@ const matrix::SquareMatrix<float, 3> Ekf::position_covariances() const
 	return cov;
 }
 
-// get the quaternion covariances
-const matrix::SquareMatrix<float, 4> Ekf::quaternion_covariances() const
+// get the orientation (quaterion) covariances
+const matrix::SquareMatrix<float, 4> Ekf::orientation_covariances() const
 {
 	matrix::SquareMatrix<float, 4> cov;
 	for (unsigned n = 0; n < 4; n++) {

--- a/EKF/ekf_helper.cpp
+++ b/EKF/ekf_helper.cpp
@@ -983,7 +983,7 @@ void Ekf::get_gyro_bias(float bias[3])
 }
 
 // get the full covariance matrix
-const matrix::SquareMatrix<float, 24> Ekf::covariances() const
+matrix::SquareMatrix<float, 24> Ekf::covariances() const
 {
 	matrix::SquareMatrix<float, 24> cov;
 	for (unsigned n = 0; n < _k_num_states; n++) {
@@ -995,7 +995,7 @@ const matrix::SquareMatrix<float, 24> Ekf::covariances() const
 }
 
 // get the diagonal elements of the covariance matrix
-const matrix::Vector<float, 24> Ekf::covariances_diagonal() const
+matrix::Vector<float, 24> Ekf::covariances_diagonal() const
 {
 	matrix::Vector<float, 24> diag;
 	for (unsigned i = 0; i < _k_num_states; i++) {
@@ -1005,7 +1005,7 @@ const matrix::Vector<float, 24> Ekf::covariances_diagonal() const
 }
 
 // get the position covariances
-const matrix::SquareMatrix<float, 3> Ekf::position_covariances() const
+matrix::SquareMatrix<float, 3> Ekf::position_covariances() const
 {
 	matrix::SquareMatrix<float, 3> cov;
 	for (unsigned n = 0; n < 3; n++) {
@@ -1017,7 +1017,7 @@ const matrix::SquareMatrix<float, 3> Ekf::position_covariances() const
 }
 
 // get the orientation (quaterion) covariances
-const matrix::SquareMatrix<float, 4> Ekf::orientation_covariances() const
+matrix::SquareMatrix<float, 4> Ekf::orientation_covariances() const
 {
 	matrix::SquareMatrix<float, 4> cov;
 	for (unsigned n = 0; n < 4; n++) {
@@ -1029,7 +1029,7 @@ const matrix::SquareMatrix<float, 4> Ekf::orientation_covariances() const
 }
 
 // get the linear velocity covariances
-const matrix::SquareMatrix<float, 3> Ekf::velocity_covariances() const
+matrix::SquareMatrix<float, 3> Ekf::velocity_covariances() const
 {
 	matrix::SquareMatrix<float, 3> cov;
 	for (unsigned n = 0; n < 3; n++) {

--- a/EKF/ekf_helper.cpp
+++ b/EKF/ekf_helper.cpp
@@ -1000,10 +1000,10 @@ void Ekf::propagate_covariances_from_quat_to_euler(matrix::SquareMatrix<float, 3
 	G(0,1) =  (q4+q1) / ((q3+q2)*(q3+q2) + (q4+q2)*(q4+q1)) - (q4-q1)/((q3-q2)*(q3-q2) + (q4-q1)*(q4-q1));
 	G(0,2) =  (q4+q1) / ((q3+q2)*(q3+q2) + (q4+q2)*(q4+q1)) + (q4-q1)/((q3-q2)*(q3-q2) + (q4-q1)*(q4-q1));
 	G(0,3) = -(q3+q2) / ((q3+q2)*(q3+q2) + (q4+q2)*(q4+q1)) - (q3-q2)/((q3-q2)*(q3-q2) + (q4-q1)*(q4-q1));
-	G(1,0) = 2 * q4 / sqrt(1 - 4 * (q2*q3 + q1*q4)*(q2*q3 + q1*q4));
-	G(1,1) = 2 * q3 / sqrt(1 - 4 * (q2*q3 + q1*q4)*(q2*q3 + q1*q4));
-	G(1,2) = 2 * q2 / sqrt(1 - 4 * (q2*q3 + q1*q4)*(q2*q3 + q1*q4));
-	G(1,3) = 2 * q1 / sqrt(1 - 4 * (q2*q3 + q1*q4)*(q2*q3 + q1*q4));
+	G(1,0) = 2 * q4 / sqrtf(1 - 4 * (q2*q3 + q1*q4)*(q2*q3 + q1*q4));
+	G(1,1) = 2 * q3 / sqrtf(1 - 4 * (q2*q3 + q1*q4)*(q2*q3 + q1*q4));
+	G(1,2) = 2 * q2 / sqrtf(1 - 4 * (q2*q3 + q1*q4)*(q2*q3 + q1*q4));
+	G(1,3) = 2 * q1 / sqrtf(1 - 4 * (q2*q3 + q1*q4)*(q2*q3 + q1*q4));
 	G(2,0) = G(0,3);
 	G(2,1) = G(0,2);
 	G(2,2) = G(0,1);

--- a/EKF/estimator_interface.h
+++ b/EKF/estimator_interface.h
@@ -110,7 +110,7 @@ public:
 
 	virtual const matrix::SquareMatrix<float, 3> position_covariances() const = 0;
 
-	virtual const matrix::SquareMatrix<float, 4> quaternion_covariances() const = 0;
+	virtual const matrix::SquareMatrix<float, 4> orientation_covariances() const = 0;
 
 	virtual const matrix::SquareMatrix<float, 3> velocity_covariances() const = 0;
 

--- a/EKF/estimator_interface.h
+++ b/EKF/estimator_interface.h
@@ -104,8 +104,6 @@ public:
 
 	virtual void get_true_airspeed(float *tas) = 0;
 
-	virtual const matrix::SquareMatrix<float, 3> propagate_covariances_from_quat_to_euler() const = 0;
-
 	virtual const matrix::SquareMatrix<float, 24> covariances() const = 0;
 
 	virtual const matrix::Vector<float, 24> covariances_diagonal() const = 0;
@@ -113,10 +111,6 @@ public:
 	virtual const matrix::SquareMatrix<float, 3> position_covariances() const = 0;
 
 	virtual const matrix::SquareMatrix<float, 4> quaternion_covariances() const = 0;
-
-	virtual const matrix::SquareMatrix<float, 3> euler_covariances() const = 0;
-
-	virtual const matrix::SquareMatrix<float, 6> pose_covariances() const = 0;
 
 	virtual const matrix::SquareMatrix<float, 3> velocity_covariances() const = 0;
 

--- a/EKF/estimator_interface.h
+++ b/EKF/estimator_interface.h
@@ -104,7 +104,21 @@ public:
 
 	virtual void get_true_airspeed(float *tas) = 0;
 
+	virtual void propagate_covariances_from_quat_to_euler(matrix::SquareMatrix<float, 3> &euler_cov) = 0;
+
 	virtual void get_covariances(float *covariances) = 0;
+
+	virtual void get_covariances_diagonal(float *covariances) = 0;
+
+	virtual void get_position_covariances(float *covariances) = 0;
+
+	virtual void get_quaternion_covariances(float *covariances) = 0;
+
+	virtual void get_euler_covariances(float *covariances) = 0;
+
+	virtual void get_pose_covariances(float *covariances) = 0;
+
+	virtual void get_velocity_covariances(float *covariances) = 0;
 
 	// gets the variances for the NED velocity states
 	virtual void get_vel_var(Vector3f &vel_var) = 0;

--- a/EKF/estimator_interface.h
+++ b/EKF/estimator_interface.h
@@ -104,16 +104,6 @@ public:
 
 	virtual void get_true_airspeed(float *tas) = 0;
 
-	virtual const matrix::SquareMatrix<float, 24> covariances() const = 0;
-
-	virtual const matrix::Vector<float, 24> covariances_diagonal() const = 0;
-
-	virtual const matrix::SquareMatrix<float, 3> position_covariances() const = 0;
-
-	virtual const matrix::SquareMatrix<float, 4> orientation_covariances() const = 0;
-
-	virtual const matrix::SquareMatrix<float, 3> velocity_covariances() const = 0;
-
 	// gets the variances for the NED velocity states
 	virtual void get_vel_var(Vector3f &vel_var) = 0;
 

--- a/EKF/estimator_interface.h
+++ b/EKF/estimator_interface.h
@@ -104,21 +104,21 @@ public:
 
 	virtual void get_true_airspeed(float *tas) = 0;
 
-	virtual void propagate_covariances_from_quat_to_euler(matrix::SquareMatrix<float, 3> &euler_cov) = 0;
+	virtual const matrix::SquareMatrix<float, 3> propagate_covariances_from_quat_to_euler() const = 0;
 
-	virtual void get_covariances(float *covariances) = 0;
+	virtual const matrix::SquareMatrix<float, 24> covariances() const = 0;
 
-	virtual void get_covariances_diagonal(float *covariances) = 0;
+	virtual const matrix::Vector<float, 24> covariances_diagonal() const = 0;
 
-	virtual void get_position_covariances(float *covariances) = 0;
+	virtual const matrix::SquareMatrix<float, 3> position_covariances() const = 0;
 
-	virtual void get_quaternion_covariances(float *covariances) = 0;
+	virtual const matrix::SquareMatrix<float, 4> quaternion_covariances() const = 0;
 
-	virtual void get_euler_covariances(float *covariances) = 0;
+	virtual const matrix::SquareMatrix<float, 3> euler_covariances() const = 0;
 
-	virtual void get_pose_covariances(float *covariances) = 0;
+	virtual const matrix::SquareMatrix<float, 6> pose_covariances() const = 0;
 
-	virtual void get_velocity_covariances(float *covariances) = 0;
+	virtual const matrix::SquareMatrix<float, 3> velocity_covariances() const = 0;
 
 	// gets the variances for the NED velocity states
 	virtual void get_vel_var(Vector3f &vel_var) = 0;


### PR DESCRIPTION
This PR aims to improve the interface with the covariances obtained by EKF. It extends far beyond the the existent method `get_covariances()`, by also adding ways of obtaining dimensions covariances.
Allows:
- obtain the full state covariances matrix;
- obtain the position, the quaternion and the velocity covariance;
- by implementing the covariances law, one is now able to obtain the 3x3 covariance from the euler anges, which is useful for the current odometry pipeline implemented on PX4;
- merges the position and orientation (euler) covariances into a single pose covariance, which not being a cross-covariance matrix, it helps at least to parse it to the PX4 internals.