### PR TITLE
EKF: added absolute range altimeter

### DIFF
--- a/EKF/common.h
+++ b/EKF/common.h
@@ -291,6 +291,7 @@ struct parameters {
 	float range_aid_innov_gate{1.0f}; 	///< gate size used for innovation consistency checks for range aid fusion
 	float range_cos_max_tilt{0.7071f};	///< cosine of the maximum tilt angle from the vertical that permits use of range finder and flow data
 	float range_stuck_threshold{0.1f};	///< minimum variation in range finder reading required to declare a range finder 'unstuck' when readings recommence after being out of range (m)
+	int32_t rng_abs{0};			///< Boolean. A value of 1 indicates that the range finder sensor always gives an absolute altitude independently from the orientation of the vehicle.
 
 	// vision position fusion
 	float ev_innov_gate{5.0f};		///< vision estimator fusion innovation consistency gate size (STD)

--- a/EKF/control.cpp
+++ b/EKF/control.cpp
@@ -116,7 +116,11 @@ void Ekf::controlFusionModes()
 		// correct the range data for position offset relative to the IMU
 		Vector3f pos_offset_body = _params.rng_pos_body - _params.imu_pos_body;
 		Vector3f pos_offset_earth = _R_to_earth * pos_offset_body;
-		_range_sample_delayed.rng += pos_offset_earth(2) / _R_rng_to_earth_2_2;
+		if (!_params.rng_abs){
+			_range_sample_delayed.rng += pos_offset_earth(2) / _R_rng_to_earth_2_2;
+		} else {
+			_range_sample_delayed.rng += pos_offset_earth(2);
+		}
 	}
 	
 	// We don't fuse flow data immediately because we have to wait for the mid integration point to fall behind the fusion time horizon.
@@ -952,7 +956,11 @@ void Ekf::controlHeightFusion()
 					_hgt_sensor_offset = _terrain_vpos;
 
 				} else {
-					_hgt_sensor_offset = _R_rng_to_earth_2_2 * _range_sample_delayed.rng + _state.pos(2);
+					if (!_params.rng_abs){
+						_hgt_sensor_offset = _R_rng_to_earth_2_2 * _range_sample_delayed.rng + _state.pos(2);
+					} else {
+						_hgt_sensor_offset = _range_sample_delayed.rng + _state.pos(2);
+					}
 				}
 			}
 
@@ -1003,9 +1011,11 @@ void Ekf::controlHeightFusion()
 				_hgt_sensor_offset = _terrain_vpos;
 
 			} else if (_control_status.flags.in_air) {
-
-				_hgt_sensor_offset = _R_rng_to_earth_2_2 * _range_sample_delayed.rng + _state.pos(2);
-
+				if (!_params.rng_abs){
+					_hgt_sensor_offset = _R_rng_to_earth_2_2 * _range_sample_delayed.rng + _state.pos(2);
+				} else {
+					_hgt_sensor_offset = _range_sample_delayed.rng + _state.pos(2);
+				}
 			} else {
 
 				_hgt_sensor_offset = _params.rng_gnd_clearance;
@@ -1037,7 +1047,11 @@ void Ekf::controlHeightFusion()
 					_hgt_sensor_offset = _terrain_vpos;
 
 				} else {
-					_hgt_sensor_offset = _R_rng_to_earth_2_2 * _range_sample_delayed.rng + _state.pos(2);
+					if (!_params.rng_abs){
+						_hgt_sensor_offset = _R_rng_to_earth_2_2 * _range_sample_delayed.rng + _state.pos(2);
+					} else {
+						_hgt_sensor_offset = _range_sample_delayed.rng + _state.pos(2);
+					}
 				}
 			}
 

--- a/EKF/ekf.cpp
+++ b/EKF/ekf.cpp
@@ -266,7 +266,11 @@ bool Ekf::initialiseFilter()
 			// so it can be used as a backup ad set the initial height using the range finder
 			const baroSample &baro_newest = _baro_buffer.get_newest();
 			_baro_hgt_offset = baro_newest.hgt;
-			_state.pos(2) = -math::max(_rng_filt_state * _R_rng_to_earth_2_2, _params.rng_gnd_clearance);
+			if (!_params.rng_abs){
+				_state.pos(2) = -math::max(_rng_filt_state * _R_rng_to_earth_2_2, _params.rng_gnd_clearance);
+			} else {
+				_state.pos(2) = -math::max(_rng_filt_state, _params.rng_gnd_clearance);
+			}
 			ECL_INFO("EKF using range finder height - commencing alignment");
 
 		} else if (_control_status.flags.ev_hgt) {

--- a/EKF/ekf_helper.cpp
+++ b/EKF/ekf_helper.cpp
@@ -65,7 +65,13 @@ bool Ekf::resetVelocity()
 		float heightAboveGndEst = fmaxf((_terrain_vpos - _state.pos(2)), _params.rng_gnd_clearance);
 
 		// calculate absolute distance from focal point to centre of frame assuming a flat earth
-		float range = heightAboveGndEst / _R_rng_to_earth_2_2;
+		float range;
+		if (!_params.rng_abs){
+			range = heightAboveGndEst / _R_rng_to_earth_2_2;
+		} else {
+			range = heightAboveGndEst;
+		}
+		
 
 		if ((range - _params.rng_gnd_clearance) > 0.3f && _flow_sample_delayed.dt > 0.05f) {
 			// we should have reliable OF measurements so
@@ -219,9 +225,18 @@ void Ekf::resetHeight()
 			// correct the range data for position offset relative to the IMU
 			Vector3f pos_offset_body = _params.rng_pos_body - _params.imu_pos_body;
 			Vector3f pos_offset_earth = _R_to_earth * pos_offset_body;
-			range_newest.rng += pos_offset_earth(2) / _R_rng_to_earth_2_2;
+			if (!_params.rng_abs){
+				range_newest.rng += pos_offset_earth(2) / _R_rng_to_earth_2_2;
+			} else {
+				range_newest.rng += pos_offset_earth(2);
+			}
 			// calculate the new vertical position using range sensor
-			float new_pos_down = _hgt_sensor_offset - range_newest.rng * _R_rng_to_earth_2_2;
+			float new_pos_down;
+			if (!_params.rng_abs){
+				new_pos_down = _hgt_sensor_offset - range_newest.rng * _R_rng_to_earth_2_2;
+			} else {	
+				new_pos_down = _hgt_sensor_offset - range_newest.rng;
+			}
 
 			// update the state and assoicated variance
 			_state.pos(2) = new_pos_down;

--- a/EKF/terrain_estimator.cpp
+++ b/EKF/terrain_estimator.cpp
@@ -50,7 +50,11 @@ bool Ekf::initHagl()
 
 	if ((_time_last_imu - latest_measurement.time_us) < (uint64_t)2e5 && _R_rng_to_earth_2_2 > _params.range_cos_max_tilt) {
 		// if we have a fresh measurement, use it to initialise the terrain estimator
-		_terrain_vpos = _state.pos(2) + latest_measurement.rng * _R_rng_to_earth_2_2;
+		if (!_params.rng_abs){
+			_terrain_vpos = _state.pos(2) + latest_measurement.rng * _R_rng_to_earth_2_2;
+		} else {
+			_terrain_vpos = _state.pos(2) + latest_measurement.rng;
+		}
 		// initialise state variance to variance of measurement
 		_terrain_var = sq(_params.range_noise);
 		// success
@@ -119,7 +123,12 @@ void Ekf::fuseHagl()
 	// If the vehicle is excessively tilted, do not try to fuse range finder observations
 	if (_R_rng_to_earth_2_2 > _params.range_cos_max_tilt) {
 		// get a height above ground measurement from the range finder assuming a flat earth
-		float meas_hagl = _range_sample_delayed.rng * _R_rng_to_earth_2_2;
+		float meas_hagl;
+		if (!_params.rng_abs){
+			meas_hagl = _range_sample_delayed.rng * _R_rng_to_earth_2_2;
+		} else {
+			meas_hagl = _range_sample_delayed.rng;
+		}
 
 		// predict the hagl from the vehicle position and terrain height
 		float pred_hagl = _terrain_vpos - _state.pos(2);

--- a/EKF/vel_pos_fusion.cpp
+++ b/EKF/vel_pos_fusion.cpp
@@ -137,10 +137,19 @@ void Ekf::fuseVelPosHeight()
 		} else if (_control_status.flags.rng_hgt && (_R_rng_to_earth_2_2 > _params.range_cos_max_tilt)) {
 			fuse_map[5] = true;
 			// use range finder with tilt correction
-			innovation[5] = _state.pos(2) - (-math::max(_range_sample_delayed.rng * _R_rng_to_earth_2_2,
+			if (!_params.rng_abs){
+				innovation[5] = _state.pos(2) - (-math::max(_range_sample_delayed.rng * _R_rng_to_earth_2_2,
 							 _params.rng_gnd_clearance)) - _hgt_sensor_offset;
+			} else {
+				innovation[5] = _state.pos(2) - (-math::max(_range_sample_delayed.rng,
+							 _params.rng_gnd_clearance)) - _hgt_sensor_offset;
+			}
 			// observation variance - user parameter defined
-			R[5] = fmaxf((sq(_params.range_noise) + sq(_params.range_noise_scaler * _range_sample_delayed.rng)) * sq(_R_rng_to_earth_2_2), 0.01f);
+			if (!_params.rng_abs){
+				R[5] = fmaxf((sq(_params.range_noise) + sq(_params.range_noise_scaler * _range_sample_delayed.rng)) * sq(_R_rng_to_earth_2_2), 0.01f);
+			} else {
+				R[5] = fmaxf((sq(_params.range_noise) + sq(_params.range_noise_scaler * _range_sample_delayed.rng)), 0.01f);
+			}
 			// innovation gate size
 			gate_size[5] = fmaxf(_params.range_innov_gate, 1.0f);
 


### PR DESCRIPTION
Added support for absolute altimeter or for range finders mounted on a gimbal such that they are alway vertical, so there is no need to rotate from body to earth frame.
A parameter is used to enable this feature.

WARNING: requires also the pull request in PX4/Firmware with the appropriate modifications to EKF2 module.