### PR TITLE
EKF: reset position when stopping GPS use and EV is active

### DIFF
--- a/EKF/control.cpp
+++ b/EKF/control.cpp
@@ -610,6 +610,10 @@ void Ekf::controlGpsFusion()
 		// Handle the case where we are using GPS and another source of aiding and GPS is failing checks
 		if (_control_status.flags.gps  && gps_checks_failing && (_control_status.flags.opt_flow || _control_status.flags.ev_pos)) {
 			_control_status.flags.gps = false;
+			// Reset position state to external vision if we are going to use absolute values
+			if (_control_status.flags.ev_pos && !(_params.fusion_mode & MASK_ROTATE_EV)) {
+				resetPosition();
+			}
 			ECL_WARN("EKF GPS data quality poor - stopping use");
 		}
 


### PR DESCRIPTION
Fixes https://github.com/PX4/Firmware/issues/12558

**Test flight log:**
* https://drive.google.com/open?id=1cEp38Vox5k4jaj3aGYZoe-yc6DTqrJjJ
* https://logs.px4.io/plot_app?log=1147e548-37b2-4b1f-b43f-37df05a0b5fa

**Screenshot:**
![plot2](https://user-images.githubusercontent.com/4330620/62151749-5857d080-b301-11e9-8ef5-7a429380e2a1.png)

"Stopping GPS usage" happens at 141 seconds. EKF states reset to EV position. Local position is valid at all times, `pos_test_ratio` is ok (<1).