### PR TITLE
[WIP] EKF: Not require a mag sensor data to initialize if fusion is disabled

### DIFF
--- a/EKF/ekf.cpp
+++ b/EKF/ekf.cpp
@@ -213,7 +213,7 @@ bool Ekf::initialiseFilter()
 
 	// check to see if we have enough measurements and return false if not
 	bool hgt_count_fail = _hgt_counter <= 2u * _obs_buffer_length;
-	bool mag_count_fail = _mag_counter <= 2u * _obs_buffer_length;
+	bool mag_count_fail = (_params.mag_fusion_type !=MAG_FUSE_TYPE_NONE) && (_mag_counter <= 2u * _obs_buffer_length);
 
 	if (hgt_count_fail || mag_count_fail) {
 		return false;


### PR DESCRIPTION
I have a board without a mag sensor and want to fly indoors with the yaw data form external vision system. This change does not require data from mag sensor to initialize the ekf if the `EKF2_MAG_TYPE` is set to `5 (None)`. The problem was described in this issue: https://github.com/PX4/Firmware/issues/11359

Tested on current PX4 master in flight with LIDAR, flow and external vision system.