### PR TITLE
mathlib delete floorf in favor of math.h

### DIFF
--- a/geo_lookup/geo_mag_declination.cpp
+++ b/geo_lookup/geo_mag_declination.cpp
@@ -46,10 +46,10 @@
 
 #include <mathlib/mathlib.h>
 
+#include <math.h>
 #include <stdint.h>
 
 using math::constrain;
-using math::floorf;
 
 /** set this always to the sampling in degrees for the table below */
 static constexpr float SAMPLING_RES = 10.0f;

--- a/mathlib/mathlib.cpp
+++ b/mathlib/mathlib.cpp
@@ -70,16 +70,6 @@ float degrees(float radians)
 	return (radians * 180.0f) / M_PI_F;
 }
 
-int floorf(float input)
-{
-	int res = int(input);
-	if (res > input) {
-		res--;
-	}
-
-	return res;
-}
-
 } // namespace math
 
 #endif /* ECL_STANDALONE */

--- a/mathlib/mathlib.h
+++ b/mathlib/mathlib.h
@@ -60,7 +60,6 @@ float max(float val1, float val2);
 float constrain(float val, float min, float max);
 float radians(float degrees);
 float degrees(float radians);
-int floorf(float input);
 
 }
 #else


### PR DESCRIPTION
In the current structure ecl uses an in tree mathlib.h when built standalone, otherwise it uses mathlib.h from PX4 when included in a submodule. Arguably this should be fixed, but at the moment it means ecl mathlib.h changes need to be mirrored in PX4.

All that is to say, let's not add anything to mathlib.h that we don't absolutely need.

https://github.com/PX4/ecl/pull/606#issuecomment-495651720