### PR TITLE
Add Paparazzi compatibility

### DIFF
--- a/EKF/estimator_interface.h
+++ b/EKF/estimator_interface.h
@@ -41,10 +41,10 @@
 
 #pragma once
 
+#include <ecl.h>
 #include "common.h"
 #include "RingBuffer.h"
 
-#include <ecl.h>
 #include <geo/geo.h>
 #include <matrix/math.hpp>
 #include <mathlib/mathlib.h>

--- a/ecl.h
+++ b/ecl.h
@@ -51,6 +51,19 @@ using ecl_abstime = hrt_abstime;
 #define ECL_WARN PX4_WARN
 #define ECL_ERR	 PX4_ERR
 
+#elif defined(__PAPARAZZI)
+
+#include "std.h"
+
+#define ecl_absolute_time() (0)
+#define ecl_elapsed_time(t) (*t * 0UL) // TODO: add simple time functions
+
+using ecl_abstime = uint64_t;
+
+#define ECL_INFO(...)
+#define ECL_WARN(...)
+#define ECL_ERR(...)
+
 #else
 
 #include <cstdio>


### PR DESCRIPTION
This adds support for the paparazzi autopilot to use this library as EKF.
The header order change has to be done in order to have `std.h` included to get certain defines at the start of the `estimator_interface.h`.