### PR TITLE
EKF - Initialize _deadrekon_time_exceeded to true.

### DIFF
--- a/EKF/estimator_interface.h
+++ b/EKF/estimator_interface.h
@@ -492,7 +492,7 @@ protected:
 	innovation_fault_status_u _innov_check_fail_status{};
 
 	bool _is_dead_reckoning{false};		// true if we are no longer fusing measurements that constrain horizontal velocity drift
-	bool _deadreckon_time_exceeded{false};	// true if the horizontal nav solution has been deadreckoning for too long and is invalid
+	bool _deadreckon_time_exceeded{true};	// true if the horizontal nav solution has been deadreckoning for too long and is invalid
 	bool _is_wind_dead_reckoning{false};	// true if we are navigationg reliant on wind relative measurements
 
 	// IMU vibration and movement monitoring


### PR DESCRIPTION
The original issue is that `ekf2 status` reports `local position: valid` if it didn't receive any IMU data because the check is `!_deadreckon_time_exceeded`.