### PR TITLE
EKF: Use math library for quaternion to rotation matrix conversions

### DIFF
--- a/EKF/drag_fusion.cpp
+++ b/EKF/drag_fusion.cpp
@@ -82,8 +82,7 @@ void Ekf::fuseDrag()
 	rel_wind(0) = vn - vwn;
 	rel_wind(1) = ve - vwe;
 	rel_wind(2) = vd;
-	Dcmf earth_to_body(_state.quat_nominal);
-	earth_to_body = earth_to_body.transpose();
+	Dcmf earth_to_body = quat_to_invrotmat(_state.quat_nominal);
 	rel_wind = earth_to_body * rel_wind;
 
 	// perform sequential fusion of XY specific forces

--- a/EKF/ekf.cpp
+++ b/EKF/ekf.cpp
@@ -251,7 +251,7 @@ bool Ekf::initialiseFilter()
 		_state.quat_nominal = Quatf(euler_init);
 
 		// update transformation matrix from body to world frame
-		_R_to_earth = quat_to_invrotmat(_state.quat_nominal);
+		_R_to_earth = Dcmf(_state.quat_nominal);
 
 		// calculate the initial magnetic field and yaw alignment
 		_control_status.flags.yaw_align = resetMagHeading(_mag_filt_state, false, false);
@@ -331,7 +331,7 @@ void Ekf::predictState()
 	Vector3f vel_last = _state.vel;
 
 	// update transformation matrix from body to world frame
-	_R_to_earth = quat_to_invrotmat(_state.quat_nominal);
+	_R_to_earth = Dcmf(_state.quat_nominal);
 
 	// Calculate an earth frame delta velocity
 	Vector3f corrected_delta_vel_ef = _R_to_earth * corrected_delta_vel;
@@ -474,7 +474,7 @@ void Ekf::calculateOutputStates()
 	_output_new.quat_nominal.normalize();
 
 	// calculate the rotation matrix from body to earth frame
-	_R_to_earth_now = quat_to_invrotmat(_output_new.quat_nominal);
+	_R_to_earth_now = Dcmf(_output_new.quat_nominal);
 
 	// correct delta velocity for bias offsets
 	const Vector3f delta_vel{imu.delta_vel - _state.accel_bias * dt_scale_correction};

--- a/EKF/ekf_helper.cpp
+++ b/EKF/ekf_helper.cpp
@@ -454,7 +454,7 @@ bool Ekf::realignYawGPS()
 			Quatf quat_before_reset = _state.quat_nominal;
 
 			// update transformation matrix from body to world frame using the current state estimate
-			_R_to_earth = quat_to_invrotmat(_state.quat_nominal);
+			_R_to_earth = Dcmf(_state.quat_nominal);
 
 			// get quaternion from existing filter states and calculate roll, pitch and yaw angles
 			Eulerf euler321(_state.quat_nominal);
@@ -486,7 +486,7 @@ bool Ekf::realignYawGPS()
 			_velpos_reset_request = badMagYaw;
 
 			// update transformation matrix from body to world frame using the current state estimate
-			_R_to_earth = quat_to_invrotmat(_state.quat_nominal);
+			_R_to_earth = Dcmf(_state.quat_nominal);
 
 			// Use the last magnetometer measurements to reset the field states
 			_state.mag_B.zero();
@@ -594,7 +594,7 @@ bool Ekf::resetMagHeading(Vector3f &mag_init, bool increase_yaw_var, bool update
 	Quatf quat_after_reset = _state.quat_nominal;
 
 	// update transformation matrix from body to world frame using the current estimate
-	_R_to_earth = quat_to_invrotmat(_state.quat_nominal);
+	_R_to_earth = Dcmf(_state.quat_nominal);
 
 	// calculate the initial quaternion
 	// determine if a 321 or 312 Euler sequence is best
@@ -707,8 +707,8 @@ bool Ekf::resetMagHeading(Vector3f &mag_init, bool increase_yaw_var, bool update
 	}
 
 	// set the earth magnetic field states using the updated rotation
-	Dcmf _R_to_earth_after = quat_to_invrotmat(quat_after_reset);
-	_state.mag_I = _R_to_earth_after * mag_init;
+	Dcmf R_to_earth_after(quat_after_reset);
+	_state.mag_I = R_to_earth_after * mag_init;
 
 	// reset the corresponding rows and columns in the covariance matrix and set the variances on the magnetic field states to the measurement variance
 	zeroRows(P, 16, 21);
@@ -739,7 +739,7 @@ bool Ekf::resetMagHeading(Vector3f &mag_init, bool increase_yaw_var, bool update
 	_state_reset_status.quat_change = q_error;
 
 	// update transformation matrix from body to world frame using the current estimate
-	_R_to_earth = quat_to_invrotmat(_state.quat_nominal);
+	_R_to_earth = Dcmf(_state.quat_nominal);
 
 	// reset the rotation from the EV to EKF frame of reference if it is being used
 	if ((_params.fusion_mode & MASK_ROTATE_EV) && !_control_status.flags.ev_yaw) {
@@ -1638,7 +1638,7 @@ void Ekf::calcExtVisRotMat()
 
 	// convert filtered vector to a quaternion and then to a rotation matrix
 	q_error.from_axis_angle(_ev_rot_vec_filt);
-	_ev_rot_mat = quat_to_invrotmat(q_error); // rotation from EV reference to EKF reference
+	_ev_rot_mat = Dcmf(q_error); // rotation from EV reference to EKF reference
 
 }
 
@@ -1663,7 +1663,7 @@ void Ekf::resetExtVisRotMat()
 	}
 
 	// reset the rotation matrix
-	_ev_rot_mat = quat_to_invrotmat(q_error); // rotation from EV reference to EKF reference
+	_ev_rot_mat = Dcmf(q_error); // rotation from EV reference to EKF reference
 }
 
 // return the quaternions for the rotation from External Vision system reference frame to the EKF reference frame

--- a/EKF/ekf_helper.cpp
+++ b/EKF/ekf_helper.cpp
@@ -1382,6 +1382,7 @@ Vector3f EstimatorInterface::cross_product(const Vector3f &vecIn1, const Vector3
 }
 
 // calculate the inverse rotation matrix from a quaternion rotation
+// this produces the inverse rotation to that produced by the math library quaternion to Dcmf operator
 Matrix3f EstimatorInterface::quat_to_invrotmat(const Quatf &quat)
 {
 	float q00 = quat(0) * quat(0);
@@ -1399,12 +1400,12 @@ Matrix3f EstimatorInterface::quat_to_invrotmat(const Quatf &quat)
 	dcm(0, 0) = q00 + q11 - q22 - q33;
 	dcm(1, 1) = q00 - q11 + q22 - q33;
 	dcm(2, 2) = q00 - q11 - q22 + q33;
-	dcm(0, 1) = 2.0f * (q12 - q03);
-	dcm(0, 2) = 2.0f * (q13 + q02);
-	dcm(1, 0) = 2.0f * (q12 + q03);
-	dcm(1, 2) = 2.0f * (q23 - q01);
-	dcm(2, 0) = 2.0f * (q13 - q02);
-	dcm(2, 1) = 2.0f * (q23 + q01);
+	dcm(1, 0) = 2.0f * (q12 - q03);
+	dcm(2, 0) = 2.0f * (q13 + q02);
+	dcm(0, 1) = 2.0f * (q12 + q03);
+	dcm(2, 1) = 2.0f * (q23 - q01);
+	dcm(0, 2) = 2.0f * (q13 - q02);
+	dcm(1, 2) = 2.0f * (q23 + q01);
 
 	return dcm;
 }

--- a/EKF/gps_yaw_fusion.cpp
+++ b/EKF/gps_yaw_fusion.cpp
@@ -395,7 +395,7 @@ bool Ekf::resetGpsAntYaw()
 			_state_reset_status.quat_change = q_error;
 
 			// update transformation matrix from body to world frame using the current estimate
-			_R_to_earth = quat_to_invrotmat(_state.quat_nominal);
+			_R_to_earth = Dcmf(_state.quat_nominal);
 
 			// reset the rotation from the EV to EKF frame of reference if it is being used
 			if ((_params.fusion_mode & MASK_ROTATE_EV) && (_params.fusion_mode & MASK_USE_EVPOS)) {

--- a/EKF/mag_fusion.cpp
+++ b/EKF/mag_fusion.cpp
@@ -73,8 +73,7 @@ void Ekf::fuseMag()
 	SH_MAG[8] = 2.0f*magE*q3;
 
 	// rotate magnetometer earth field state into body frame
-	Dcmf R_to_body(_state.quat_nominal);
-	R_to_body = R_to_body.transpose();
+	Dcmf R_to_body = quat_to_invrotmat(_state.quat_nominal);
 
 	Vector3f mag_I_rot = R_to_body * _state.mag_I;
 

--- a/EKF/optflow_fusion.cpp
+++ b/EKF/optflow_fusion.cpp
@@ -68,8 +68,7 @@ void Ekf::fuseOptFlow()
 	float Kfusion[24][2] = {}; // Optical flow Kalman gains
 
 	// get rotation matrix from earth to body
-	Dcmf earth_to_body(_state.quat_nominal);
-	earth_to_body = earth_to_body.transpose();
+	Dcmf earth_to_body = quat_to_invrotmat(_state.quat_nominal);
 
 	// calculate the sensor position relative to the IMU
 	Vector3f pos_offset_body = _params.flow_pos_body - _params.imu_pos_body;

--- a/EKF/sideslip_fusion.cpp
+++ b/EKF/sideslip_fusion.cpp
@@ -73,8 +73,7 @@ void Ekf::fuseSideslip()
 	rel_wind(1) = ve - vwe;
 	rel_wind(2) = vd;
 
-	Dcmf earth_to_body(_state.quat_nominal);
-	earth_to_body = earth_to_body.transpose(); //Why transpose?
+	Dcmf earth_to_body = quat_to_invrotmat(_state.quat_nominal);
 
 	// rotate into body axes
 	rel_wind = earth_to_body * rel_wind;

--- a/EKF/terrain_estimator.cpp
+++ b/EKF/terrain_estimator.cpp
@@ -199,8 +199,7 @@ void Ekf::fuseFlowForTerrain()
 	float R_LOS = calcOptFlowMeasVar();
 
 	// get rotation matrix from earth to body
-	Dcmf earth_to_body(_state.quat_nominal);
-	earth_to_body = earth_to_body.transpose();
+	Dcmf earth_to_body = quat_to_invrotmat(_state.quat_nominal);
 
 	// calculate the sensor position relative to the IMU
 	Vector3f pos_offset_body = _params.flow_pos_body - _params.imu_pos_body;


### PR DESCRIPTION
This change fixes the following issues:

1) The quat_to_invrotmat function produced the same rotation matrix as the math library operator, but the name and comments indicated otherwise. This function was being used in several places where the math library could be used instead.
2) In several places where an inverse rotation was required, the rotation matrix was being calculated, then transposed.

The following changes have been made

1) Wherever the required rotation matrix can be calculated directly from the quaternion using the math library operator, this is done.
2) The quat_to_invrotmat function has been modified so that it outputs the inverse rotation to that produced by the math library and the comments have been updated to make this clear.
2) Wherever an inverse rotation matrix is required from a quaternion, the quat_to_invrotmat function is used instead of calculating the matrix and then transposing it.

SITL log attached:

https://review.px4.io/plot_app?log=397c0931-225d-423d-bf55-0a1014075998