### PR TITLE
Fix flag globallocalconverter_init

### DIFF
--- a/geo/geo.cpp
+++ b/geo/geo.cpp
@@ -212,7 +212,7 @@ int globallocalconverter_init(double lat_0, double lon_0, float alt_0, uint64_t 
 {
 	gl_ref.alt = alt_0;
 
-	if (map_projection_global_init(lat_0, lon_0, timestamp) != 0) {
+	if (!map_projection_global_init(lat_0, lon_0, timestamp)) {
 		gl_ref.init_done = true;
 		return 0;
 	}


### PR DESCRIPTION
When trying to initialize `globallocalconverter` using `globallocalconverter_init`, the return value of `map_projection_global_init` will always be 0 (As shown below), which will make the initialization of the globallocalconverter always fail.


https://github.com/Jaeyoung-Lim/ecl/blob/ab495c92fa49883d8adb7ffd1827133fcb4201b2/geo/geo.cpp#L90-L102


Changing the checks result in a successful initialization of the `globallocalconverter` and was used in a offboard local position setpoint implementation for fixed wing position control.