### PR TITLE
EKF: fix covariance and output filter buffer initialization

### DIFF
--- a/EKF/ekf.cpp
+++ b/EKF/ekf.cpp
@@ -60,6 +60,7 @@ bool Ekf::init(uint64_t timestamp)
 	_output_new.vel.setZero();
 	_output_new.pos.setZero();
 	_output_new.quat_nominal.setZero();
+	_output_new.quat_nominal(0) = 1.0f;
 
 	_delta_angle_corr.setZero();
 	_imu_down_sampled.delta_ang.setZero();

--- a/EKF/ekf.cpp
+++ b/EKF/ekf.cpp
@@ -256,13 +256,10 @@ bool Ekf::initialiseFilter()
 		// update transformation matrix from body to world frame
 		_R_to_earth = quat_to_invrotmat(_state.quat_nominal);
 
-		// calculate the averaged magnetometer reading
-		Vector3f mag_init = _mag_filt_state;
-
 		// calculate the initial magnetic field and yaw alignment
 		// Get the magnetic declination
 		calcMagDeclination();
-		_control_status.flags.yaw_align = resetMagHeading(mag_init);
+		_control_status.flags.yaw_align = resetMagHeading(_mag_filt_state);
 
 		if (_control_status.flags.rng_hgt) {
 			// if we are using the range finder as the primary source, then calculate the baro height at origin so  we can use baro as a backup

--- a/EKF/ekf.cpp
+++ b/EKF/ekf.cpp
@@ -249,7 +249,6 @@ bool Ekf::initialiseFilter()
 		// calculate initial tilt alignment
 		Eulerf euler_init(roll, pitch, 0.0f);
 		_state.quat_nominal = Quatf(euler_init);
-		_output_new.quat_nominal = _state.quat_nominal;
 
 		// update transformation matrix from body to world frame
 		_R_to_earth = quat_to_invrotmat(_state.quat_nominal);

--- a/EKF/ekf.h
+++ b/EKF/ekf.h
@@ -532,9 +532,9 @@ private:
 	// update the terrain vertical position estimate using a height above ground measurement from the range finder
 	void fuseHagl();
 
-	// reset the heading and magnetic field states using the declination and magnetometer measurements
+	// reset the heading and magnetic field states using the declination and magnetometer/external vision measurements
 	// return true if successful
-	bool resetMagHeading(Vector3f &mag_init);
+	bool resetMagHeading(Vector3f &mag_init, bool increase_yaw_var = true, bool update_buffer=true);
 
 	// Do a forced re-alignment of the yaw angle to align with the horizontal velocity vector from the GPS.
 	// It is used to align the yaw angle after launch or takeoff for fixed wing vehicle.

--- a/EKF/ekf_helper.cpp
+++ b/EKF/ekf_helper.cpp
@@ -394,6 +394,12 @@ void Ekf::alignOutputFilter()
 		_output_buffer[i].vel += vel_delta;
 		_output_buffer[i].pos += pos_delta;
 	}
+
+	_output_new.quat_nominal *= q_delta;
+	_output_new.quat_nominal.normalize();
+
+	_output_sample_delayed.quat_nominal *= q_delta;
+	_output_sample_delayed.quat_nominal.normalize();
 }
 
 // Do a forced re-alignment of the yaw angle to align with the horizontal velocity vector from the GPS.

--- a/EKF/ekf_helper.cpp
+++ b/EKF/ekf_helper.cpp
@@ -379,7 +379,7 @@ void Ekf::resetHeight()
 void Ekf::alignOutputFilter()
 {
 	// calculate the quaternion delta between the output and EKF quaternions at the EKF fusion time horizon
-	Quatf q_delta = _state.quat_nominal.inversed() * _output_sample_delayed.quat_nominal;
+	Quatf q_delta = _state.quat_nominal * _output_sample_delayed.quat_nominal.inversed();
 	q_delta.normalize();
 
 	// calculate the velocity and posiiton deltas between the output and EKF at the EKF fusion time horizon

--- a/EKF/ekf_helper.cpp
+++ b/EKF/ekf_helper.cpp
@@ -716,21 +716,6 @@ bool Ekf::resetMagHeading(Vector3f &mag_init)
 	Quatf q_error =  quat_before_reset.inversed() * quat_after_reset;
 	q_error.normalize();
 
-	// convert the quaternion delta to a delta angle
-	Vector3f delta_ang_error;
-	float scalar;
-
-	if (q_error(0) >= 0.0f) {
-		scalar = -2.0f;
-
-	} else {
-		scalar = 2.0f;
-	}
-
-	delta_ang_error(0) = scalar * q_error(1);
-	delta_ang_error(1) = scalar * q_error(2);
-	delta_ang_error(2) = scalar * q_error(3);
-
 	// update quaternion states
 	_state.quat_nominal = quat_after_reset;
 	uncorrelateQuatStates();

--- a/EKF/ekf_helper.cpp
+++ b/EKF/ekf_helper.cpp
@@ -379,7 +379,7 @@ void Ekf::resetHeight()
 void Ekf::alignOutputFilter()
 {
 	// calculate the quaternion delta between the output and EKF quaternions at the EKF fusion time horizon
-	Quatf q_delta = _state.quat_nominal * _output_sample_delayed.quat_nominal.inversed();
+	Quatf q_delta = _output_sample_delayed.quat_nominal.inversed() *  _state.quat_nominal;
 	q_delta.normalize();
 
 	// calculate the velocity and posiiton deltas between the output and EKF at the EKF fusion time horizon
@@ -387,7 +387,7 @@ void Ekf::alignOutputFilter()
 	const Vector3f pos_delta = _state.pos - _output_sample_delayed.pos;
 
 	// loop through the output filter state history and add the deltas
-	// Note q1 *= q2 is equivalent to q1 = q2 * q1
+	// Note q1 *= q2 is equivalent to q1 = q1 * q2
 	for (uint8_t i = 0; i < _output_buffer.get_length(); i++) {
 		_output_buffer[i].quat_nominal *= q_delta;
 		_output_buffer[i].quat_nominal.normalize();


### PR DESCRIPTION
This PR fixes several issues that were present in the initialization of the attitude covariances and the output filter buffer.

- Issue 1: The attitude covariances were initialized [before the attitude](https://github.com/PX4/ecl/blob/a85d3a43edc4ac4b85ae21159510b9c26f7359e6/EKF/ekf.cpp#L235-L253) which does not work properly since the initialization is [dependent on the attitude](https://github.com/PX4/ecl/blob/a85d3a43edc4ac4b85ae21159510b9c26f7359e6/EKF/ekf_helper.cpp#L1462-L1478).
- Issue 2: After the attitude was initialized we [rotate the yaw angle](https://github.com/PX4/ecl/blob/a85d3a43edc4ac4b85ae21159510b9c26f7359e6/EKF/ekf.cpp#L265-L265). In this function we also rotated all attitude solutions in the output buffer. However, the data in the buffer did not include the tilt rotation. So the "yaw rotation" was applied along a completely different axis.
- Issue 3: At the end of the initialization we [align the output filter](https://github.com/PX4/ecl/blob/a85d3a43edc4ac4b85ae21159510b9c26f7359e6/EKF/ekf_helper.cpp#L379-L379) to match the state estimate at the delayed time horizon. However, the rotation was applied in the wrong direction.
- Issue 4: The `_output_new` quaternion was [not initialized to a valid quaternion](https://github.com/PX4/ecl/blob/a85d3a43edc4ac4b85ae21159510b9c26f7359e6/EKF/ekf.cpp#L62-L62)

This PR changes the EKF initialization to:
1) init tilt
2) init yaw
3) init tilt uncertainty
4) init yaw uncertainty

This have quite large consequences. Below is a logfile with high temperature gradient replayed with master code and this PR.

On master the delta velocity bias states diverge before takeoff triggering a reset of the covariance matrix while on the PR they are stable

**master/PR**
![image](https://user-images.githubusercontent.com/7795133/54036138-1e9ff500-41bb-11e9-8cce-e1e08eb862f8.png)

This is because on the PR the uncertainty in the delta velocity bias aligned with gravity decrease much faster since this axis is more observable than the axes aligned with the horizontal plane.

**master/PR**
Note that this plot is from a tailsitter with body x axis facing upwards
![image](https://user-images.githubusercontent.com/7795133/54036448-ecdb5e00-41bb-11e9-8045-4a7bbe9b11b1.png)

This is a plot comparing the attitude estimate at the current time and at the delayed time horizon right after the EKF initialization. (This is normally not logged since the ekf2_main.cpp only logs the attitude estimate when tilt is aligned. So for testing the attitude estimate at the current time is added to estimator status)

**master/PR**
![image](https://user-images.githubusercontent.com/7795133/54036719-9cb0cb80-41bc-11e9-8d34-ba7de412701e.png)




