### PR TITLE
Implemented Kahan summation algorithm for adding process noise

### DIFF
--- a/EKF/CMakeLists.txt
+++ b/EKF/CMakeLists.txt
@@ -55,6 +55,8 @@ target_link_libraries(ecl_EKF PRIVATE ecl_geo ecl_geo_lookup mathlib)
 
 set_target_properties(ecl_EKF PROPERTIES PUBLIC_HEADER "ekf.h")
 
+target_compile_options(ecl_EKF PRIVATE -fno-associative-math)
+
 if(EKF_PYTHON_TESTS)
 	add_subdirectory(swig)
 endif()

--- a/EKF/ekf.h
+++ b/EKF/ekf.h
@@ -363,6 +363,9 @@ private:
 
 	float P[_k_num_states][_k_num_states] {};	///< state covariance matrix
 
+	Vector3f _delta_vel_bias_var_accum;		///< kahan summation algorithm accumulator for delta velocity bias variance
+	Vector3f _delta_angle_bias_var_accum;	///< kahan summation algorithm accumulator for delta angle bias variance
+
 	float _vel_pos_innov[6] {};	///< NED velocity and position innovations: 0-2 vel (m/sec),  3-5 pos (m)
 	float _vel_pos_innov_var[6] {};	///< NED velocity and position innovation variances: 0-2 vel ((m/sec)**2), 3-5 pos (m**2)
 	float _aux_vel_innov[2] {};	///< NE auxiliary velocity innovations: (m/sec)
@@ -706,5 +709,11 @@ private:
 
 	// uncorrelate quaternion states from other states
 	void uncorrelateQuatStates();
+
+	// Use Kahan summation algorithm to get the sum of "sum_previous" and "input".
+	// This function relies on the caller to be responsible for keeping a copy of
+	// "accumulator" and passing this value at the next iteration.
+	// Ref: https://en.wikipedia.org/wiki/Kahan_summation_algorithm
+	float kahanSummation(float sum_previous, float input, float &accumulator) const;
 
 };

--- a/EKF/ekf_helper.cpp
+++ b/EKF/ekf_helper.cpp
@@ -1722,3 +1722,11 @@ void Ekf::save_mag_cov_data()
 		}
 	}
 }
+
+float Ekf::kahanSummation(float sum_previous, float input, float &accumulator) const
+{
+	float y = input - accumulator;
+	float t = sum_previous + y;
+	accumulator = (t - sum_previous) - y;
+	return t;
+}


### PR DESCRIPTION
Each time there is a covariance matrix update we add process noise to the variance of each state.
For the delta angle and the delta velocity bias variances these contributions can be so small compared to the actual variance that they get lost due to numerical limitations when dealing with floating point variables.

One solution for this problem is to use the Kahan summation algorithm which relies on an accumulator variable which captures the small increments that would get lost otherwise.

For more details, see https://en.wikipedia.org/wiki/Kahan_summation_algorithm

Thanks to @priseborough for helping debug this issue and thanks to @jkflying for suggesting the algorithm.

Delta velocity z bias variance prior to this change:
![image (4)](https://user-images.githubusercontent.com/7610489/57372170-3680fe80-7195-11e9-9153-f3d657537731.png)

Delta velocity z bias variance after this change:
![image (3)](https://user-images.githubusercontent.com/7610489/57372187-43055700-7195-11e9-82f1-9738fa7b3ec9.png)

I also compared the results of this PR against the previous code when the delta velocity bias noise was set very high (0.3 m/s/s/s) in order to see if both implementations lead to similar variances. The figure below shows that this was the case.

![variance!UNITO-UNDERSCORE!diff](https://user-images.githubusercontent.com/7610489/57372893-35e96780-7197-11e9-9144-9fb7e7fb5061.png)

This is a replay log file from an S500 which has been used for validation:
https://logs.px4.io/plot_app?log=7ebfbbc0-d9ed-4e4f-92f0-e9ab73f0016f

