### PR TITLE
EKF: fake rng if faulty on ground

### DIFF
--- a/EKF/terrain_estimator.cpp
+++ b/EKF/terrain_estimator.cpp
@@ -97,9 +97,10 @@ void Ekf::runTerrainEstimator()
 		// limit the variance to prevent it becoming badly conditioned
 		_terrain_var = math::constrain(_terrain_var, 0.0f, 1e4f);
 
-		// if stationary on the ground and no range data for over a second, fake a measurement
+		// if stationary on the ground and no or bad range data for over a second, fake a measurement
 		// to handle bad range finder data when on ground
-		if (!_range_data_ready && !_control_status.flags.in_air && _vehicle_at_rest && (_time_last_imu - _time_last_hagl_fuse) > (uint64_t)1E6) {
+		if ((_rng_hgt_faulty || !_range_data_ready) && !_control_status.flags.in_air && _vehicle_at_rest &&
+			(_time_last_imu - _time_last_hagl_fuse) > (uint64_t)1E6) {
 			_range_data_ready = true;
 			_rng_hgt_faulty = false;
 			_range_sample_delayed.rng = _params.rng_gnd_clearance;


### PR DESCRIPTION
Tiny detail we forgot in #639 :
If we are stationary on the ground, we want to fake a measurement both if:
- The range sensor doesn't report anything
- The range sensor reports garbage

The previous PR only handled the first case