### PR TITLE
EKF: Fix bug allowing state initialisation to a bad GPS height

### DIFF
--- a/EKF/ekf.h
+++ b/EKF/ekf.h
@@ -412,6 +412,7 @@ private:
 	uint64_t _last_gps_pass_us{0};		///< last system time in usec that the GPS passed it's checks
 	float _gps_error_norm{1.0f};		///< normalised gps error
 	uint32_t _min_gps_health_time_us{10000000}; ///< GPS is marked as healthy only after this amount of time
+	bool _gps_checks_passed{false};		///> true when all active GPS checks have passed
 
 	// Variables used to publish the WGS-84 location of the EKF local NED origin
 	uint64_t _last_gps_origin_time_us{0};	///< time the origin was last set (uSec)
@@ -460,9 +461,9 @@ private:
 	float _dt_last_range_update_filt_us{0.0f};	///< filtered value of the delta time elapsed since the last range measurement came into the filter (uSec)
 	bool _hagl_valid{false};		///< true when the height above ground estimate is valid
 
-	// height sensor fault status
+	// height sensor status
 	bool _baro_hgt_faulty{false};		///< true if valid baro data is unavailable for use
-	bool _gps_hgt_faulty{false};		///< true if valid gps height data is unavailable for use
+	bool _gps_hgt_intermittent{false};	///< true if gps height into the buffer is intermittent
 	bool _rng_hgt_faulty{false};		///< true if valid range finder height data is unavailable for use
 	int _primary_hgt_source{VDIST_SENSOR_BARO};	///< specifies primary source of height data
 

--- a/EKF/gps_checks.cpp
+++ b/EKF/gps_checks.cpp
@@ -59,8 +59,8 @@
 bool Ekf::collect_gps(const gps_message &gps)
 {
 	// Run GPS checks always
-	bool gps_checks_pass = gps_is_good(gps);
-	if (!_NED_origin_initialised && gps_checks_pass) {
+	_gps_checks_passed = gps_is_good(gps);
+	if (!_NED_origin_initialised && _gps_checks_passed) {
 		// If we have good GPS data set the origin's WGS-84 position to the last gps fix
 		double lat = gps.lat / 1.0e7;
 		double lon = gps.lon / 1.0e7;


### PR DESCRIPTION
If GPS is being used as the primary height source (EKF2_HGT_MODE = 1) then the first 3D fix from the GPS is used to set the height origin. This can cause problems because these erarly estimates are inaccurate and can result in the EKF origin being out by 30m or more. The GPS height solution then improves and the large rapid change in measurement causes it to be rejected by the EKF until the height rejection timeout, resulting in a reset. The following figure shows the large innovations and the reset caused by this behaviour.

<img width="777" alt="before" src="https://user-images.githubusercontent.com/3596952/59168112-b96fed00-8b77-11e9-91ce-68ba7bc0b34c.png">

With this fix applied, replay of the same data shows the problem to be fixed.

<img width="776" alt="after" src="https://user-images.githubusercontent.com/3596952/59168155-f0460300-8b77-11e9-8b69-4fb0ca9c4725.png">

This fix requires that the same GPS quality check used to determine if GPs can be used for navigation are also required before it can be used as the primary height sensor. The _gps_hgt_faulty class variable has been renamed _gps_hgt_intermittent to be consistent with its usage and unnecessary resets of this variable have been removed.

Flight testing with EKF2_HGT_MODE = 1 is required