### PR TITLE
EKF: Fix innovation in fuseDeclination()

### DIFF
--- a/EKF/control.cpp
+++ b/EKF/control.cpp
@@ -48,9 +48,6 @@ void Ekf::controlFusionModes()
 	// Store the status to enable change detection
 	_control_status_prev.value = _control_status.value;
 
-	// Get the magnetic declination
-	calcMagDeclination();
-
 	// monitor the tilt alignment
 	if (!_control_status.flags.tilt_align) {
 		// whilst we are aligning the tilt, monitor the variances

--- a/EKF/ekf.cpp
+++ b/EKF/ekf.cpp
@@ -254,8 +254,6 @@ bool Ekf::initialiseFilter()
 		_R_to_earth = quat_to_invrotmat(_state.quat_nominal);
 
 		// calculate the initial magnetic field and yaw alignment
-		// Get the magnetic declination
-		calcMagDeclination();
 		_control_status.flags.yaw_align = resetMagHeading(_mag_filt_state, false, false);
 
 		// initialise the state covariance matrix

--- a/EKF/ekf.h
+++ b/EKF/ekf.h
@@ -550,7 +550,7 @@ private:
 	// It is used to align the yaw angle after launch or takeoff for fixed wing vehicle.
 	bool realignYawGPS();
 
-	// calculate the magnetic declination to be used by the alignment and fusion processing
+	// Return the magnetic declination in radians to be used by the alignment and fusion processing
 	float getMagDeclination();
 
 	// reset position states of the ekf (only horizontal position)

--- a/EKF/ekf.h
+++ b/EKF/ekf.h
@@ -389,8 +389,6 @@ private:
 	bool _inhibit_flow_use{false};	///< true when use of optical flow and range finder is being inhibited
 	Vector2f _flowRadXYcomp;	///< measured delta angle of the image about the X and Y body axes after removal of body rotation (rad), RH rotation is positive
 
-	float _mag_declination{0.0f};	///< magnetic declination used by reset and fusion functions (rad)
-
 	// output predictor states
 	Vector3f _delta_angle_corr;	///< delta angle correction vector (rad)
 	imuSample _imu_down_sampled{};	///< down sampled imu data (sensor rate -> filter update rate)
@@ -553,7 +551,7 @@ private:
 	bool realignYawGPS();
 
 	// calculate the magnetic declination to be used by the alignment and fusion processing
-	void calcMagDeclination();
+	float getMagDeclination();
 
 	// reset position states of the ekf (only horizontal position)
 	bool resetPosition();

--- a/EKF/ekf_helper.cpp
+++ b/EKF/ekf_helper.cpp
@@ -766,7 +766,7 @@ bool Ekf::resetMagHeading(Vector3f &mag_init, bool increase_yaw_var, bool update
 	return true;
 }
 
-// Calculate the magnetic declination to be used by the alignment and fusion processing
+// Return the magnetic declination in radians to be used by the alignment and fusion processing
 float Ekf::getMagDeclination()
 {
 	// set source of magnetic declination for internal use

--- a/EKF/ekf_helper.cpp
+++ b/EKF/ekf_helper.cpp
@@ -610,7 +610,7 @@ bool Ekf::resetMagHeading(Vector3f &mag_init, bool increase_yaw_var, bool update
 			// rotate the magnetometer measurements into earth frame using a zero yaw angle
 			Vector3f mag_earth_pred = R_to_earth * mag_init;
 			// the angle of the projection onto the horizontal gives the yaw angle
-			euler321(2) = -atan2f(mag_earth_pred(1), mag_earth_pred(0)) + _mag_declination;
+			euler321(2) = -atan2f(mag_earth_pred(1), mag_earth_pred(0)) + getMagDeclination();
 
 		} else if (_params.mag_fusion_type == MAG_FUSE_TYPE_INDOOR && _mag_use_inhibit) {
 			// we are operating without knowing the earth frame yaw angle
@@ -668,7 +668,7 @@ bool Ekf::resetMagHeading(Vector3f &mag_init, bool increase_yaw_var, bool update
 			// rotate the magnetometer measurements into earth frame using a zero yaw angle
 			Vector3f mag_earth_pred = R_to_earth * mag_init;
 			// the angle of the projection onto the horizontal gives the yaw angle
-			euler312(0) = -atan2f(mag_earth_pred(1), mag_earth_pred(0)) + _mag_declination;
+			euler312(0) = -atan2f(mag_earth_pred(1), mag_earth_pred(0)) + getMagDeclination();
 
 		} else if (_params.mag_fusion_type == MAG_FUSE_TYPE_INDOOR && _mag_use_inhibit) {
 			// we are operating without knowing the earth frame yaw angle
@@ -767,28 +767,28 @@ bool Ekf::resetMagHeading(Vector3f &mag_init, bool increase_yaw_var, bool update
 }
 
 // Calculate the magnetic declination to be used by the alignment and fusion processing
-void Ekf::calcMagDeclination()
+float Ekf::getMagDeclination()
 {
 	// set source of magnetic declination for internal use
 	if (_control_status.flags.mag_align_complete) {
 		// Use value consistent with earth field state
-		_mag_declination = atan2f(_state.mag_I(1), _state.mag_I(0));
+		return atan2f(_state.mag_I(1), _state.mag_I(0));
 
 	} else if (_params.mag_declination_source & MASK_USE_GEO_DECL) {
 		// use parameter value until GPS is available, then use value returned by geo library
 		if (_NED_origin_initialised) {
-			_mag_declination = _mag_declination_gps;
-			_mag_declination_to_save_deg = math::degrees(_mag_declination);
+			_mag_declination_to_save_deg = math::degrees(_mag_declination_gps);
+			return _mag_declination_gps;
 
 		} else {
-			_mag_declination = math::radians(_params.mag_declination_deg);
 			_mag_declination_to_save_deg = _params.mag_declination_deg;
+			return math::radians(_params.mag_declination_deg);
 		}
 
 	} else {
 		// always use the parameter value
-		_mag_declination = math::radians(_params.mag_declination_deg);
 		_mag_declination_to_save_deg = _params.mag_declination_deg;
+		return math::radians(_params.mag_declination_deg);
 	}
 }
 

--- a/EKF/ekf_helper.cpp
+++ b/EKF/ekf_helper.cpp
@@ -777,17 +777,14 @@ float Ekf::getMagDeclination()
 	} else if (_params.mag_declination_source & MASK_USE_GEO_DECL) {
 		// use parameter value until GPS is available, then use value returned by geo library
 		if (_NED_origin_initialised) {
-			_mag_declination_to_save_deg = math::degrees(_mag_declination_gps);
 			return _mag_declination_gps;
 
 		} else {
-			_mag_declination_to_save_deg = _params.mag_declination_deg;
 			return math::radians(_params.mag_declination_deg);
 		}
 
 	} else {
 		// always use the parameter value
-		_mag_declination_to_save_deg = _params.mag_declination_deg;
 		return math::radians(_params.mag_declination_deg);
 	}
 }

--- a/EKF/estimator_interface.h
+++ b/EKF/estimator_interface.h
@@ -335,8 +335,14 @@ public:
 	// At the next startup, set param.mag_declination_deg to the value saved
 	bool get_mag_decl_deg(float *val)
 	{
-		*val = _mag_declination_to_save_deg;
-		return _NED_origin_initialised && (_params.mag_declination_source & MASK_SAVE_GEO_DECL);
+		*val = 0.0f;
+		if (_NED_origin_initialised && (_params.mag_declination_source & MASK_SAVE_GEO_DECL)) {
+			*val = math::degrees(_mag_declination_gps);
+			return true;
+
+		} else {
+			return false;
+		}
 	}
 
 	virtual void get_accel_bias(float bias[3]) = 0;
@@ -549,7 +555,6 @@ protected:
 	void unallocate_buffers();
 
 	float _mag_declination_gps{0.0f};         // magnetic declination returned by the geo library using the last valid GPS position (rad)
-	float _mag_declination_to_save_deg{0.0f}; // magnetic declination to save to EKF2_MAG_DECL (deg)
 	float _mag_inclination_gps{0.0f};	  // magnetic inclination returned by the geo library using the last valid GPS position (rad)
 	float _mag_strength_gps{0.0f};	          // magnetic strength returned by the geo library using the last valid GPS position (T)
 

--- a/EKF/mag_fusion.cpp
+++ b/EKF/mag_fusion.cpp
@@ -491,7 +491,7 @@ void Ekf::fuseHeading()
 			}
 
 			// the angle of the projection onto the horizontal gives the yaw angle
-			measured_hdg = -atan2f(mag_earth_pred(1), mag_earth_pred(0)) + _mag_declination;
+			measured_hdg = -atan2f(mag_earth_pred(1), mag_earth_pred(0)) + getMagDeclination();
 
 		} else if (_control_status.flags.ev_yaw) {
 			// calculate the yaw angle for a 321 sequence
@@ -584,7 +584,7 @@ void Ekf::fuseHeading()
 			}
 
 			// the angle of the projection onto the horizontal gives the yaw angle
-			measured_hdg = -atan2f(mag_earth_pred(1), mag_earth_pred(0)) + _mag_declination;
+			measured_hdg = -atan2f(mag_earth_pred(1), mag_earth_pred(0)) + getMagDeclination();
 
 		} else if (_control_status.flags.ev_yaw) {
 			// calculate the yaw angle for a 312 sequence
@@ -873,7 +873,7 @@ void Ekf::fuseDeclination(float decl_sigma)
 	Kfusion[23] = -t4*t13*(P[23][16]*magE-P[23][17]*magN);
 
 	// calculate innovation and constrain
-	float innovation = atan2f(magE, magN) - _mag_declination;
+	float innovation = atan2f(magE, magN) - getMagDeclination();
 	innovation = math::constrain(innovation, -0.5f, 0.5f);
 
 	// apply covariance correction via P_new = (I -K*H)*P
@@ -963,8 +963,9 @@ void Ekf::limitDeclination()
 			_state.mag_I(1) *= h_scaler;
 		} else {
 			// too small to scale radially so set to expected value
-			_state.mag_I(0) = 2.0f * h_field_min * cosf(_mag_declination);
-			_state.mag_I(1) = 2.0f * h_field_min * sinf(_mag_declination);
+			float mag_declination = getMagDeclination();
+			_state.mag_I(0) = 2.0f * h_field_min * cosf(mag_declination);
+			_state.mag_I(1) = 2.0f * h_field_min * sinf(mag_declination);
 		}
 		h_field = h_field_min;
 	}


### PR DESCRIPTION
Before we only calculated the `_mag_declination` variable before mag fusion, leading to the fact that in fuseDeclination() the innovation was not zero (since mag fusion updated the states) even though mag_align_complete was true.

