### PR TITLE
Fix alignment of external local frame 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -124,7 +124,7 @@ if(CMAKE_SOURCE_DIR STREQUAL PROJECT_SOURCE_DIR)
 	include(ExternalProject)
 	ExternalProject_Add(matrix
 			GIT_REPOSITORY "https://github.com/PX4/Matrix.git"
-			GIT_TAG 6b0777d815cd64902eb0575d56ec52f53aebb4a0
+			GIT_TAG 84b3da227cda0b66a2c8ebaa99aeddedf8858b02
 			UPDATE_COMMAND ""
 			PATCH_COMMAND ""
 			CONFIGURE_COMMAND ""

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -124,7 +124,7 @@ if(CMAKE_SOURCE_DIR STREQUAL PROJECT_SOURCE_DIR)
 	include(ExternalProject)
 	ExternalProject_Add(matrix
 			GIT_REPOSITORY "https://github.com/PX4/Matrix.git"
-			GIT_TAG 84b3da227cda0b66a2c8ebaa99aeddedf8858b02
+			GIT_TAG 6b0777d815cd64902eb0575d56ec52f53aebb4a0
 			UPDATE_COMMAND ""
 			PATCH_COMMAND ""
 			CONFIGURE_COMMAND ""

--- a/EKF/control.cpp
+++ b/EKF/control.cpp
@@ -167,14 +167,21 @@ void Ekf::controlExternalVisionFusion()
 
 		// if the ev data is not in a NED reference frame, then the transformation between EV and EKF navigation frames
 		// needs to be calculated and the observations rotated into the EKF frame of reference
-		if ((_params.fusion_mode & MASK_ROTATE_EV) && (_params.fusion_mode & MASK_USE_EVPOS) && !_control_status.flags.ev_yaw) {
+		if ((_params.fusion_mode & MASK_ROTATE_EV) && !_control_status.flags.ev_yaw) {
 			// rotate EV measurements into the EKF Navigation frame
 			calcExtVisRotMat();
 		}
 
+		// reset external vision rotation matrix independent if is actually used for debugging purposes
+		if ((_time_last_imu - _time_last_ext_vision) < (2 * EV_MAX_INTERVAL)
+			&& (_params.fusion_mode & MASK_ROTATE_EV) && !(_params.fusion_mode & MASK_USE_EVYAW)){
+			// Reset transformation between EV and EKF navigation frames
+			resetExtVisRotMat();
+		}
+
 		// external vision position aiding selection logic
 		if ((_params.fusion_mode & MASK_USE_EVPOS) && !_control_status.flags.ev_pos && _control_status.flags.tilt_align
-		    && _control_status.flags.yaw_align) {
+			&& _control_status.flags.yaw_align) {
 
 			// check for a external vision measurement that has fallen behind the fusion time horizon
 			if ((_time_last_imu - _time_last_ext_vision) < (2 * EV_MAX_INTERVAL)) {

--- a/EKF/ekf.h
+++ b/EKF/ekf.h
@@ -256,7 +256,7 @@ public:
 	void get_ekf_soln_status(uint16_t *status);
 
 	// return the quaternion defining the rotation from the EKF to the External Vision reference frame
-	void get_ekf2ev_quaternion(float *quat);
+	void get_ev2ekf_quaternion(float *quat);
 
 	// use the latest IMU data at the current time horizon.
 	Quatf calculate_quaternion() const;

--- a/EKF/ekf.h
+++ b/EKF/ekf.h
@@ -255,7 +255,7 @@ public:
 	// return a bitmask integer that describes which state estimates can be used for flight control
 	void get_ekf_soln_status(uint16_t *status);
 
-	// return the quaternion defining the rotation from the EKF to the External Vision reference frame
+	// return the quaternion defining the rotation from the External Vision to the EKF reference frame
 	void get_ev2ekf_quaternion(float *quat);
 
 	// use the latest IMU data at the current time horizon.

--- a/EKF/ekf_helper.cpp
+++ b/EKF/ekf_helper.cpp
@@ -1593,10 +1593,9 @@ void Ekf::setControlEVHeight()
 // and calculate a rotation matrix which rotates EV measurements into the EKF's navigation frame
 void Ekf::calcExtVisRotMat()
 {
-	// calculate the quaternion delta between the EV and EKF reference frames at the EKF fusion time horizon
+	// Calculate the quaternion delta that rotates from the EV to the EKF reference frame at the EKF fusion time horizon.
 	Quatf q_error = _state.quat_nominal * _ev_sample_delayed.quat.inversed();
 	q_error.normalize();
-	q_error.canonicalize();
 
 	// convert to a delta angle and apply a spike and low pass filter
 	Vector3f rot_vec = q_error.to_axis_angle();
@@ -1623,9 +1622,7 @@ void Ekf::calcExtVisRotMat()
 
 	// convert filtered vector to a quaternion and then to a rotation matrix
 	q_error.from_axis_angle(_ev_rot_vec_filt);
-	q_error.normalize();
-	q_error.canonicalize();
-	_ev_rot_mat = Dcmf(q_error); // rotation from EV reference to EKF reference
+	_ev_rot_mat = quat_to_invrotmat(q_error); // rotation from EV reference to EKF reference
 
 }
 
@@ -1633,7 +1630,7 @@ void Ekf::calcExtVisRotMat()
 // and update the rotation matrix which rotates EV measurements into the EKF's navigation frame
 void Ekf::resetExtVisRotMat()
 {
-	// calculate the quaternion delta between the EV and EKF reference frames at the EKF fusion time horizon
+	// Calculate the quaternion delta that rotates from the EV to the EKF reference frame at the EKF fusion time horizon.
 	Quatf q_error = _state.quat_nominal * _ev_sample_delayed.quat.inversed();
 	q_error.normalize();
 
@@ -1650,7 +1647,7 @@ void Ekf::resetExtVisRotMat()
 	}
 
 	// reset the rotation matrix
-	_ev_rot_mat = Dcmf(q_error); // rotation from EV reference to EKF reference
+	_ev_rot_mat = quat_to_invrotmat(q_error); // rotation from EV reference to EKF reference
 }
 
 // return the quaternions for the rotation from External Vision system reference frame to the EKF reference frame

--- a/EKF/ekf_helper.cpp
+++ b/EKF/ekf_helper.cpp
@@ -1593,9 +1593,8 @@ void Ekf::setControlEVHeight()
 // and calculate a rotation matrix which rotates EV measurements into the EKF's navigation frame
 void Ekf::calcExtVisRotMat()
 {
-	// calculate the quaternion delta between the EKF and EV reference frames at the EKF fusion time horizon
-	Quatf quat_inv = _ev_sample_delayed.quat.inversed();
-	Quatf q_error =   quat_inv * _state.quat_nominal;
+	// calculate the quaternion delta between the EV and EKF reference frames at the EKF fusion time horizon
+	Quatf q_error = _state.quat_nominal * _ev_sample_delayed.quat.inversed();
 	q_error.normalize();
 
 	// convert to a delta angle and apply a spike and low pass filter
@@ -1623,7 +1622,8 @@ void Ekf::calcExtVisRotMat()
 
 	// convert filtered vector to a quaternion and then to a rotation matrix
 	q_error.from_axis_angle(_ev_rot_vec_filt);
-	_ev_rot_mat = quat_to_invrotmat(q_error);
+	q_error.normalize();
+	_ev_rot_mat = Dcmf(q_error); // rotation from EV reference to EKF reference
 
 }
 
@@ -1631,9 +1631,8 @@ void Ekf::calcExtVisRotMat()
 // and update the rotation matrix which rotates EV measurements into the EKF's navigation frame
 void Ekf::resetExtVisRotMat()
 {
-	// calculate the quaternion delta between the EKF and EV reference frames at the EKF fusion time horizon
-	Quatf quat_inv = _ev_sample_delayed.quat.inversed();
-	Quatf q_error =   quat_inv * _state.quat_nominal;
+	// calculate the quaternion delta between the EV and EKF reference frames at the EKF fusion time horizon
+	Quatf q_error = _state.quat_nominal * _ev_sample_delayed.quat.inversed();
 	q_error.normalize();
 
 	// convert to a delta angle and reset
@@ -1649,7 +1648,7 @@ void Ekf::resetExtVisRotMat()
 	}
 
 	// reset the rotation matrix
-	_ev_rot_mat = quat_to_invrotmat(q_error);
+	_ev_rot_mat = Dcmf(q_error); // rotation from EV reference to EKF reference
 }
 
 // return the quaternions for the rotation from the EKF to the External Vision system frame of reference

--- a/EKF/ekf_helper.cpp
+++ b/EKF/ekf_helper.cpp
@@ -731,7 +731,7 @@ bool Ekf::resetMagHeading(Vector3f &mag_init, bool increase_yaw_var, bool update
 	_R_to_earth = quat_to_invrotmat(_state.quat_nominal);
 
 	// reset the rotation from the EV to EKF frame of reference if it is being used
-	if ((_params.fusion_mode & MASK_ROTATE_EV) && (_params.fusion_mode & MASK_USE_EVPOS) && !_control_status.flags.ev_yaw) {
+	if ((_params.fusion_mode & MASK_ROTATE_EV) && !_control_status.flags.ev_yaw) {
 		resetExtVisRotMat();
 	}
 

--- a/EKF/ekf_helper.cpp
+++ b/EKF/ekf_helper.cpp
@@ -1606,10 +1606,10 @@ void Ekf::calcExtVisRotMat()
 
 		// apply an input limiter to protect from spikes
 		Vector3f _input_delta_vec = rot_vec - _ev_rot_vec_filt;
-		float input_delta_mag = _input_delta_vec.norm();
+		float input_delta_len = _input_delta_vec.norm();
 
-		if (input_delta_mag > 0.1f) {
-			rot_vec = _ev_rot_vec_filt + _input_delta_vec * (0.1f / input_delta_mag);
+		if (input_delta_len > 0.1f) {
+			rot_vec = _ev_rot_vec_filt + _input_delta_vec * (0.1f / input_delta_len);
 		}
 
 		// Apply a first order IIR low pass filter

--- a/EKF/ekf_helper.cpp
+++ b/EKF/ekf_helper.cpp
@@ -1596,6 +1596,7 @@ void Ekf::calcExtVisRotMat()
 	// calculate the quaternion delta between the EV and EKF reference frames at the EKF fusion time horizon
 	Quatf q_error = _state.quat_nominal * _ev_sample_delayed.quat.inversed();
 	q_error.normalize();
+	q_error.canonicalize();
 
 	// convert to a delta angle and apply a spike and low pass filter
 	Vector3f rot_vec = q_error.to_axis_angle();
@@ -1623,6 +1624,7 @@ void Ekf::calcExtVisRotMat()
 	// convert filtered vector to a quaternion and then to a rotation matrix
 	q_error.from_axis_angle(_ev_rot_vec_filt);
 	q_error.normalize();
+	q_error.canonicalize();
 	_ev_rot_mat = Dcmf(q_error); // rotation from EV reference to EKF reference
 
 }

--- a/EKF/ekf_helper.cpp
+++ b/EKF/ekf_helper.cpp
@@ -1653,14 +1653,14 @@ void Ekf::resetExtVisRotMat()
 	_ev_rot_mat = Dcmf(q_error); // rotation from EV reference to EKF reference
 }
 
-// return the quaternions for the rotation from the EKF to the External Vision system frame of reference
-void Ekf::get_ekf2ev_quaternion(float *quat)
+// return the quaternions for the rotation from External Vision system reference frame to the EKF reference frame
+void Ekf::get_ev2ekf_quaternion(float *quat)
 {
-	Quatf quat_ekf2ev;
-	quat_ekf2ev.from_axis_angle(_ev_rot_vec_filt);
+	Quatf quat_ev2ekf;
+	quat_ev2ekf.from_axis_angle(_ev_rot_vec_filt);
 
 	for (unsigned i = 0; i < 4; i++) {
-		quat[i] = quat_ekf2ev(i);
+		quat[i] = quat_ev2ekf(i);
 	}
 }
 

--- a/EKF/estimator_interface.h
+++ b/EKF/estimator_interface.h
@@ -287,7 +287,7 @@ public:
 	const matrix::Quatf &get_quaternion() const { return _output_new.quat_nominal; }
 
 	// return the quaternion defining the rotation from the EKF to the External Vision reference frame
-	virtual void get_ekf2ev_quaternion(float *quat) = 0;
+	virtual void get_ev2ekf_quaternion(float *quat) = 0;
 
 	// get the velocity of the body frame origin in local NED earth frame
 	void get_velocity(float *vel)


### PR DESCRIPTION
These changes fix the alignment between the local origin frame and an external fixed frame of the external vision system. The changes contain:
- fix the computation of the orientation error between the frames
- enable access to the estimated alignment rotation
- removed mag suffix
- enable the computation of the orientation error only based on MASK_ROTATE_EV
- fixes wrong labeling of get_ekf2ev_quaternion function (also see: PR #635)

![EKF_AID_MASK_63](https://user-images.githubusercontent.com/23532607/63355006-bf4b3100-c365-11e9-9742-85dfb0505971.png)
@priseborough 