### PR TITLE
Implemented use of optical flow for terrain estimation

### DIFF
--- a/EKF/control.cpp
+++ b/EKF/control.cpp
@@ -124,7 +124,7 @@ void Ekf::controlFusionModes()
 	}
 
 	// check if we should fuse flow data for terrain estimation
-	if (!_flow_for_terrain_data_ready && _flow_data_ready) {
+	if (!_flow_for_terrain_data_ready && _flow_data_ready && _control_status.flags.in_air) {
 		// only fuse flow for terrain if range data hasn't been fused for 5 seconds
 		_flow_for_terrain_data_ready = (_time_last_imu - _time_last_hagl_fuse) > 5 * 1000 * 1000;
 		// only fuse flow for terrain if the main filter is not fusing flow and we are using gps

--- a/EKF/control.cpp
+++ b/EKF/control.cpp
@@ -123,6 +123,14 @@ void Ekf::controlFusionModes()
 				   && (_R_to_earth(2, 2) > _params.range_cos_max_tilt);
 	}
 
+	// check if we should fuse flow data for terrain estimation
+	if (!_flow_for_terrain_data_ready && _flow_data_ready) {
+		// only fuse flow for terrain if range data hasn't been fused for 5 seconds
+		_flow_for_terrain_data_ready = (_time_last_imu - _time_last_hagl_fuse) > 5 * 1000 * 1000;
+		// only fuse flow for terrain if the main filter is not fusing flow and we are using gps
+		_flow_for_terrain_data_ready &= (!_control_status.flags.opt_flow && _control_status.flags.gps);
+	}
+
 	_ev_data_ready = _ext_vision_buffer.pop_first_older_than(_imu_sample_delayed.time_us, &_ev_sample_delayed);
 	_tas_data_ready = _airspeed_buffer.pop_first_older_than(_imu_sample_delayed.time_us, &_airspeed_sample_delayed);
 

--- a/EKF/ekf.h
+++ b/EKF/ekf.h
@@ -315,6 +315,7 @@ private:
 	bool _flow_data_ready{false};	///< true when the leading edge of the optical flow integration period has fallen behind the fusion time horizon
 	bool _ev_data_ready{false};	///< true when new external vision system data has fallen behind the fusion time horizon and is available to be fused
 	bool _tas_data_ready{false};	///< true when new true airspeed data has fallen behind the fusion time horizon and is available to be fused
+	bool _flow_for_terrain_data_ready{false}; /// same flag as "_flow_data_ready" but used for separate terrain estimator
 
 	uint64_t _time_last_fake_gps{0};	///< last time we faked GPS position measurements to constrain tilt errors during operation without external aiding (uSec)
 	uint64_t _time_ins_deadreckon_start{0};	///< amount of time we have been doing inertial only deadreckoning (uSec)
@@ -543,6 +544,9 @@ private:
 
 	// update the terrain vertical position estimate using a height above ground measurement from the range finder
 	void fuseHagl();
+
+	// update the terrain vertical position estimate using an optical flow measurement
+	void fuseFlowForTerrain();
 
 	// reset the heading and magnetic field states using the declination and magnetometer/external vision measurements
 	// return true if successful

--- a/EKF/python/terrain_flow_derivation/derive_terrain_flow.py
+++ b/EKF/python/terrain_flow_derivation/derive_terrain_flow.py
@@ -1,0 +1,98 @@
+"""
+
+This script calculates the observation scalars (H matrix) for fusing optical flow
+measurements for terrain estimation.
+
+@author: roman
+"""
+
+from sympy import *
+
+# q: quaternion describing rotation from frame 1 to frame 2
+# returns a rotation matrix derived form q which describes the same
+# rotation
+def quat2Rot(q):
+    q0 = q[0]
+    q1 = q[1]
+    q2 = q[2]
+    q3 = q[3]
+
+    Rot = Matrix([[q0**2 + q1**2 - q2**2 - q3**2, 2*(q1*q2 - q0*q3), 2*(q1*q3 + q0*q2)],
+                  [2*(q1*q2 + q0*q3), q0**2 - q1**2 + q2**2 - q3**2, 2*(q2*q3 - q0*q1)],
+                   [2*(q1*q3-q0*q2), 2*(q2*q3 + q0*q1), q0**2 - q1**2 - q2**2 + q3**2]])
+
+    return Rot
+
+# take an expression calculated by the cse() method and write the expression
+# into a text file in C format
+def write_simplified(P_touple, filename, out_name):
+    subs = P_touple[0]
+    P = Matrix(P_touple[1])
+    fd = open(filename, 'a')
+
+    is_vector = P.shape[0] == 1 or P.shape[1] == 1
+
+    # write sub expressions
+    for index, item in enumerate(subs):
+        fd.write('float ' + str(item[0]) + ' = ' + str(item[1]) + ';\n')
+
+    # write actual matrix values
+    fd.write('\n')
+
+    if not is_vector:
+        iterator = range(0,sqrt(len(P)), 1)
+        for row in iterator:
+            for column in iterator:
+                fd.write(out_name + '(' + str(row) + ',' + str(column) + ') = ' + str(P[row, column]) + ';\n')
+    else:
+        iterator = range(0, len(P), 1)
+
+        for item in iterator:
+            fd.write(out_name + '(' + str(item) + ') = ' + str(P[item]) + ';\n')
+
+    fd.write('\n\n')
+    fd.close()
+
+########## Symbolic variable definition #######################################
+
+
+# vehicle velocity
+v_x = Symbol("v_x", real=True)  # vehicle body x velocity
+v_y = Symbol("v_y", real=True)  # vehicle body y velocity
+
+# unit quaternion describing vehicle attitude, qw is real part
+qw = Symbol("q0", real=True)
+qx = Symbol("q1", real=True)
+qy = Symbol("q2", real=True)
+qz = Symbol("q3", real=True)
+q_att = Matrix([qw, qx, qy, qz])
+
+# terrain vertial position in local NED frame
+_terrain_vpos = Symbol("_terrain_vpos", real=True)
+
+_terrain_var = Symbol("_terrain_var", real=True)
+
+# vehicle vertical position in local NED frame
+pos_z = Symbol("z", real=True)
+
+R_body_to_earth = quat2Rot(q_att)
+
+# Optical flow around x axis
+flow_x = -v_y / (_terrain_vpos - pos_z) * R_body_to_earth[2,2]
+
+# Calculate observation scalar
+H_x = Matrix([flow_x]).jacobian(Matrix([_terrain_vpos]))
+
+H_x_simple = cse(H_x, symbols('t0:30'))
+
+# Optical flow around y axis
+flow_y = v_x / (_terrain_vpos - pos_z) * R_body_to_earth[2,2]
+
+# Calculate observation scalar
+H_y = Matrix([flow_y]).jacobian(Matrix([_terrain_vpos]))
+
+H_y_simple = cse(H_y, symbols('t0:30'))
+
+write_simplified(H_x_simple, "flow_x_observation.txt", "Hx")
+write_simplified(H_y_simple, "flow_y_observation.txt", "Hy")
+

--- a/EKF/terrain_estimator.cpp
+++ b/EKF/terrain_estimator.cpp
@@ -56,7 +56,8 @@ bool Ekf::initHagl()
 		// success
 		return true;
 	} else if (_flow_for_terrain_data_ready) {
-		_terrain_vpos = _state.pos(2);
+		// initialise terrain vertical position to origin as this is the best guess we have
+		_terrain_vpos = fmaxf(0.0f,  _state.pos(2));
 		_terrain_var = 100.0f;
 		return true;
 	} else if (!_control_status.flags.in_air) {
@@ -213,6 +214,9 @@ void Ekf::fuseFlowForTerrain()
 
 	// Calculate observation matrix for flow around the vehicle x axis
 	float Hx = vel_body(1) * t0 /(pred_hagl * pred_hagl);
+
+	// Constrain terrain variance to be non-negative
+	_terrain_var = fmaxf(_terrain_var, 0.0f);
 
 	// Cacluate innovation variance
 	_flow_innov_var[0] = Hx * Hx * _terrain_var + R_LOS;


### PR DESCRIPTION
This PR allows optical flow measurements to be used for terrain estimation. I see the following two cases when this could be useful:
- terrain estimation for fixed wing flight and auto land (potentially using the flow sensor at higher altitude and a lidar when close to the ground)
@priseborough already did this in another project and I believe he had good success with the [pmw3901](https://www.seeedstudio.com/Flow-Breakout-Board-p-2949.html) optical flow sensor.
- enhancement of the detection logic for ground effect (see https://github.com/PX4/Firmware/pull/11592 )

Flow measurements will only be fused in the terrain estimator if no range data is being fused and if the primary EKF is not fusing flow.
So far this has only been tested in SITL using iris_opt_flow model. Two logs are being provided, one where the terrain estimate is initialized to 50m on the ground in order to see if the filter recovers.
The second log shows a normal flight in position control over a flat surface. As the vehicle starts to move the terrain height becomes observable and the estimated terrain variance decreases. When the vehicle holds position the terrain variance increases again.

**Terrain initialized to 50m** 
![terrain_flow](https://user-images.githubusercontent.com/7610489/56092131-38b6ac80-5eb8-11e9-9f1e-d99e92d5dbda.png)

**Normal flight over flat ground**
![terrain_flow2](https://user-images.githubusercontent.com/7610489/56092140-4ec46d00-5eb8-11e9-8621-835a259848f1.png)

**Logs:**
Terrain initialized to 50m:
https://logs.px4.io/plot_app?log=e47c69ed-125c-4a82-a1df-dc0553904b63

Normal flight:
https://logs.px4.io/plot_app?log=a3864090-d60c-42af-8fc8-f8465ded7790

**How to test:**
Currently this feature can only be tested if optical flow in the main filter is deactivated and if no range data is available. Therefore, the following two steps are required for testing:
1) Set EKF2_AID_MASK to only use GPS
2) Comment out [this line](https://github.com/PX4/Firmware/blob/master/src/modules/simulator/simulator_mavlink.cpp#L312) to avoid the system publishing range finder data.

**Required action items:**

- [x]  test on real vehicle (multicopter and fixed wing)
- [ ] - make sure we do not break existing optical flow & terrain estimation via lidar
- [x] - potentially adjust innovation gate size, optical flow measurement noise for robustness

