### PR TITLE
control.cpp: clean up extra code judge

### DIFF
--- a/EKF/control.cpp
+++ b/EKF/control.cpp
@@ -590,10 +590,8 @@ void Ekf::controlGpsFusion()
 
 					}
 
-					if (_control_status.flags.gps) {
-						ECL_INFO("EKF commencing GPS fusion");
-						_time_last_gps = _time_last_imu;
-					}
+					ECL_INFO("EKF commencing GPS fusion");
+					_time_last_gps = _time_last_imu;
 				}
 			}
 

--- a/EKF/control.cpp
+++ b/EKF/control.cpp
@@ -583,15 +583,10 @@ void Ekf::controlGpsFusion()
 					// if we are not already aiding with optical flow, then we need to reset the position and velocity
 					// otherwise we only need to reset the position
 					_control_status.flags.gps = true;
+					resetPosition();
 
-					if (!_control_status.flags.opt_flow) {
-						if (!resetPosition() || !resetVelocity()) {
-							_control_status.flags.gps = false;
-
-						}
-
-					} else if (!resetPosition()) {
-						_control_status.flags.gps = false;
+					if (!_control_status.flags.opt_flow) {					
+						resetVelocity();
 
 					}
 


### PR DESCRIPTION
```
resetVelocity();
resetPosition();
```
always return `ture,` so we don't need judge more, just direct `resetVelocity();resetPosition();`


