### PR TITLE
implemented synthesized magnetometer Z measurement

### DIFF
--- a/EKF/common.h
+++ b/EKF/common.h
@@ -357,6 +357,9 @@ struct parameters {
 
 	// control of on-ground movement check
 	float is_moving_scaler{1.0f};		///< gain scaler used to adjust the threshold for the on-ground movement detection. Larger values make the test less sensitive.
+
+	// compute synthetic magnetomter Z value if possible
+	int32_t synthesize_mag_z{0};
 };
 
 struct stateSample {
@@ -458,6 +461,7 @@ union filter_control_status_u {
 		uint32_t gps_yaw     : 1; ///< 22 - true when yaw (not ground course) data from a GPS receiver is being fused
 		uint32_t mag_align_complete   : 1; ///< 23 - true when the in-flight mag field alignment has been completed
 		uint32_t ev_vel      : 1; ///< 24 - true when local earth frame velocity data from external vision measurements are being fused
+		uint32_t synthetic_mag_z : 1; ///< 25 - true when we are using a synthesized measurement for the magnetometer Z component
 	} flags;
 	uint32_t value;
 };

--- a/EKF/ekf.h
+++ b/EKF/ekf.h
@@ -362,6 +362,7 @@ private:
 	bool _vehicle_at_rest_prev{false};	///< true when the vehicle was at rest the previous time the status was checked
 	bool _mag_yaw_reset_req{false};		///< true when a reset of the yaw using the magnetometer data has been requested
 	bool _mag_decl_cov_reset{false};	///< true after the fuseDeclination() function has been used to modify the earth field covariances after a magnetic field reset event.
+	bool _synthetic_mag_z_active{false};	///< true if we are generating synthetic magnetometer Z measurements
 
 	float P[_k_num_states][_k_num_states] {};	///< state covariance matrix
 
@@ -718,5 +719,9 @@ private:
 	// "accumulator" and passing this value at the next iteration.
 	// Ref: https://en.wikipedia.org/wiki/Kahan_summation_algorithm
 	float kahanSummation(float sum_previous, float input, float &accumulator) const;
+
+	// calculate a synthetic value for the magnetometer Z component, given the 3D magnetomter
+	// sensor measurement
+	float calculate_synthetic_mag_z_measurement(Vector3f mag_meas, Vector3f mag_earth_predicted);
 
 };


### PR DESCRIPTION
This PR intends to improve yaw / magnetic field vector estimation for setups where the quality of the magnetomter Z component is bad. This is e.g. the case when there is a strong coupling between motor current and magnetometer Z measurement.

If this feature is enabled and the global position on earth is known then the estimator will calculate the magnetometer Z component based on the knowledge of the direction and strength of the magnetic field vector.
The synthesized component is used for the heading fusion but not for the 3D fusion. In the 3D fusion we rely on the x/y components of the magnetometer measurement to estimate the 3D magnetic field vector.

**Follow up work**
1) Since we don't fuse the synthetic Z measurement for 3D fusion we need to make sure to disable the mag Z bias state.
2) If we have the knowledge about the earth magnetic field vector we should add it as a direct fusion. That should be very cheap as we can observe the states directly. Currently we only fuse the declination as an observation in order to put some constraints on the earth fields states, however, we can go even further and constrain the vector itself.

**Testing**
I have tested this PR on a small racer vehicle. In order to do realistic tests I distorted the magnetometer Z measurements from the sensor as a function of the demanded throttle.

Heading innovations using magnetometer Z data:

![bad_heading](https://user-images.githubusercontent.com/7610489/64331973-05de9380-cfd4-11e9-8100-1d993d9cb306.png)

Heading innovation using synthesized measurement:
![heading_good](https://user-images.githubusercontent.com/7610489/64332008-155ddc80-cfd4-11e9-821b-226f78e354a6.png)

I also did a SITL test where I set the max tilt angle of the drone to 70 degrees and flew a maneuver where the drone would spiral around in yaw with a 70 degrees bank angle.
I misused the hagl_innov field of the ekf2_innovations message to store the synthesized value for the magnetomter Z component. As seen in the plot below the actual sensor measurement is calculated quite accurately.
![image](https://user-images.githubusercontent.com/7610489/64333834-b4380800-cfd7-11e9-927c-51c1d6b3d8d1.png)




