### PR TITLE
ground effect: removed dependency on local position

### DIFF
--- a/EKF/control.cpp
+++ b/EKF/control.cpp
@@ -985,12 +985,9 @@ void Ekf::controlHeightFusion()
 				_hgt_sensor_offset = 0.0f;
 			}
 
-			// Turn off ground effect compensation if it times out or sufficient height has been gained
-			// since takeoff.
+			// Turn off ground effect compensation if it times out
 			if (_control_status.flags.gnd_effect) {
-				if (((_time_last_imu - _time_last_gnd_effect_on) > GNDEFFECT_TIMEOUT) ||
-				    (((_last_on_ground_posD - _state.pos(2)) > _params.gnd_effect_max_hgt) &&
-				     _control_status.flags.in_air)) {
+				if ((_time_last_imu - _time_last_gnd_effect_on > GNDEFFECT_TIMEOUT)) {
 
 					_control_status.flags.gnd_effect = false;
 				}


### PR DESCRIPTION
Ground effect compensation activation logic for systems without a range finder has been implemented in
https://github.com/PX4/Firmware/pull/11592

However, the ekf would deactivate ground effect compensation when the vehicle was in_air and not close to the takeoff altitude. This means that ground effect compensation did not work if the user took off from some altitude and tried to land the drone at a higher altitude. 

