### PR TITLE
TECS underspeed respect max throttle parameter

### DIFF
--- a/tecs/tecs.cpp
+++ b/tecs/tecs.cpp
@@ -315,8 +315,8 @@ void TECS::_update_throttle_setpoint(const float throttle_cruise, const matrix::
 
 	// Calculate the throttle demand
 	if (_underspeed_detected) {
-		// always use full throttle to recover from an underspeed condition
-		_throttle_setpoint = 1.0f;
+		// always use max throttle to recover from an underspeed condition
+		_throttle_setpoint = _throttle_setpoint_max;
 
 	} else {
 		// Adjust the demanded total energy rate to compensate for induced drag rise in turns.


### PR DESCRIPTION
A small standalone fix from @almaaro's pull request. https://github.com/PX4/ecl/pull/538

> Also changed the throttle setpoint in underspeed conditions from 100% to the user defined max value. No more burnt ESCs.