### PR TITLE
EKF: Fix bug causing continual yaw reset when EKF2_MAG_TYPE = 2

### DIFF
--- a/EKF/control.cpp
+++ b/EKF/control.cpp
@@ -1533,7 +1533,7 @@ void Ekf::controlMagFusion()
 			}
 
 		} else if (_params.mag_fusion_type == MAG_FUSE_TYPE_3D) {
-			if (!_control_status.flags.mag_3D && _control_status.flags.yaw_align && (_flt_mag_align_start_time > 0)) {
+			if (!_control_status.flags.mag_3D && _control_status.flags.yaw_align) {
 				// only commence 3-axis fusion when yaw is aligned and field states set
 				_control_status.flags.mag_3D = true;
 			}

--- a/EKF/control.cpp
+++ b/EKF/control.cpp
@@ -1533,16 +1533,10 @@ void Ekf::controlMagFusion()
 			}
 
 		} else if (_params.mag_fusion_type == MAG_FUSE_TYPE_3D) {
-			// if transitioning into 3-axis fusion mode, we need to initialise the yaw angle and field states
-			if (!_control_status.flags.mag_3D || !_control_status.flags.mag_align_complete) {
-				_control_status.flags.mag_align_complete = resetMagHeading(_mag_sample_delayed.mag);
-				_control_status.flags.yaw_align = _control_status.flags.yaw_align || _control_status.flags.mag_align_complete;
+			if (!_control_status.flags.mag_3D && _control_status.flags.yaw_align && (_flt_mag_align_start_time > 0)) {
+				// only commence 3-axis fusion when yaw is aligned and field states set
+				_control_status.flags.mag_3D = true;
 			}
-
-			// use 3-axis mag fusion if reset was successful
-			_control_status.flags.mag_3D = _control_status.flags.mag_align_complete;
-			_control_status.flags.mag_hdg = false;
-
 		} else {
 			// do no magnetometer fusion at all
 			_control_status.flags.mag_hdg = false;


### PR DESCRIPTION
Fixes https://github.com/PX4/ecl/issues/575

SITL test log here: https://logs.px4.io/plot_app?log=2e403ed3-2189-443b-b72d-504a9541ac1d with EKF2_MAG_TYPE = 2

Print statements at each call to resetMagHeading() were use to verify that reset only occurred at the following events:

1. State vector initialisation (does not increment quaternion reset count)
2. Completion of tilt alignment
3. Commencement of GPS aiding when local declination was available
4. When 1.5 metres was cleared after takeoff

Reset Counter:
![screen shot 2019-03-02 at 9 09 11 am](https://user-images.githubusercontent.com/3596952/53669789-78408500-3ccc-11e9-86b6-88bd65bd586e.png)

Earth Field States:
![screen shot 2019-03-02 at 9 09 38 am](https://user-images.githubusercontent.com/3596952/53669782-6eb71d00-3ccc-11e9-8fe1-e340b354f1ed.png)

XYZ Innovations:
![screen shot 2019-03-02 at 9 10 17 am](https://user-images.githubusercontent.com/3596952/53669795-7d9dcf80-3ccc-11e9-9423-fc5d32c16505.png)

Height:
![screen shot 2019-03-02 at 9 11 19 am](https://user-images.githubusercontent.com/3596952/53669767-5f37d400-3ccc-11e9-9d14-f5331b1949cb.png)
