### PR TITLE
EKF: Reinitialize terrain estimate if variance is very large

### DIFF
--- a/EKF/terrain_estimator.cpp
+++ b/EKF/terrain_estimator.cpp
@@ -75,8 +75,8 @@ void Ekf::runTerrainEstimator()
 	// Perform a continuity check on range finder data
 	checkRangeDataContinuity();
 
-	// Perform initialisation check
-	if (!_terrain_initialised) {
+	// Perform initialisation check. Reinitialize terrain estimate if variance is very large
+	if (!_terrain_initialised || _terrain_var > 100.0f) {
 		_terrain_initialised = initHagl();
 
 	} else {


### PR DESCRIPTION
Reinitialize terrain estimate if variance is very large. This is needed since otherwise if the vehicle has been out of distance sensor range for some time it can happen that the very first sample is rejected by the innovation check and hence the range sensor will never be fused