### PR TITLE
Flow takeoff improvements

### DIFF
--- a/EKF/common.h
+++ b/EKF/common.h
@@ -133,6 +133,7 @@ struct baroSample {
 struct rangeSample {
 	float       rng;	///< range (distance to ground) measurement (m)
 	uint64_t    time_us;	///< timestamp of the measurement (uSec)
+	uint8_t	    quality; ///< quality indicator between 0 and 255
 };
 
 struct airspeedSample {

--- a/EKF/common.h
+++ b/EKF/common.h
@@ -131,9 +131,9 @@ struct baroSample {
 };
 
 struct rangeSample {
-	float       rng;	///< range (distance to ground) measurement (m)
+	float       rng;	    ///< range (distance to ground) measurement (m)
 	uint64_t    time_us;	///< timestamp of the measurement (uSec)
-	uint8_t	    quality; ///< quality indicator between 0 and 255
+	int8_t	    quality;    ///< Signal quality in percent (0...100%), where 0 = invalid signal, 100 = perfect signal, and -1 = unknown signal quality.
 };
 
 struct airspeedSample {

--- a/EKF/control.cpp
+++ b/EKF/control.cpp
@@ -1198,7 +1198,7 @@ void Ekf::checkRangeDataValidity()
 		return;
 	} else {
 		// reset fault status when we get new data
-		_rng_hgt_faulty = false;
+		_rng_hgt_faulty = (_range_sample_delayed.quality == 0);
 	}
 
 	// Check if excessively tilted
@@ -1244,7 +1244,7 @@ void Ekf::checkRangeDataValidity()
 			}
 
 			_control_status.flags.rng_stuck = true;
-			_rng_hgt_faulty = true;
+			_rng_hgt_faulty = (_range_sample_delayed.quality == 0);
 		}
 
 	} else {

--- a/EKF/control.cpp
+++ b/EKF/control.cpp
@@ -1244,7 +1244,7 @@ void Ekf::checkRangeDataValidity()
 			}
 
 			_control_status.flags.rng_stuck = true;
-			_rng_hgt_faulty = (_range_sample_delayed.quality == 0);
+			_rng_hgt_faulty = true;
 		}
 
 	} else {

--- a/EKF/estimator_interface.cpp
+++ b/EKF/estimator_interface.cpp
@@ -314,7 +314,7 @@ void EstimatorInterface::setAirspeedData(uint64_t time_usec, float true_airspeed
 	}
 }
 
-void EstimatorInterface::setRangeData(uint64_t time_usec, float data, uint8_t quality)
+void EstimatorInterface::setRangeData(uint64_t time_usec, float data, int8_t quality)
 {
 	if (!_initialised || _range_buffer_fail) {
 		return;

--- a/EKF/estimator_interface.cpp
+++ b/EKF/estimator_interface.cpp
@@ -314,7 +314,7 @@ void EstimatorInterface::setAirspeedData(uint64_t time_usec, float true_airspeed
 	}
 }
 
-void EstimatorInterface::setRangeData(uint64_t time_usec, float data)
+void EstimatorInterface::setRangeData(uint64_t time_usec, float data, uint8_t quality)
 {
 	if (!_initialised || _range_buffer_fail) {
 		return;
@@ -336,6 +336,7 @@ void EstimatorInterface::setRangeData(uint64_t time_usec, float data)
 		rangeSample range_sample_new;
 		range_sample_new.rng = data;
 		range_sample_new.time_us = time_usec - _params.range_delay_ms * 1000;
+		range_sample_new.quality = quality;
 		_time_last_range = time_usec;
 
 		_range_buffer.push(range_sample_new);

--- a/EKF/estimator_interface.h
+++ b/EKF/estimator_interface.h
@@ -191,7 +191,7 @@ public:
 	void setAirspeedData(uint64_t time_usec, float true_airspeed, float eas2tas);
 
 	// set range data
-	void setRangeData(uint64_t time_usec, float data, uint8_t quality);
+	void setRangeData(uint64_t time_usec, float data, int8_t quality);
 
 	// set optical flow data
 	// if optical flow sensor gyro delta angles are not available, set gyroXYZ vector fields to NaN and the EKF will use its internal delta angle data instead

--- a/EKF/estimator_interface.h
+++ b/EKF/estimator_interface.h
@@ -191,7 +191,7 @@ public:
 	void setAirspeedData(uint64_t time_usec, float true_airspeed, float eas2tas);
 
 	// set range data
-	void setRangeData(uint64_t time_usec, float data);
+	void setRangeData(uint64_t time_usec, float data, uint8_t quality);
 
 	// set optical flow data
 	// if optical flow sensor gyro delta angles are not available, set gyroXYZ vector fields to NaN and the EKF will use its internal delta angle data instead

--- a/EKF/terrain_estimator.cpp
+++ b/EKF/terrain_estimator.cpp
@@ -99,7 +99,7 @@ void Ekf::runTerrainEstimator()
 
 		// if stationary on the ground and no range data for over a second, fake a measurement
 		// to handle bad range finder data when on ground
-		if (_rng_hgt_faulty && !_range_data_ready && !_control_status.flags.in_air && _vehicle_at_rest && (_time_last_imu - _time_last_hagl_fuse) > (uint64_t)1E6) {
+		if (!_range_data_ready && !_control_status.flags.in_air && _vehicle_at_rest && (_time_last_imu - _time_last_hagl_fuse) > (uint64_t)1E6) {
 			_range_data_ready = true;
 			_rng_hgt_faulty = false;
 			_range_sample_delayed.rng = _params.rng_gnd_clearance;

--- a/EKF/terrain_estimator.cpp
+++ b/EKF/terrain_estimator.cpp
@@ -97,6 +97,13 @@ void Ekf::runTerrainEstimator()
 		// limit the variance to prevent it becoming badly conditioned
 		_terrain_var = math::constrain(_terrain_var, 0.0f, 1e4f);
 
+		// if stationary on the ground and no range data for over a second, fake a measurement
+		// to handle bad range finder data when on ground
+		if (!_range_data_ready && !_control_status.flags.in_air && _vehicle_at_rest && (_time_last_imu - _time_last_hagl_fuse) > (uint64_t)1E6) {
+			_range_data_ready = true;
+			_range_sample_delayed.rng = _params.rng_gnd_clearance;
+		}
+
 		// Fuse range finder data if available
 		if (_range_data_ready && !_rng_hgt_faulty) {
 			fuseHagl();


### PR DESCRIPTION
This PR improves the behavior when taking off using only optical flow. Specifically:
 - It publishes a "fake range measurement" when the vehicle is on the ground and range sensor data contains garbage. This change now publishes the value of the parameter `rng_gnd_clearance` in that case.
- It adds the range sensor quality to the terrain estimator. Fundamentally, the information is fused into the existing `_rng_hgt_faulty` flag. It is also used in the decision-making of the above point, as well as in the initialization of the height above ground `initHagl()`.

I've tested this on two different vehicles on PX4 with different range sensors:
- Using the CM8JL65, a lidar sensor which is quite accurate from 0.1m ~ 6m
- Using the MB12xx, a sonar which starts working around 0.65m ~ 5m

The drivers of the two vary a bit: the CM8JL65 doesn't actually set the quality flag, but correctly reports the saturated min/max values, while my (custom) driver for the MB12xx reports garbage but correctly identifies it as such and sets the quality metric accordingly.

Logs:
CM8JL65: https://review.px4.io/plot_app?log=01deedd4-2afb-4b09-ad37-726814424121
![image](https://user-images.githubusercontent.com/14265408/64704041-e355ea00-d4ad-11e9-8c86-70bbfed792ce.png)



MB12xx: https://review.px4.io/plot_app?log=bc610be1-089b-4b57-90f6-937d97326797
![image](https://user-images.githubusercontent.com/14265408/64703270-6413e680-d4ac-11e9-8612-a3a0a3bb1612.png)
