### PR TITLE
EKF: Stop mag fusion when GPS heading fusion is active

### DIFF
--- a/EKF/control.cpp
+++ b/EKF/control.cpp
@@ -1374,7 +1374,7 @@ void Ekf::controlMagFusion()
 
 	// check for new magnetometer data that has fallen behind the fusion time horizon
 	// If we are using external vision data for heading then no magnetometer fusion is used
-	if (!_control_status.flags.ev_yaw && _mag_data_ready) {
+	if (!_control_status.flags.ev_yaw && !_control_status.flags.gps_yaw && _mag_data_ready) {
 
 		// We need to reset the yaw angle after climbing away from the ground to enable
 		// recovery from ground level magnetic interference.


### PR DESCRIPTION
Review needed, initial suggestion for fixing https://github.com/PX4/ecl/issues/625

This changes removes the mag innovation spikes from the plot in the issue and it can look like this now:

<img width="1372" alt="Screenshot 2019-08-06 at 21 15 44" src="https://user-images.githubusercontent.com/5750020/62570734-47bed180-b890-11e9-8e11-23cc3e456bc7.png">

We see the heading drift in this plot though, so if we can get rid of that too it would be in an initial good working state.