### PR TITLE
EKF: Fix bug causing incorrect yaw variance value to be used after a reset

### DIFF
--- a/EKF/ekf_helper.cpp
+++ b/EKF/ekf_helper.cpp
@@ -729,7 +729,7 @@ bool Ekf::resetMagHeading(Vector3f &mag_init)
 	}
 
 	// update the yaw angle variance using the variance of the measurement
-	if (!_control_status.flags.ev_yaw) {
+	if (_control_status.flags.ev_yaw) {
 		// using error estimate from external vision data
 		angle_err_var_vec(2) = sq(fmaxf(_ev_sample_delayed.angErr, 1.0e-2f));
 


### PR DESCRIPTION
Fixes https://github.com/PX4/ecl/issues/548

When using magnetometer as the primary yaw reference for a yaw angle reset, the mag heading uncertainty should always be used to set the variance of the rotation vector Z-axis.  The external vision angular uncertainty should only be used when external vision data is being used as the yaw reference.