### PR TITLE
Fixed airspeed scaling

### DIFF
--- a/airdata/WindEstimator.cpp
+++ b/airdata/WindEstimator.cpp
@@ -326,7 +326,13 @@ WindEstimator::run_sanity_checks()
 	}
 
 	// constrain airspeed scale factor, negative values physically do not make sense
-	_state(tas) = math::max(0.0f, _state(tas));
+	if (_scale_estimation_on) {
+		_state(tas) = math::max(0.0f, _state(tas));
+	} else {
+		_state(tas) = 1.0f;
+	}
+
+
 
 	// attain symmetry
 	for (unsigned row = 0; row < 3; row++) {

--- a/airdata/WindEstimator.cpp
+++ b/airdata/WindEstimator.cpp
@@ -330,14 +330,14 @@ WindEstimator::run_sanity_checks()
 		return;
 	}
 
-	// constrain airspeed scale factor, negative values physically do not make sense
-	if (_scale_estimation_on) {
+	// check if we should inhibit learning of airspeed scale factor and rather use a pre-set value.
+	// airspeed scale factor errors arise from sensor installation which does not change and only needs
+	// to be computed once for a perticular installation.
+	if (_enforced_airspeed_scale < 0) {
 		_state(tas) = math::max(0.0f, _state(tas));
 	} else {
-		_state(tas) = 1.0f;
+		_state(tas) = _enforced_airspeed_scale;
 	}
-
-
 
 	// attain symmetry
 	for (unsigned row = 0; row < 3; row++) {

--- a/airdata/WindEstimator.cpp
+++ b/airdata/WindEstimator.cpp
@@ -88,6 +88,8 @@ WindEstimator::initialise(const matrix::Vector3f &velI, const matrix::Vector2f &
 	_time_rejected_tas = 0;
 	_time_rejected_beta = 0;
 
+	_wind_estimator_reset = true;
+
 	return true;
 }
 
@@ -97,6 +99,9 @@ WindEstimator::update(uint64_t time_now)
 	if (!_initialised) {
 		return;
 	}
+
+	// set reset state to false (is set to true when initialise fuction is called later)
+	_wind_estimator_reset = false;
 
 	// run covariance prediction at 1Hz
 	if (time_now - _time_last_update < 1000 * 1000 || _time_last_update == 0) {

--- a/airdata/WindEstimator.hpp
+++ b/airdata/WindEstimator.hpp
@@ -81,6 +81,7 @@ public:
 		wind_var[0] = _P(0, 0);
 		wind_var[1] = _P(1, 1);
 	}
+	bool get_wind_estimator_reset() { return _wind_estimator_reset; }
 
 	void set_wind_p_noise(float wind_sigma) { _wind_p_var = wind_sigma * wind_sigma; }
 	void set_tas_scale_p_noise(float tas_scale_sigma) { _tas_scale_p_var = tas_scale_sigma * tas_scale_sigma; }
@@ -122,6 +123,8 @@ private:
 	uint64_t _time_rejected_tas =
 		0;		///<timestamp of when true airspeed measurements have consistently started to be rejected
 	bool _scale_estimation_on = false; ///< online scale estimation (IAS-->CAS/EAS) is on
+
+	bool _wind_estimator_reset = false; ///< wind estimator was reset in this cycle
 
 	// initialise state and state covariance matrix
 	bool initialise(const matrix::Vector3f &velI, const matrix::Vector2f &velIvar, const float tas_meas);

--- a/airdata/WindEstimator.hpp
+++ b/airdata/WindEstimator.hpp
@@ -88,6 +88,7 @@ public:
 	void set_beta_noise(float beta_var) { _beta_var = beta_var * beta_var; }
 	void set_tas_gate(uint8_t gate_size) {_tas_gate = gate_size; }
 	void set_beta_gate(uint8_t gate_size) {_beta_gate = gate_size; }
+	void set_scale_estimation_on(bool scale_estimation_on) {_scale_estimation_on = scale_estimation_on; }
 
 private:
 	enum {
@@ -120,6 +121,7 @@ private:
 	uint64_t _time_rejected_beta = 0;		///< timestamp of when sideslip measurements have consistently started to be rejected
 	uint64_t _time_rejected_tas =
 		0;		///<timestamp of when true airspeed measurements have consistently started to be rejected
+	bool _scale_estimation_on = false; ///< online scale estimation (IAS-->CAS/EAS) is on
 
 	// initialise state and state covariance matrix
 	bool initialise(const matrix::Vector3f &velI, const matrix::Vector2f &velIvar, const float tas_meas);

--- a/airdata/WindEstimator.hpp
+++ b/airdata/WindEstimator.hpp
@@ -89,7 +89,10 @@ public:
 	void set_beta_noise(float beta_var) { _beta_var = beta_var * beta_var; }
 	void set_tas_gate(uint8_t gate_size) {_tas_gate = gate_size; }
 	void set_beta_gate(uint8_t gate_size) {_beta_gate = gate_size; }
-	void set_scale_estimation_on(bool scale_estimation_on) {_scale_estimation_on = scale_estimation_on; }
+
+	// Inhibit learning of the airspeed scale factor and force the estimator to use _enforced_airspeed_scale as scale factor.
+	// Negative input values enable learning of the airspeed scale factor.
+	void enforce_airspeed_scale(float scale) {_enforced_airspeed_scale = scale; }
 
 private:
 	enum {
@@ -122,9 +125,9 @@ private:
 	uint64_t _time_rejected_beta = 0;		///< timestamp of when sideslip measurements have consistently started to be rejected
 	uint64_t _time_rejected_tas =
 		0;		///<timestamp of when true airspeed measurements have consistently started to be rejected
-	bool _scale_estimation_on = false; ///< online scale estimation (IAS-->CAS/EAS) is on
 
 	bool _wind_estimator_reset = false; ///< wind estimator was reset in this cycle
+	float _enforced_airspeed_scale{-1}; ///< by default we want to estimate the true airspeed scale factor (see enforce_airspeed_scale(...) )
 
 	// initialise state and state covariance matrix
 	bool initialise(const matrix::Vector3f &velI, const matrix::Vector2f &velIvar, const float tas_meas);


### PR DESCRIPTION
Small enhancement to the wind estimation library.
1) Added API which allows to disable true airspeed scale factor learning but instead use a pre-set value.
Airspeed scale factor errors are affected by the particular installation of the pitot tube. Once the scale factor has been learned it should not change anymore.

2) Added method which notifies if a reset of the filter has taken place in the current cycle.