### PR TITLE
EKF: initialize covariances before we reset the heading in order to p…

### DIFF
--- a/EKF/ekf.cpp
+++ b/EKF/ekf.cpp
@@ -232,6 +232,9 @@ bool Ekf::initialiseFilter()
 		_state.mag_B.setZero();
 		_state.wind_vel.setZero();
 
+		// initialise the state covariance matrix
+		initialiseCovariance();
+
 		// get initial roll and pitch estimate from delta velocity vector, assuming vehicle is static
 		float pitch = 0.0f;
 		float roll = 0.0f;
@@ -275,9 +278,6 @@ bool Ekf::initialiseFilter()
 			resetHeight();
 
 		}
-
-		// initialise the state covariance matrix
-		initialiseCovariance();
 
 		// try to initialise the terrain estimator
 		_terrain_initialised = initHagl();

--- a/EKF/mag_fusion.cpp
+++ b/EKF/mag_fusion.cpp
@@ -646,7 +646,7 @@ void Ekf::fuseHeading()
 	// wrap the innovation to the interval between +-pi
 	_heading_innov = wrap_pi(_heading_innov);
 
-	// Calculate innovation variance and Kalman gains, taking advantage of the fact that only the first 3 elements in H are non zero
+	// Calculate innovation variance and Kalman gains, taking advantage of the fact that only the first 4 elements in H are non zero
 	// calculate the innovaton variance
 	float PH[4];
 	_heading_innov_var = R_YAW;


### PR DESCRIPTION
…reserve the yaw uncertainty

During bootup we first reset the heading and initialize the yaw variance. Then directly afterwards we reset the covariance matrix. This PR shifts the order such that the increase in yaw uncertainty during the heading reset is preserved. 

Two bootups in sitl with and without the change. (The spike at x=200 is the increase in yaw variance during the heading reset when we get GPS lock)

**master**
![image](https://user-images.githubusercontent.com/7795133/50968880-d4610700-14dc-11e9-9087-dc0c43c8a86a.png)

**PR**
![image](https://user-images.githubusercontent.com/7795133/50968885-dcb94200-14dc-11e9-9e4b-6a5eae628fb8.png)
