### PR TITLE
Flow aiding - Reset state when flow is enabled only if it is the only position/velocity aiding sensor

### DIFF
--- a/EKF/control.cpp
+++ b/EKF/control.cpp
@@ -465,20 +465,19 @@ void Ekf::controlOpticalFlowFusion()
 				_control_status.flags.opt_flow = true;
 				_time_last_of_fuse = _time_last_imu;
 
-				// if we are not using GPS then the velocity and position states and covariances need to be set
-				if (!_control_status.flags.gps || !_control_status.flags.ev_pos) {
+				// if we are not using GPS or external vision aiding, then the velocity and position states and covariances need to be set
+				const bool flow_aid_only = !(_control_status.flags.gps || _control_status.flags.ev_pos);
+				if (flow_aid_only) {
 					resetVelocity();
 					resetPosition();
 
 					// align the output observer to the EKF states
 					alignOutputFilter();
-
 				}
 			}
 
 		} else if (!(_params.fusion_mode & MASK_USE_OF)) {
 			_control_status.flags.opt_flow = false;
-
 		}
 
 		// handle the case when we have optical flow, are reliant on it, but have not been using it for an extended period


### PR DESCRIPTION
I'm currently working on a drone with an optical flow sensor and is has a nasty attitude glitch at each stop. After analyzing the log, I found out that the vxy and xy reset counters are incremented every time the drone stops. The reset occurs at each stop because it goes in and out of flow aiding and that the condition for a reset is always true "if the vehicle doesn't have GPS or external vision aiding" (my vehicle has GPS but no EV); the correct check should be "if it doesn't have gps and doesn't have external vision aiding" or -as I implemented it here- "if flow is the only velocity/position aiding source".

Below a log showing that the reset counter is incremented every time the height source switches from baro (during motion) to range aid (after a stop).
![2019-09-02_13-41-05_01_plot](https://user-images.githubusercontent.com/14822839/64114453-4a2c2280-cd8d-11e9-864a-cf4707697c05.png)

@jkflying This should also fix the glitches you see on the Eiger