### PR TITLE
EKF: control: stop vision yaw fusion on timeout

### DIFF
--- a/EKF/control.cpp
+++ b/EKF/control.cpp
@@ -353,6 +353,7 @@ void Ekf::controlExternalVisionFusion()
 
 		// Turn off EV fusion mode if no data has been received
 		_control_status.flags.ev_pos = false;
+		_control_status.flags.ev_yaw = false;
 		ECL_INFO("EKF External Vision Data Stopped");
 
 	}


### PR DESCRIPTION
Crucial fix for external vision.

When external data is stopped, EKF kept on fusing old data, resulting in a stuck heading.