### PR TITLE
EKF: Fix on ground yaw drift when using EKF2_MAG_TYPE = 4

### DIFF
--- a/EKF/control.cpp
+++ b/EKF/control.cpp
@@ -1521,7 +1521,7 @@ void Ekf::controlMagFusion()
 				save_mag_cov_data();
 			}
 
-		} else if (_params.mag_fusion_type == MAG_FUSE_TYPE_HEADING) {
+		} else if (_params.mag_fusion_type == MAG_FUSE_TYPE_HEADING || _params.mag_fusion_type == MAG_FUSE_TYPE_INDOOR) {
 			// always use heading fusion
 			_control_status.flags.mag_hdg = true;
 

--- a/EKF/ekf.h
+++ b/EKF/ekf.h
@@ -357,7 +357,6 @@ private:
 	bool _mag_use_inhibit_prev{false};	///< true when magnetometer use was being inhibited the previous frame
 	bool _mag_inhibit_yaw_reset_req{false};	///< true when magnetometer inhibit has been active for long enough to require a yaw reset when conditions improve.
 	float _last_static_yaw{0.0f};		///< last yaw angle recorded when on ground motion checks were passing (rad)
-	bool _vehicle_at_rest_prev{false};	///< true when the vehicle was at rest the previous time the status was checked
 	bool _mag_yaw_reset_req{false};		///< true when a reset of the yaw using the magnetometer data has been requested
 	bool _mag_decl_cov_reset{false};	///< true after the fuseDeclination() function has been used to modify the earth field covariances after a magnetic field reset event.
 

--- a/EKF/mag_fusion.cpp
+++ b/EKF/mag_fusion.cpp
@@ -500,9 +500,15 @@ void Ekf::fuseHeading()
 			float Tbn_0_0 = sq(_ev_sample_delayed.quat(0))+sq(_ev_sample_delayed.quat(1))-sq(_ev_sample_delayed.quat(2))-sq(_ev_sample_delayed.quat(3));
 			measured_hdg = atan2f(Tbn_1_0,Tbn_0_0);
 
+		} else if (_mag_use_inhibit) {
+			// Special case where we either use the current or last known stationary value
+			// so set to current value as a safe default
+			measured_hdg = predicted_hdg;
+
 		} else {
-			// there is no yaw observation
+			// Should not be doing yaw fusion
 			return;
+
 		}
 
 	} else {
@@ -593,8 +599,13 @@ void Ekf::fuseHeading()
 			float Tbn_1_1 = sq(_ev_sample_delayed.quat(0))-sq(_ev_sample_delayed.quat(1))+sq(_ev_sample_delayed.quat(2))-sq(_ev_sample_delayed.quat(3));
 			measured_hdg = atan2f(Tbn_0_1_neg,Tbn_1_1);
 
+		} else if (_mag_use_inhibit) {
+			// Special case where we either use the current or last known stationary value
+			// so set to current value as a safe default
+			measured_hdg = predicted_hdg;
+
 		} else {
-			// there is no yaw observation
+			// Should not be doing yaw fusion
 			return;
 
 		}
@@ -610,8 +621,8 @@ void Ekf::fuseHeading()
 		R_YAW = sq(fmaxf(_ev_sample_delayed.angErr, 1.0e-2f));
 
 	} else {
-		// there is no yaw observation
-		return;
+		// default value
+		R_YAW = 0.01f;
 	}
 
 	// wrap the heading to the interval between +-pi
@@ -626,22 +637,20 @@ void Ekf::fuseHeading()
 			// Vehicle is not at rest so fuse a zero innovation and record the
 			// predicted heading to use as an observation when movement ceases.
 			_heading_innov = 0.0f;
-			_vehicle_at_rest_prev = false;
+			_last_static_yaw = predicted_hdg;
+
 		} else {
 			// Vehicle is at rest so use the last moving prediction as an observation
 			// to prevent the heading from drifting and to enable yaw gyro bias learning
 			// before takeoff.
-			if (!_vehicle_at_rest_prev || !_mag_use_inhibit_prev) {
-				_last_static_yaw = predicted_hdg;
-				_vehicle_at_rest_prev = true;
-			}
 			_heading_innov = predicted_hdg - _last_static_yaw;
-			R_YAW = 0.01f;
 			innov_gate = 5.0f;
+
 		}
 	} else {
 		_heading_innov = predicted_hdg - measured_hdg;
 		_last_static_yaw = predicted_hdg;
+
 	}
 	_mag_use_inhibit_prev = _mag_use_inhibit;
 


### PR DESCRIPTION
Fixes https://github.com/PX4/ecl/issues/627

Tested using replay log:

Before change log: https://logs.px4.io/plot_app?log=d1023af3-5b3c-43e2-a7e6-c3e7362af495

The yaw angle continued to drift when on ground
<img width="1123" alt="euler angles - before" src="https://user-images.githubusercontent.com/3596952/62527577-bb57e300-b87e-11e9-977a-c4935e2145db.png">

Quaternion variance continues to grow - if left unchecked this will eventually destabilise the filter
<img width="1123" alt="variances - before" src="https://user-images.githubusercontent.com/3596952/62527619-d6c2ee00-b87e-11e9-8c82-65289006f4cb.png">

After change log: https://logs.px4.io/plot_app?log=d4591d33-40c6-4fd2-bd99-a892f2a308d6

Yaw doesn't drift
<img width="1117" alt="euler angles - after" src="https://user-images.githubusercontent.com/3596952/62527629-dde9fc00-b87e-11e9-807d-5e656ec44cfd.png">

Quaternion variance when resting on ground doesn't continue to grow:
<img width="1118" alt="variances - after" src="https://user-images.githubusercontent.com/3596952/62527707-04a83280-b87f-11e9-8c20-87c7232a47bf.png">

Short flight test of changes here: https://logs.px4.io/plot_app?log=eb89707c-d3b9-4175-8806-8e01d5d6f9ae