### PR TITLE
External vision velocity

### DIFF
--- a/EKF/common.h
+++ b/EKF/common.h
@@ -80,8 +80,8 @@ struct flow_message {
 };
 
 struct ext_vision_message {
-	Vector3f posNED;	///< XYZ position in earth frame (m) - Z must be aligned with down axis
-	Vector3f velNED;	///< XYZ velocity in earth frame (m/sec) - Z must be aligned with down axis
+	Vector3f pos;	///< XYZ position in earth frame (m) - Z must be aligned with down axis
+	Vector3f vel;	///< XYZ velocity in earth frame (m/sec) - Z must be aligned with down axis
 	Quatf quat;		///< quaternion defining rotation from body to earth frame
 	float posErr;		///< 1-Sigma horizontal position accuracy (m)
 	float hgtErr;		///< 1-Sigma height accuracy (m)
@@ -153,8 +153,8 @@ struct flowSample {
 };
 
 struct extVisionSample {
-	Vector3f posNED;	///< XYZ position in earth frame (m) - Z must be aligned with down axis
-	Vector3f velNED;	///< XYZ velocity in earth frame (m/sec) - Z must be aligned with down axis
+	Vector3f pos;	///< XYZ position in earth frame (m) - Z must be aligned with down axis
+	Vector3f vel;	///< XYZ velocity in earth frame (m/sec) - Z must be aligned with down axis
 	Quatf quat;		///< quaternion defining rotation from body to earth frame
 	float posErr;		///< 1-Sigma horizontal position accuracy (m)
 	float hgtErr;		///< 1-Sigma height accuracy (m)

--- a/EKF/common.h
+++ b/EKF/common.h
@@ -260,8 +260,8 @@ struct parameters {
 	float pos_noaid_noise{10.0f};		///< observation noise for non-aiding position fusion (m)
 	float baro_noise{2.0f};			///< observation noise for barometric height fusion (m)
 	float baro_innov_gate{5.0f};		///< barometric and GPS height innovation consistency gate size (STD)
-	float posNE_innov_gate{5.0f};		///< GPS horizontal position innovation consistency gate size (STD)
-	float vel_innov_gate{5.0f};		///< GPS velocity innovation consistency gate size (STD)
+        float gps_pos_innov_gate{5.0f};		///< GPS horizontal position innovation consistency gate size (STD)
+        float gps_vel_innov_gate{5.0f};		///< GPS velocity innovation consistency gate size (STD)
 	float gnd_effect_deadzone{5.0f};	///< Size of deadzone applied to negative baro innovations when ground effect compensation is active (m)
 	float gnd_effect_max_hgt{0.5f};		///< Height above ground at which baro ground effect becomes insignificant (m)
 

--- a/EKF/common.h
+++ b/EKF/common.h
@@ -80,10 +80,12 @@ struct flow_message {
 };
 
 struct ext_vision_message {
-	Vector3f posNED;	///< measured NED position relative to the local origin (m)
-	Quatf quat;		///< measured quaternion orientation defining rotation from NED to body frame
+	Vector3f posNED;	///< XYZ position in earth frame (m) - Z must be aligned with down axis
+	Vector3f velNED;	///< XYZ velocity in earth frame (m/sec) - Z must be aligned with down axis
+	Quatf quat;		///< quaternion defining rotation from body to earth frame
 	float posErr;		///< 1-Sigma horizontal position accuracy (m)
 	float hgtErr;		///< 1-Sigma height accuracy (m)
+	float velErr;		///< 1-Sigma velocity accuracy (m/sec)
 	float angErr;		///< 1-Sigma angular error (rad)
 };
 
@@ -151,10 +153,12 @@ struct flowSample {
 };
 
 struct extVisionSample {
-	Vector3f posNED;	///< measured NED position relative to the local origin (m)
-	Quatf quat;		///< measured quaternion orientation defining rotation from NED to body frame
+	Vector3f posNED;	///< XYZ position in earth frame (m) - Z must be aligned with down axis
+	Vector3f velNED;	///< XYZ velocity in earth frame (m/sec) - Z must be aligned with down axis
+	Quatf quat;		///< quaternion defining rotation from body to earth frame
 	float posErr;		///< 1-Sigma horizontal position accuracy (m)
 	float hgtErr;		///< 1-Sigma height accuracy (m)
+	float velErr;		///< 1-Sigma velocity accuracy (m/sec)
 	float angErr;		///< 1-Sigma angular error (rad)
 	uint64_t time_us;	///< timestamp of the measurement (uSec)
 };

--- a/EKF/common.h
+++ b/EKF/common.h
@@ -189,11 +189,12 @@ struct auxVelSample {
 #define MASK_USE_GPS    (1<<0)		///< set to true to use GPS data
 #define MASK_USE_OF     (1<<1)		///< set to true to use optical flow data
 #define MASK_INHIBIT_ACC_BIAS (1<<2)	///< set to true to inhibit estimation of accelerometer delta velocity bias
-#define MASK_USE_EVPOS	(1<<3)		///< set to true to use external vision NED position data
+#define MASK_USE_EVPOS	(1<<3)		///< set to true to use external vision position data
 #define MASK_USE_EVYAW  (1<<4)		///< set to true to use external vision quaternion data for yaw
 #define MASK_USE_DRAG  (1<<5)		///< set to true to use the multi-rotor drag model to estimate wind
 #define MASK_ROTATE_EV  (1<<6)		///< set to true to if the EV observations are in a non NED reference frame and need to be rotated before being used
 #define MASK_USE_GPSYAW  (1<<7)		///< set to true to use GPS yaw data if available
+#define MASK_USE_EVVEL  (1<<8)		///< sset to true to use external vision velocity data
 
 // Integer definitions for mag_fusion_type
 #define MAG_FUSE_TYPE_AUTO      0	///< The selection of either heading or 3D magnetometer fusion will be automatic
@@ -299,7 +300,9 @@ struct parameters {
 	float range_stuck_threshold{0.1f};	///< minimum variation in range finder reading required to declare a range finder 'unstuck' when readings recommence after being out of range (m)
 
 	// vision position fusion
-	float ev_innov_gate{5.0f};		///< vision estimator fusion innovation consistency gate size (STD)
+        float ev_innov_gate{5.0f};		///< vision estimator fusion innovation consistency gate size (STD)
+        float ev_vel_innov_gate{3.0f};		///< vision velocity fusion innovation consistency gate size (STD)
+        float ev_pos_innov_gate{5.0f};		///< vision position fusion innovation consistency gate size (STD)
 
 	// optical flow fusion
 	float flow_noise{0.15f};		///< observation noise for optical flow LOS rate measurements (rad/sec)
@@ -455,6 +458,7 @@ union filter_control_status_u {
 		uint32_t rng_stuck   : 1; ///< 21 - true when rng data wasn't ready for more than 10s and new rng values haven't changed enough
 		uint32_t gps_yaw     : 1; ///< 22 - true when yaw (not ground course) data from a GPS receiver is being fused
 		uint32_t mag_align_complete   : 1; ///< 23 - true when the in-flight mag field alignment has been completed
+		uint32_t ev_vel      : 1; ///< 24 - true when local earth frame velocity data from external vision measurements are being fused
 	} flags;
 	uint32_t value;
 };

--- a/EKF/common.h
+++ b/EKF/common.h
@@ -260,8 +260,8 @@ struct parameters {
 	float pos_noaid_noise{10.0f};		///< observation noise for non-aiding position fusion (m)
 	float baro_noise{2.0f};			///< observation noise for barometric height fusion (m)
 	float baro_innov_gate{5.0f};		///< barometric and GPS height innovation consistency gate size (STD)
-        float gps_pos_innov_gate{5.0f};		///< GPS horizontal position innovation consistency gate size (STD)
-        float gps_vel_innov_gate{5.0f};		///< GPS velocity innovation consistency gate size (STD)
+	float gps_pos_innov_gate{5.0f};		///< GPS horizontal position innovation consistency gate size (STD)
+	float gps_vel_innov_gate{5.0f};		///< GPS velocity innovation consistency gate size (STD)
 	float gnd_effect_deadzone{5.0f};	///< Size of deadzone applied to negative baro innovations when ground effect compensation is active (m)
 	float gnd_effect_max_hgt{0.5f};		///< Height above ground at which baro ground effect becomes insignificant (m)
 

--- a/EKF/control.cpp
+++ b/EKF/control.cpp
@@ -167,43 +167,36 @@ void Ekf::controlExternalVisionFusion()
 
 		// if the ev data is not in a NED reference frame, then the transformation between EV and EKF navigation frames
 		// needs to be calculated and the observations rotated into the EKF frame of reference
-		if ((_params.fusion_mode & MASK_ROTATE_EV) && !_control_status.flags.ev_yaw) {
+		if ((_params.fusion_mode & MASK_ROTATE_EV) && ((_params.fusion_mode & MASK_USE_EVPOS) || (_params.fusion_mode & MASK_USE_EVVEL)) && !_control_status.flags.ev_yaw) {
 			// rotate EV measurements into the EKF Navigation frame
 			calcExtVisRotMat();
 		}
 
-		// reset external vision rotation matrix independent if is actually used for debugging purposes
-		if ((_time_last_imu - _time_last_ext_vision) < (2 * EV_MAX_INTERVAL)
-			&& (_params.fusion_mode & MASK_ROTATE_EV) && !(_params.fusion_mode & MASK_USE_EVYAW)){
-			// Reset transformation between EV and EKF navigation frames
-			resetExtVisRotMat();
-		}
-
-		// external vision position aiding selection logic
-		if ((_params.fusion_mode & MASK_USE_EVPOS) && !_control_status.flags.ev_pos && _control_status.flags.tilt_align
-			&& _control_status.flags.yaw_align) {
+                // external vision aiding selection logic
+                if (_control_status.flags.tilt_align && _control_status.flags.yaw_align) {
 
 			// check for a external vision measurement that has fallen behind the fusion time horizon
 			if ((_time_last_imu - _time_last_ext_vision) < (2 * EV_MAX_INTERVAL)) {
 				// turn on use of external vision measurements for position
-				_control_status.flags.ev_pos = true;
-				ECL_INFO("EKF commencing external vision position fusion");
-
-				if ((_params.fusion_mode & MASK_ROTATE_EV) && !(_params.fusion_mode & MASK_USE_EVYAW))  {
-					// Reset transformation between EV and EKF navigation frames when starting fusion
-					resetExtVisRotMat();
+                                if (_params.fusion_mode & MASK_USE_EVPOS && !_control_status.flags.ev_pos) {
+					_control_status.flags.ev_pos = true;
+                                        resetPosition();
+					ECL_INFO("EKF commencing external vision position fusion");
 				}
 
-				// reset the position if we are not already aiding using GPS, else use a relative position
-				// method for fusing the position data
-				if (_control_status.flags.gps) {
-					_fuse_hpos_as_odom = true;
-
-				} else {
-					resetPosition();
-					resetVelocity();
-
+				// turn on use of external vision measurements for velocity
+                                if (_params.fusion_mode & MASK_USE_EVVEL && !_control_status.flags.ev_vel) {
+					_control_status.flags.ev_vel = true;
+                                        resetVelocity();
+					ECL_INFO("EKF commencing external vision velocity fusion");
 				}
+
+                                if ((_params.fusion_mode & MASK_ROTATE_EV) && !(_params.fusion_mode & MASK_USE_EVYAW)
+                                        && !_ev_rot_mat_initialised)  {
+                                        // Reset transformation between EV and EKF navigation frames when starting fusion
+                                        resetExtVisRotMat();
+                                        _ev_rot_mat_initialised = true;
+                                }
 			}
 		}
 
@@ -332,7 +325,7 @@ void Ekf::controlExternalVisionFusion()
 				// check if we have been deadreckoning too long
 				if ((_time_last_imu - _time_last_pos_fuse) > _params.reset_timeout_max) {
 					// don't reset velocity if we have another source of aiding constraining it
-					if ((_time_last_imu - _time_last_of_fuse) > (uint64_t)1E6) {
+					if (((_time_last_imu - _time_last_of_fuse) > (uint64_t)1E6) && ((_time_last_imu - _time_last_vel_fuse) > (uint64_t)1E6)) {
 						resetVelocity();
 					}
 
@@ -340,16 +333,55 @@ void Ekf::controlExternalVisionFusion()
 				}
 			}
 
+			// innovation gate size
+                        _posInnovGateNE = fmaxf(_params.ev_pos_innov_gate, 1.0f);
+                }else{
+                    _vel_pos_innov[3] = 0.0f;
+                    _vel_pos_innov[4] = 0.0f;
+                }
+
+		// determine if we should use the velocity observations
+		if (_control_status.flags.ev_vel) {
+                        _fuse_hor_vel = true;
+                        _fuse_vert_vel = true;
+
+                        Vector3f velNED_aligned{_ev_sample_delayed.velNED};
+
+			// rotate measurement into correct earth frame if required
+			if (_params.fusion_mode & MASK_ROTATE_EV) {
+                                velNED_aligned = _ev_rot_mat * _ev_sample_delayed.velNED;
+			}
+
+			// correct velocity for offset relative to IMU
+			Vector3f ang_rate = _imu_sample_delayed.delta_ang * (1.0f / _imu_sample_delayed.delta_ang_dt);
+			Vector3f pos_offset_body = _params.ev_pos_body - _params.imu_pos_body;
+			Vector3f vel_offset_body = cross_product(ang_rate, pos_offset_body);
+			Vector3f vel_offset_earth = _R_to_earth * vel_offset_body;
+                        velNED_aligned -= vel_offset_earth;
+
+                        _vel_pos_innov[0] = _state.vel(0) - velNED_aligned(0);
+                        _vel_pos_innov[1] = _state.vel(1) - velNED_aligned(1);
+                        _vel_pos_innov[2] = _state.vel(2) - velNED_aligned(2);
+
+			// check if we have been deadreckoning too long
+			if ((_time_last_imu - _time_last_vel_fuse) > _params.reset_timeout_max) {
+				// don't reset velocity if we have another source of aiding constraining it
+				if (((_time_last_imu - _time_last_of_fuse) > (uint64_t)1E6) && ((_time_last_imu - _time_last_pos_fuse) > (uint64_t)1E6)) {
+					resetVelocity();
+				}
+			}
+
 			// observation 1-STD error
-			_posObsNoiseNE = fmaxf(_ev_sample_delayed.posErr, 0.01f);
+			_velObsVarNED(2) = _velObsVarNED(1) = _velObsVarNED(0) = fmaxf(_ev_sample_delayed.velErr, 0.01f);
 
 			// innovation gate size
-			_posInnovGateNE = fmaxf(_params.ev_innov_gate, 1.0f);
+                        _vvelInnovGate = _hvelInnovGate = fmaxf(_params.ev_vel_innov_gate, 1.0f);
 		}
 
 		// Fuse available NED position data into the main filter
-		if (_fuse_height || _fuse_pos) {
+		if (_fuse_height || _fuse_pos || _fuse_hor_vel || _fuse_vert_vel) {
 			fuseVelPosHeight();
+			_fuse_vert_vel = _fuse_hor_vel = false;
 			_fuse_pos = _fuse_height = false;
 			_fuse_hpos_as_odom = false;
 
@@ -361,12 +393,13 @@ void Ekf::controlExternalVisionFusion()
 
 		}
 
-	} else if (_control_status.flags.ev_pos
+	} else if ((_control_status.flags.ev_pos || _control_status.flags.ev_vel)
 		   && (_time_last_imu >= _time_last_ext_vision)
 		   && ((_time_last_imu - _time_last_ext_vision) > (uint64_t)_params.reset_timeout_max)) {
 
 		// Turn off EV fusion mode if no data has been received
 		_control_status.flags.ev_pos = false;
+		_control_status.flags.ev_vel = false;
 		_control_status.flags.ev_yaw = false;
 		ECL_INFO("EKF External Vision Data Stopped");
 
@@ -688,7 +721,7 @@ void Ekf::controlGpsFusion()
 				_posObsNoiseNE = math::constrain(_gps_sample_delayed.hacc, lower_limit, upper_limit);
 			}
 
-			_velObsVarNE(1) = _velObsVarNE(0) = sq(fmaxf(_gps_sample_delayed.sacc, _params.gps_vel_noise));
+			_velObsVarNED(2) = _velObsVarNED(1) = _velObsVarNED(0) = sq(fmaxf(_gps_sample_delayed.sacc, _params.gps_vel_noise));
 
 			// calculate innovations
 			_vel_pos_innov[0] = _state.vel(0) - _gps_sample_delayed.vel(0);
@@ -1627,6 +1660,7 @@ void Ekf::controlVelPosFusion()
 	if (!_control_status.flags.gps &&
 	    !_control_status.flags.opt_flow &&
 	    !_control_status.flags.ev_pos &&
+            !_control_status.flags.ev_vel &&
 	    !(_control_status.flags.fuse_aspd && _control_status.flags.fuse_beta)) {
 
 		// We now need to use a synthetic position observation to prevent unconstrained drift of the INS states.
@@ -1690,7 +1724,8 @@ void Ekf::controlAuxVelFusion()
 		_fuse_hor_vel_aux = true;
 		_aux_vel_innov[0] = _state.vel(0) - _auxvel_sample_delayed.velNE(0);
 		_aux_vel_innov[1] = _state.vel(1) - _auxvel_sample_delayed.velNE(1);
-		_velObsVarNE = _auxvel_sample_delayed.velVarNE;
+		_velObsVarNED(0) = _auxvel_sample_delayed.velVarNE(0);
+		_velObsVarNED(1) = _auxvel_sample_delayed.velVarNE(1);
 		_hvelInnovGate = _params.auxvel_gate;
 		fuseVelPosHeight();
 	}

--- a/EKF/control.cpp
+++ b/EKF/control.cpp
@@ -172,31 +172,31 @@ void Ekf::controlExternalVisionFusion()
 			calcExtVisRotMat();
 		}
 
-                // external vision aiding selection logic
-                if (_control_status.flags.tilt_align && _control_status.flags.yaw_align) {
+		// external vision aiding selection logic
+		if (_control_status.flags.tilt_align && _control_status.flags.yaw_align) {
 
 			// check for a external vision measurement that has fallen behind the fusion time horizon
 			if ((_time_last_imu - _time_last_ext_vision) < (2 * EV_MAX_INTERVAL)) {
 				// turn on use of external vision measurements for position
-                                if (_params.fusion_mode & MASK_USE_EVPOS && !_control_status.flags.ev_pos) {
+				if (_params.fusion_mode & MASK_USE_EVPOS && !_control_status.flags.ev_pos) {
 					_control_status.flags.ev_pos = true;
-                                        resetPosition();
+					resetPosition();
 					ECL_INFO("EKF commencing external vision position fusion");
 				}
 
 				// turn on use of external vision measurements for velocity
-                                if (_params.fusion_mode & MASK_USE_EVVEL && !_control_status.flags.ev_vel) {
+				if (_params.fusion_mode & MASK_USE_EVVEL && !_control_status.flags.ev_vel) {
 					_control_status.flags.ev_vel = true;
-                                        resetVelocity();
+					resetVelocity();
 					ECL_INFO("EKF commencing external vision velocity fusion");
 				}
 
-                                if ((_params.fusion_mode & MASK_ROTATE_EV) && !(_params.fusion_mode & MASK_USE_EVYAW)
-                                        && !_ev_rot_mat_initialised)  {
-                                        // Reset transformation between EV and EKF navigation frames when starting fusion
-                                        resetExtVisRotMat();
-                                        _ev_rot_mat_initialised = true;
-                                }
+				if ((_params.fusion_mode & MASK_ROTATE_EV) && !(_params.fusion_mode & MASK_USE_EVYAW)
+					&& !_ev_rot_mat_initialised)  {
+					// Reset transformation between EV and EKF navigation frames when starting fusion
+					resetExtVisRotMat();
+					_ev_rot_mat_initialised = true;
+				}
 			}
 		}
 
@@ -283,8 +283,8 @@ void Ekf::controlExternalVisionFusion()
 			_ev_sample_delayed.posNED(1) -= pos_offset_earth(1);
 			_ev_sample_delayed.posNED(2) -= pos_offset_earth(2);
 
-                        // Use an incremental position fusion method for EV position data if GPS is also used
-                        if (_params.fusion_mode & MASK_USE_GPS) {
+			// Use an incremental position fusion method for EV position data if GPS is also used
+			if (_params.fusion_mode & MASK_USE_GPS) {
 				_fuse_hpos_as_odom = true;
 			} else {
 				_fuse_hpos_as_odom = false;
@@ -300,15 +300,15 @@ void Ekf::controlExternalVisionFusion()
 					// calculate the change in position since the last measurement
 					Vector3f ev_delta_pos = _ev_sample_delayed.posNED - _pos_meas_prev;
 
-                                        // rotate measurement into body frame is required when fusing with GPS
-                                        ev_delta_pos = _ev_rot_mat * ev_delta_pos;
+					// rotate measurement into body frame is required when fusing with GPS
+					ev_delta_pos = _ev_rot_mat * ev_delta_pos;
 
 					// use the change in position since the last measurement
 					_vel_pos_innov[3] = _state.pos(0) - _hpos_pred_prev(0) - ev_delta_pos(0);
 					_vel_pos_innov[4] = _state.pos(1) - _hpos_pred_prev(1) - ev_delta_pos(1);
 
-                                        // observation 1-STD error, incremental pos observation is expected to have more uncertainty
-                                        _posObsNoiseNE = fmaxf(_ev_sample_delayed.posErr, 0.5f);
+					// observation 1-STD error, incremental pos observation is expected to have more uncertainty
+					_posObsNoiseNE = fmaxf(_ev_sample_delayed.posErr, 0.5f);
 				}
 
 				// record observation and estimate for use next time
@@ -318,14 +318,14 @@ void Ekf::controlExternalVisionFusion()
 
 			} else {
 				// use the absolute position
-                                Vector3f ev_pos_meas = _ev_sample_delayed.posNED;
-                                if (_params.fusion_mode & MASK_ROTATE_EV) {
-                                        ev_pos_meas = _ev_rot_mat * ev_pos_meas;
-                                }
-                                _vel_pos_innov[3] = _state.pos(0) - ev_pos_meas(0);
-                                _vel_pos_innov[4] = _state.pos(1) - ev_pos_meas(1);
-                                // observation 1-STD error
-                                _posObsNoiseNE = fmaxf(_ev_sample_delayed.posErr, 0.01f);
+				Vector3f ev_pos_meas = _ev_sample_delayed.posNED;
+				if (_params.fusion_mode & MASK_ROTATE_EV) {
+					ev_pos_meas = _ev_rot_mat * ev_pos_meas;
+				}
+				_vel_pos_innov[3] = _state.pos(0) - ev_pos_meas(0);
+				_vel_pos_innov[4] = _state.pos(1) - ev_pos_meas(1);
+				// observation 1-STD error
+				_posObsNoiseNE = fmaxf(_ev_sample_delayed.posErr, 0.01f);
 
 				// check if we have been deadreckoning too long
 				if ((_time_last_imu - _time_last_pos_fuse) > _params.reset_timeout_max) {
@@ -339,22 +339,22 @@ void Ekf::controlExternalVisionFusion()
 			}
 
 			// innovation gate size
-                        _posInnovGateNE = fmaxf(_params.ev_pos_innov_gate, 1.0f);
-                }else{
-                    _vel_pos_innov[3] = 0.0f;
-                    _vel_pos_innov[4] = 0.0f;
-                }
+			_posInnovGateNE = fmaxf(_params.ev_pos_innov_gate, 1.0f);
+		}else{
+			_vel_pos_innov[3] = 0.0f;
+			_vel_pos_innov[4] = 0.0f;
+		}
 
 		// determine if we should use the velocity observations
 		if (_control_status.flags.ev_vel) {
-                        _fuse_hor_vel = true;
-                        _fuse_vert_vel = true;
+			_fuse_hor_vel = true;
+			_fuse_vert_vel = true;
 
-                        Vector3f velNED_aligned{_ev_sample_delayed.velNED};
+			Vector3f velNED_aligned{_ev_sample_delayed.velNED};
 
 			// rotate measurement into correct earth frame if required
 			if (_params.fusion_mode & MASK_ROTATE_EV) {
-                                velNED_aligned = _ev_rot_mat * _ev_sample_delayed.velNED;
+				velNED_aligned = _ev_rot_mat * _ev_sample_delayed.velNED;
 			}
 
 			// correct velocity for offset relative to IMU
@@ -362,11 +362,11 @@ void Ekf::controlExternalVisionFusion()
 			Vector3f pos_offset_body = _params.ev_pos_body - _params.imu_pos_body;
 			Vector3f vel_offset_body = cross_product(ang_rate, pos_offset_body);
 			Vector3f vel_offset_earth = _R_to_earth * vel_offset_body;
-                        velNED_aligned -= vel_offset_earth;
+			velNED_aligned -= vel_offset_earth;
 
-                        _vel_pos_innov[0] = _state.vel(0) - velNED_aligned(0);
-                        _vel_pos_innov[1] = _state.vel(1) - velNED_aligned(1);
-                        _vel_pos_innov[2] = _state.vel(2) - velNED_aligned(2);
+			_vel_pos_innov[0] = _state.vel(0) - velNED_aligned(0);
+			_vel_pos_innov[1] = _state.vel(1) - velNED_aligned(1);
+			_vel_pos_innov[2] = _state.vel(2) - velNED_aligned(2);
 
 			// check if we have been deadreckoning too long
 			if ((_time_last_imu - _time_last_vel_fuse) > _params.reset_timeout_max) {
@@ -380,7 +380,7 @@ void Ekf::controlExternalVisionFusion()
 			_velObsVarNED(2) = _velObsVarNED(1) = _velObsVarNED(0) = fmaxf(_ev_sample_delayed.velErr, 0.01f);
 
 			// innovation gate size
-                        _vvelInnovGate = _hvelInnovGate = fmaxf(_params.ev_vel_innov_gate, 1.0f);
+			_vvelInnovGate = _hvelInnovGate = fmaxf(_params.ev_vel_innov_gate, 1.0f);
 		}
 
 		// Fuse available NED position data into the main filter
@@ -453,7 +453,7 @@ void Ekf::controlOpticalFlowFusion()
 		// Check if we are in-air and require optical flow to control position drift
 		bool flow_required = _control_status.flags.in_air &&
 				(_is_dead_reckoning // is doing inertial dead-reckoning so must constrain drift urgently
-                                  || (_control_status.flags.opt_flow && !_control_status.flags.gps && !_control_status.flags.ev_pos && !_control_status.flags.ev_vel) // is completely reliant on optical flow
+				  || (_control_status.flags.opt_flow && !_control_status.flags.gps && !_control_status.flags.ev_pos && !_control_status.flags.ev_vel) // is completely reliant on optical flow
 				  || (_control_status.flags.gps && (_gps_error_norm > gps_err_norm_lim))); // is using GPS, but GPS is bad
 
 		if (!_inhibit_flow_use && _control_status.flags.opt_flow) {
@@ -504,7 +504,7 @@ void Ekf::controlOpticalFlowFusion()
 				_time_last_of_fuse = _time_last_imu;
 
 				// if we are not using GPS or external vision aiding, then the velocity and position states and covariances need to be set
-                                const bool flow_aid_only = !(_control_status.flags.gps || _control_status.flags.ev_pos || _control_status.flags.ev_vel);
+				const bool flow_aid_only = !(_control_status.flags.gps || _control_status.flags.ev_pos || _control_status.flags.ev_vel);
 				if (flow_aid_only) {
 					resetVelocity();
 					resetPosition();
@@ -521,8 +521,8 @@ void Ekf::controlOpticalFlowFusion()
 		// handle the case when we have optical flow, are reliant on it, but have not been using it for an extended period
 		if (_control_status.flags.opt_flow
 		    && !_control_status.flags.gps
-                    && !_control_status.flags.ev_pos
-                    && !_control_status.flags.ev_vel) {
+		    && !_control_status.flags.ev_pos
+		    && !_control_status.flags.ev_vel) {
 
 			bool do_reset = ((_time_last_imu - _time_last_of_fuse) > _params.reset_timeout_max);
 
@@ -653,7 +653,7 @@ void Ekf::controlGpsFusion()
 		}
 
 		// Handle the case where we are using GPS and another source of aiding and GPS is failing checks
-                if (_control_status.flags.gps  && gps_checks_failing && (_control_status.flags.opt_flow || _control_status.flags.ev_pos || _control_status.flags.ev_vel)) {
+		if (_control_status.flags.gps  && gps_checks_failing && (_control_status.flags.opt_flow || _control_status.flags.ev_pos || _control_status.flags.ev_vel)) {
 			_control_status.flags.gps = false;
 			// Reset position state to external vision if we are going to use absolute values
 			if (_control_status.flags.ev_pos && !(_params.fusion_mode & MASK_ROTATE_EV)) {
@@ -715,7 +715,7 @@ void Ekf::controlGpsFusion()
 			// calculate observation process noise
 			float lower_limit = fmaxf(_params.gps_pos_noise, 0.01f);
 
-                        if (_control_status.flags.opt_flow || _control_status.flags.ev_pos || _control_status.flags.ev_vel) {
+			if (_control_status.flags.opt_flow || _control_status.flags.ev_pos || _control_status.flags.ev_vel) {
 				// if we are using other sources of aiding, then relax the upper observation
 				// noise limit which prevents bad GPS perturbing the position estimate
 				_posObsNoiseNE = fmaxf(_gps_sample_delayed.hacc, lower_limit);
@@ -737,14 +737,14 @@ void Ekf::controlGpsFusion()
 			_vel_pos_innov[4] = _state.pos(1) - _gps_sample_delayed.pos(1);
 
 			// set innovation gate size
-                        _posInnovGateNE = fmaxf(_params.gps_pos_innov_gate, 1.0f);
-                        _hvelInnovGate = _vvelInnovGate = fmaxf(_params.gps_vel_innov_gate, 1.0f);
+			_posInnovGateNE = fmaxf(_params.gps_pos_innov_gate, 1.0f);
+			_hvelInnovGate = _vvelInnovGate = fmaxf(_params.gps_vel_innov_gate, 1.0f);
 		}
 
 	} else if (_control_status.flags.gps && (_imu_sample_delayed.time_us - _gps_sample_delayed.time_us > (uint64_t)10e6)) {
 		_control_status.flags.gps = false;
 		ECL_WARN("EKF GPS data stopped");
-        }  else if (_control_status.flags.gps && (_imu_sample_delayed.time_us - _gps_sample_delayed.time_us > (uint64_t)1e6) && (_control_status.flags.opt_flow || _control_status.flags.ev_pos || _control_status.flags.ev_vel)) {
+	}  else if (_control_status.flags.gps && (_imu_sample_delayed.time_us - _gps_sample_delayed.time_us > (uint64_t)1e6) && (_control_status.flags.opt_flow || _control_status.flags.ev_pos || _control_status.flags.ev_vel)) {
 		// Handle the case where we are fusing another position source along GPS,
 		// stop waiting for GPS after 1 s of lost signal
 		_control_status.flags.gps = false;
@@ -1187,7 +1187,7 @@ void Ekf::rangeAidConditionsMet()
 			can_use_range_finder = (_terrain_vpos - _state.pos(2) < 0.7f * _params.max_hagl_for_range_aid) && get_terrain_valid();
 		}
 
-                bool horz_vel_valid = (_control_status.flags.gps || _control_status.flags.ev_pos || _control_status.flags.ev_vel || _control_status.flags.opt_flow)
+		bool horz_vel_valid = (_control_status.flags.gps || _control_status.flags.ev_pos || _control_status.flags.ev_vel || _control_status.flags.opt_flow)
 				      && (_fault_status.value == 0);
 
 		if (horz_vel_valid) {
@@ -1472,7 +1472,7 @@ void Ekf::controlMagFusion()
 				_yaw_angle_observable = _accel_lpf_NE.norm() > 2.0f * _params.mag_acc_gate;
 			}
 
-                        _yaw_angle_observable = _yaw_angle_observable && (_control_status.flags.gps || _control_status.flags.ev_pos); // Do we have to add ev_vel here?
+			_yaw_angle_observable = _yaw_angle_observable && (_control_status.flags.gps || _control_status.flags.ev_pos); // Do we have to add ev_vel here?
 
 			// check if there is enough yaw rotation to make the mag bias states observable
 			if (!_mag_bias_observable && (fabsf(_yaw_rate_lpf_ef) > _params.mag_yaw_rate_gate)) {
@@ -1611,10 +1611,10 @@ void Ekf::controlMagFusion()
 		// is available, assume that we are operating indoors and the magnetometer should not be used.
 		bool user_selected = (_params.mag_fusion_type == MAG_FUSE_TYPE_INDOOR);
 		bool not_using_gps = !(_params.fusion_mode & MASK_USE_GPS) || !_control_status.flags.gps;
-                bool not_using_evpos = !(_params.fusion_mode & MASK_USE_EVPOS) || !_control_status.flags.ev_pos;
-                bool not_using_evvel = !(_params.fusion_mode & MASK_USE_EVVEL) || !_control_status.flags.ev_vel;
-                bool not_selected_evyaw =  !(_params.fusion_mode & MASK_USE_EVYAW);
-                if (user_selected && not_using_gps && not_using_evpos && not_using_evvel && not_selected_evyaw) {
+		bool not_using_evpos = !(_params.fusion_mode & MASK_USE_EVPOS) || !_control_status.flags.ev_pos;
+		bool not_using_evvel = !(_params.fusion_mode & MASK_USE_EVVEL) || !_control_status.flags.ev_vel;
+		bool not_selected_evyaw =  !(_params.fusion_mode & MASK_USE_EVYAW);
+		if (user_selected && not_using_gps && not_using_evpos && not_using_evvel && not_selected_evyaw) {
 			_mag_use_inhibit = true;
 		} else {
 			_mag_use_inhibit = false;
@@ -1667,7 +1667,7 @@ void Ekf::controlVelPosFusion()
 	if (!_control_status.flags.gps &&
 	    !_control_status.flags.opt_flow &&
 	    !_control_status.flags.ev_pos &&
-            !_control_status.flags.ev_vel &&
+	    !_control_status.flags.ev_vel &&
 	    !(_control_status.flags.fuse_aspd && _control_status.flags.fuse_beta)) {
 
 		// We now need to use a synthetic position observation to prevent unconstrained drift of the INS states.
@@ -1724,7 +1724,7 @@ void Ekf::controlVelPosFusion()
 void Ekf::controlAuxVelFusion()
 {
 	bool data_ready = _auxvel_buffer.pop_first_older_than(_imu_sample_delayed.time_us, &_auxvel_sample_delayed);
-        bool primary_aiding = _control_status.flags.gps || _control_status.flags.ev_pos || _control_status.flags.ev_vel || _control_status.flags.opt_flow;
+	bool primary_aiding = _control_status.flags.gps || _control_status.flags.ev_pos || _control_status.flags.ev_vel || _control_status.flags.opt_flow;
 
 	if (data_ready && primary_aiding) {
 		_fuse_hor_vel = _fuse_vert_vel = _fuse_pos = _fuse_height = false;

--- a/EKF/control.cpp
+++ b/EKF/control.cpp
@@ -652,7 +652,7 @@ void Ekf::controlGpsFusion()
 		}
 
 		// Handle the case where we are using GPS and another source of aiding and GPS is failing checks
-		if (_control_status.flags.gps  && gps_checks_failing && (_control_status.flags.opt_flow || _control_status.flags.ev_pos)) {
+                if (_control_status.flags.gps  && gps_checks_failing && (_control_status.flags.opt_flow || _control_status.flags.ev_pos || _control_status.flags.ev_vel)) {
 			_control_status.flags.gps = false;
 			// Reset position state to external vision if we are going to use absolute values
 			if (_control_status.flags.ev_pos && !(_params.fusion_mode & MASK_ROTATE_EV)) {

--- a/EKF/control.cpp
+++ b/EKF/control.cpp
@@ -279,9 +279,9 @@ void Ekf::controlExternalVisionFusion()
 			// correct position and height for offset relative to IMU
 			Vector3f pos_offset_body = _params.ev_pos_body - _params.imu_pos_body;
 			Vector3f pos_offset_earth = _R_to_earth * pos_offset_body;
-			_ev_sample_delayed.posNED(0) -= pos_offset_earth(0);
-			_ev_sample_delayed.posNED(1) -= pos_offset_earth(1);
-			_ev_sample_delayed.posNED(2) -= pos_offset_earth(2);
+			_ev_sample_delayed.pos(0) -= pos_offset_earth(0);
+			_ev_sample_delayed.pos(1) -= pos_offset_earth(1);
+			_ev_sample_delayed.pos(2) -= pos_offset_earth(2);
 
 			// Use an incremental position fusion method for EV position data if GPS is also used
 			if (_params.fusion_mode & MASK_USE_GPS) {
@@ -298,7 +298,7 @@ void Ekf::controlExternalVisionFusion()
 
 				} else {
 					// calculate the change in position since the last measurement
-					Vector3f ev_delta_pos = _ev_sample_delayed.posNED - _pos_meas_prev;
+					Vector3f ev_delta_pos = _ev_sample_delayed.pos - _pos_meas_prev;
 
 					// rotate measurement into body frame is required when fusing with GPS
 					ev_delta_pos = _ev_rot_mat * ev_delta_pos;
@@ -312,13 +312,13 @@ void Ekf::controlExternalVisionFusion()
 				}
 
 				// record observation and estimate for use next time
-				_pos_meas_prev = _ev_sample_delayed.posNED;
+				_pos_meas_prev = _ev_sample_delayed.pos;
 				_hpos_pred_prev(0) = _state.pos(0);
 				_hpos_pred_prev(1) = _state.pos(1);
 
 			} else {
 				// use the absolute position
-				Vector3f ev_pos_meas = _ev_sample_delayed.posNED;
+				Vector3f ev_pos_meas = _ev_sample_delayed.pos;
 				if (_params.fusion_mode & MASK_ROTATE_EV) {
 					ev_pos_meas = _ev_rot_mat * ev_pos_meas;
 				}
@@ -350,11 +350,11 @@ void Ekf::controlExternalVisionFusion()
 			_fuse_hor_vel = true;
 			_fuse_vert_vel = true;
 
-			Vector3f velNED_aligned{_ev_sample_delayed.velNED};
+			Vector3f vel_aligned{_ev_sample_delayed.vel};
 
 			// rotate measurement into correct earth frame if required
 			if (_params.fusion_mode & MASK_ROTATE_EV) {
-				velNED_aligned = _ev_rot_mat * _ev_sample_delayed.velNED;
+				vel_aligned = _ev_rot_mat * _ev_sample_delayed.vel;
 			}
 
 			// correct velocity for offset relative to IMU
@@ -362,11 +362,11 @@ void Ekf::controlExternalVisionFusion()
 			Vector3f pos_offset_body = _params.ev_pos_body - _params.imu_pos_body;
 			Vector3f vel_offset_body = cross_product(ang_rate, pos_offset_body);
 			Vector3f vel_offset_earth = _R_to_earth * vel_offset_body;
-			velNED_aligned -= vel_offset_earth;
+			vel_aligned -= vel_offset_earth;
 
-			_vel_pos_innov[0] = _state.vel(0) - velNED_aligned(0);
-			_vel_pos_innov[1] = _state.vel(1) - velNED_aligned(1);
-			_vel_pos_innov[2] = _state.vel(2) - velNED_aligned(2);
+			_vel_pos_innov[0] = _state.vel(0) - vel_aligned(0);
+			_vel_pos_innov[1] = _state.vel(1) - vel_aligned(1);
+			_vel_pos_innov[2] = _state.vel(2) - vel_aligned(2);
 
 			// check if we have been deadreckoning too long
 			if ((_time_last_imu - _time_last_vel_fuse) > _params.reset_timeout_max) {

--- a/EKF/control.cpp
+++ b/EKF/control.cpp
@@ -736,8 +736,8 @@ void Ekf::controlGpsFusion()
 			_vel_pos_innov[4] = _state.pos(1) - _gps_sample_delayed.pos(1);
 
 			// set innovation gate size
-			_posInnovGateNE = fmaxf(_params.posNE_innov_gate, 1.0f);
-			_hvelInnovGate = fmaxf(_params.vel_innov_gate, 1.0f);
+                        _posInnovGateNE = fmaxf(_params.gps_pos_innov_gate, 1.0f);
+                        _hvelInnovGate = _vvelInnovGate = fmaxf(_params.gps_vel_innov_gate, 1.0f);
 		}
 
 	} else if (_control_status.flags.gps && (_imu_sample_delayed.time_us - _gps_sample_delayed.time_us > (uint64_t)10e6)) {

--- a/EKF/ekf.h
+++ b/EKF/ekf.h
@@ -298,17 +298,19 @@ private:
 	float _posObsNoiseNE{0.0f};		///< 1-STD observation noise used for the fusion of NE position data (m)
 	float _posInnovGateNE{1.0f};		///< Number of standard deviations used for the NE position fusion innovation consistency check
 
-	Vector2f _velObsVarNE;		///< 1-STD observation noise variance used for the fusion of NE velocity data (m/sec)**2
-	float _hvelInnovGate{1.0f};		///< Number of standard deviations used for the horizontal velocity fusion innovation consistency check
+	Vector3f _velObsVarNED;		///< 1-STD observation noise variance used for the fusion of NED velocity data (m/sec)**2
+	float _hvelInnovGate{1.0f};	///< Number of standard deviations used for the horizontal velocity fusion innovation consistency check
+	float _vvelInnovGate{1.0f};	///< Number of standard deviations used for the vertical velocity fusion innovation consistency check
 
 	// variables used when position data is being fused using a relative position odometry model
 	bool _fuse_hpos_as_odom{false};		///< true when the NE position data is being fused using an odometry assumption
 	Vector3f _pos_meas_prev;		///< previous value of NED position measurement fused using odometry assumption (m)
 	Vector2f _hpos_pred_prev;		///< previous value of NE position state used by odometry fusion (m)
 	bool _hpos_prev_available{false};	///< true when previous values of the estimate and measurement are available for use
-	Vector3f _ev_rot_vec_filt;		///< filtered rotation vector defining the rotation from EKF to EV reference (rad)
-	Dcmf _ev_rot_mat;			///< transformation matrix that rotates observations from the EV to the EKF navigation frame
-	uint64_t _ev_rot_last_time_us{0};	///< previous time that the calculation of the ekf to ev rotation matrix was updated (uSec)
+	Vector3f _ev_rot_vec_filt;		///< filtered rotation vector defining the rotation EV to EKF reference, initiliazied to zero rotation  (rad)
+	Dcmf _ev_rot_mat;			///< transformation matrix that rotates observations from the EV to the EKF navigation frame, initialized with Identity
+	uint64_t _ev_rot_last_time_us{0};	///< previous time that the calculation of the EV to EKF rotation matrix was updated (uSec)
+        bool _ev_rot_mat_initialised{0};	///< _ev_rot_mat should only be initialised once in the beginning through the reset function
 
 	// booleans true when fresh sensor data is available at the fusion time horizon
 	bool _gps_data_ready{false};	///< true when new GPS data has fallen behind the fusion time horizon and is available to be fused

--- a/EKF/ekf.h
+++ b/EKF/ekf.h
@@ -310,7 +310,7 @@ private:
 	Vector3f _ev_rot_vec_filt;		///< filtered rotation vector defining the rotation EV to EKF reference, initiliazied to zero rotation  (rad)
 	Dcmf _ev_rot_mat;			///< transformation matrix that rotates observations from the EV to the EKF navigation frame, initialized with Identity
 	uint64_t _ev_rot_last_time_us{0};	///< previous time that the calculation of the EV to EKF rotation matrix was updated (uSec)
-        bool _ev_rot_mat_initialised{0};	///< _ev_rot_mat should only be initialised once in the beginning through the reset function
+	bool _ev_rot_mat_initialised{0};	///< _ev_rot_mat should only be initialised once in the beginning through the reset function
 
 	// booleans true when fresh sensor data is available at the fusion time horizon
 	bool _gps_data_ready{false};	///< true when new GPS data has fallen behind the fusion time horizon and is available to be fused

--- a/EKF/ekf_helper.cpp
+++ b/EKF/ekf_helper.cpp
@@ -53,7 +53,7 @@ bool Ekf::resetVelocity()
 	Vector3f vel_before_reset = _state.vel;
 
 	// reset EKF states
-        if (_control_status.flags.gps && _gps_check_fail_status.value==0) {
+	if (_control_status.flags.gps && _gps_check_fail_status.value==0) {
 		// this reset is only called if we have new gps data at the fusion time horizon
 		_state.vel = _gps_sample_delayed.vel;
 
@@ -94,16 +94,16 @@ bool Ekf::resetVelocity()
 
 		// reset the horizontal velocity variance using the optical flow noise variance
 		P[5][5] = P[4][4] = sq(range) * calcOptFlowMeasVar();
-        } else if (_control_status.flags.ev_vel) {
-                Vector3f _ev_vel = _ev_sample_delayed.velNED;
-                if(_params.fusion_mode & MASK_ROTATE_EV){
-                    _ev_vel = _ev_rot_mat *_ev_sample_delayed.velNED;
-                }
-                _state.vel(0) = _ev_vel(0);
-                _state.vel(1) = _ev_vel(1);
-                _state.vel(2) = _ev_vel(2);
-                // TODO: to what should we set the covariances?
-        } else if (_control_status.flags.ev_pos) {
+	} else if (_control_status.flags.ev_vel) {
+		Vector3f _ev_vel = _ev_sample_delayed.velNED;
+		if(_params.fusion_mode & MASK_ROTATE_EV){
+			_ev_vel = _ev_rot_mat *_ev_sample_delayed.velNED;
+		}
+		_state.vel(0) = _ev_vel(0);
+		_state.vel(1) = _ev_vel(1);
+		_state.vel(2) = _ev_vel(2);
+		// TODO: to what should we set the covariances?
+	} else if (_control_status.flags.ev_pos) {
 		_state.vel.setZero();
 		zeroOffDiag(P, 4, 6);
 	} else {
@@ -156,12 +156,12 @@ bool Ekf::resetPosition()
 
 	} else if (_control_status.flags.ev_pos) {
 		// this reset is only called if we have new ev data at the fusion time horizon
-                Vector3f _ev_pos = _ev_sample_delayed.posNED;
-                if(_params.fusion_mode & MASK_ROTATE_EV){
-                    _ev_pos = _ev_rot_mat *_ev_sample_delayed.posNED;
-                }
-                _state.pos(0) = _ev_pos(0);
-                _state.pos(1) = _ev_pos(1);
+		Vector3f _ev_pos = _ev_sample_delayed.posNED;
+		if(_params.fusion_mode & MASK_ROTATE_EV){
+			_ev_pos = _ev_rot_mat *_ev_sample_delayed.posNED;
+		}
+		_state.pos(0) = _ev_pos(0);
+		_state.pos(1) = _ev_pos(1);
 
 		// use EV accuracy to reset variances
 		setDiag(P, 7, 8, sq(_ev_sample_delayed.posErr));
@@ -1085,10 +1085,10 @@ void Ekf::get_ekf_vel_accuracy(float *ekf_evh, float *ekf_evv)
 			vel_err_conservative = math::max(vel_err_conservative, sqrtf(sq(_vel_pos_innov[0]) + sq(_vel_pos_innov[1])));
 		}
 
-                if (_control_status.flags.ev_vel) {
-                    // What is the right thing to do here
+		if (_control_status.flags.ev_vel) {
+			// What is the right thing to do here
 //			vel_err_conservative = math::max(vel_err_conservative, sqrtf(sq(_vel_pos_innov[0]) + sq(_vel_pos_innov[1])));
-                }
+		}
 
 		hvel_err = math::max(hvel_err, vel_err_conservative);
 	}
@@ -1208,7 +1208,7 @@ void Ekf::get_ekf_soln_status(uint16_t *status)
 	ekf_solution_status soln_status;
 
 	soln_status.flags.attitude = _control_status.flags.tilt_align && _control_status.flags.yaw_align && (_fault_status.value == 0);
-        soln_status.flags.velocity_horiz = (_control_status.flags.gps || _control_status.flags.ev_pos|| _control_status.flags.ev_vel || _control_status.flags.opt_flow || (_control_status.flags.fuse_beta && _control_status.flags.fuse_aspd)) && (_fault_status.value == 0);
+	soln_status.flags.velocity_horiz = (_control_status.flags.gps || _control_status.flags.ev_pos|| _control_status.flags.ev_vel || _control_status.flags.opt_flow || (_control_status.flags.fuse_beta && _control_status.flags.fuse_aspd)) && (_fault_status.value == 0);
 	soln_status.flags.velocity_vert = (_control_status.flags.baro_hgt || _control_status.flags.ev_hgt || _control_status.flags.gps_hgt || _control_status.flags.rng_hgt) && (_fault_status.value == 0);
 	soln_status.flags.pos_horiz_rel = (_control_status.flags.gps || _control_status.flags.ev_pos || _control_status.flags.opt_flow) && (_fault_status.value == 0);
 	soln_status.flags.pos_horiz_abs = (_control_status.flags.gps || _control_status.flags.ev_pos) && (_fault_status.value == 0);

--- a/EKF/ekf_helper.cpp
+++ b/EKF/ekf_helper.cpp
@@ -1336,7 +1336,7 @@ bool Ekf::global_position_is_valid()
 // return true if we are totally reliant on inertial dead-reckoning for position
 void Ekf::update_deadreckoning_status()
 {
-	bool velPosAiding = (_control_status.flags.gps || _control_status.flags.ev_pos)
+	bool velPosAiding = (_control_status.flags.gps || _control_status.flags.ev_pos || _control_status.flags.ev_vel)
 			    && (((_time_last_imu - _time_last_pos_fuse) <= _params.no_aid_timeout_max)
 				|| ((_time_last_imu - _time_last_vel_fuse) <= _params.no_aid_timeout_max)
 				|| ((_time_last_imu - _time_last_delpos_fuse) <= _params.no_aid_timeout_max));

--- a/EKF/ekf_helper.cpp
+++ b/EKF/ekf_helper.cpp
@@ -1121,7 +1121,7 @@ void Ekf::get_ekf_ctrl_limits(float *vxy_max, float *vz_max, float *hagl_min, fl
 
 	bool relying_on_rangefinder = _control_status.flags.rng_hgt && !_params.range_aid;
 
-        bool relying_on_optical_flow = _control_status.flags.opt_flow && !(_control_status.flags.gps || _control_status.flags.ev_pos || _control_status.flags.ev_vel);
+	bool relying_on_optical_flow = _control_status.flags.opt_flow && !(_control_status.flags.gps || _control_status.flags.ev_pos || _control_status.flags.ev_vel);
 
 	// Do not require limiting by default
 	*vxy_max = NAN;

--- a/EKF/ekf_helper.cpp
+++ b/EKF/ekf_helper.cpp
@@ -95,14 +95,14 @@ bool Ekf::resetVelocity()
 		// reset the horizontal velocity variance using the optical flow noise variance
 		P[5][5] = P[4][4] = sq(range) * calcOptFlowMeasVar();
 	} else if (_control_status.flags.ev_vel) {
-		Vector3f _ev_vel = _ev_sample_delayed.velNED;
+		Vector3f _ev_vel = _ev_sample_delayed.vel;
 		if(_params.fusion_mode & MASK_ROTATE_EV){
-			_ev_vel = _ev_rot_mat *_ev_sample_delayed.velNED;
+			_ev_vel = _ev_rot_mat *_ev_sample_delayed.vel;
 		}
 		_state.vel(0) = _ev_vel(0);
 		_state.vel(1) = _ev_vel(1);
 		_state.vel(2) = _ev_vel(2);
-		// TODO: to what should we set the covariances?
+		setDiag(P, 4, 6, sq(_ev_sample_delayed.velErr));
 	} else if (_control_status.flags.ev_pos) {
 		_state.vel.setZero();
 		zeroOffDiag(P, 4, 6);
@@ -156,9 +156,9 @@ bool Ekf::resetPosition()
 
 	} else if (_control_status.flags.ev_pos) {
 		// this reset is only called if we have new ev data at the fusion time horizon
-		Vector3f _ev_pos = _ev_sample_delayed.posNED;
+		Vector3f _ev_pos = _ev_sample_delayed.pos;
 		if(_params.fusion_mode & MASK_ROTATE_EV){
-			_ev_pos = _ev_rot_mat *_ev_sample_delayed.posNED;
+			_ev_pos = _ev_rot_mat *_ev_sample_delayed.pos;
 		}
 		_state.pos(0) = _ev_pos(0);
 		_state.pos(1) = _ev_pos(1);
@@ -308,10 +308,10 @@ void Ekf::resetHeight()
 		vert_pos_reset = true;
 
 		if (std::abs(dt_newest) < std::abs(dt_delayed)) {
-			_state.pos(2) = ev_newest.posNED(2);
+			_state.pos(2) = ev_newest.pos(2);
 
 		} else {
-			_state.pos(2) = _ev_sample_delayed.posNED(2);
+			_state.pos(2) = _ev_sample_delayed.pos(2);
 		}
 
 	}

--- a/EKF/estimator_interface.cpp
+++ b/EKF/estimator_interface.cpp
@@ -442,9 +442,11 @@ void EstimatorInterface::setExtVisionData(uint64_t time_usec, ext_vision_message
 		// copy required data
 		ev_sample_new.angErr = evdata->angErr;
 		ev_sample_new.posErr = evdata->posErr;
+		ev_sample_new.velErr = evdata->velErr;
 		ev_sample_new.hgtErr = evdata->hgtErr;
 		ev_sample_new.quat = evdata->quat;
 		ev_sample_new.posNED = evdata->posNED;
+		ev_sample_new.velNED = evdata->velNED;
 
 		// record time for comparison next measurement
 		_time_last_ext_vision = time_usec;

--- a/EKF/estimator_interface.cpp
+++ b/EKF/estimator_interface.cpp
@@ -445,8 +445,8 @@ void EstimatorInterface::setExtVisionData(uint64_t time_usec, ext_vision_message
 		ev_sample_new.velErr = evdata->velErr;
 		ev_sample_new.hgtErr = evdata->hgtErr;
 		ev_sample_new.quat = evdata->quat;
-		ev_sample_new.posNED = evdata->posNED;
-		ev_sample_new.velNED = evdata->velNED;
+		ev_sample_new.pos = evdata->pos;
+		ev_sample_new.vel = evdata->vel;
 
 		// record time for comparison next measurement
 		_time_last_ext_vision = time_usec;

--- a/EKF/estimator_interface.cpp
+++ b/EKF/estimator_interface.cpp
@@ -384,7 +384,7 @@ void EstimatorInterface::setOpticalFlowData(uint64_t time_usec, flow_message *fl
 			flow_magnitude_good = (flow_rate_magnitude <= _flow_max_rate);
 		}
 
-                bool relying_on_flow = !_control_status.flags.gps && !_control_status.flags.ev_pos && !_control_status.flags.ev_vel;
+		bool relying_on_flow = !_control_status.flags.gps && !_control_status.flags.ev_pos && !_control_status.flags.ev_vel;
 
 		// check quality metric
 		bool flow_quality_good = (flow->quality >= _params.flow_qual_min);

--- a/EKF/estimator_interface.cpp
+++ b/EKF/estimator_interface.cpp
@@ -384,7 +384,7 @@ void EstimatorInterface::setOpticalFlowData(uint64_t time_usec, flow_message *fl
 			flow_magnitude_good = (flow_rate_magnitude <= _flow_max_rate);
 		}
 
-		bool relying_on_flow = !_control_status.flags.gps && !_control_status.flags.ev_pos;
+                bool relying_on_flow = !_control_status.flags.gps && !_control_status.flags.ev_pos && !_control_status.flags.ev_vel;
 
 		// check quality metric
 		bool flow_quality_good = (flow->quality >= _params.flow_qual_min);

--- a/EKF/gps_checks.cpp
+++ b/EKF/gps_checks.cpp
@@ -67,7 +67,7 @@ bool Ekf::collect_gps(const gps_message &gps)
 		map_projection_init_timestamped(&_pos_ref, lat, lon, _time_last_imu);
 
 		// if we are already doing aiding, correct for the change in position since the EKF started navigationg
-                if (_control_status.flags.opt_flow || _control_status.flags.gps || _control_status.flags.ev_pos || _control_status.flags.ev_vel) {
+		if (_control_status.flags.opt_flow || _control_status.flags.gps || _control_status.flags.ev_pos || _control_status.flags.ev_vel) {
 			double est_lat, est_lon;
 			map_projection_reproject(&_pos_ref, -_state.pos(0), -_state.pos(1), &est_lat, &est_lon);
 			map_projection_init_timestamped(&_pos_ref, est_lat, est_lon, _time_last_imu);

--- a/EKF/gps_checks.cpp
+++ b/EKF/gps_checks.cpp
@@ -67,7 +67,7 @@ bool Ekf::collect_gps(const gps_message &gps)
 		map_projection_init_timestamped(&_pos_ref, lat, lon, _time_last_imu);
 
 		// if we are already doing aiding, correct for the change in position since the EKF started navigationg
-		if (_control_status.flags.opt_flow || _control_status.flags.gps || _control_status.flags.ev_pos) {
+                if (_control_status.flags.opt_flow || _control_status.flags.gps || _control_status.flags.ev_pos || _control_status.flags.ev_vel) {
 			double est_lat, est_lon;
 			map_projection_reproject(&_pos_ref, -_state.pos(0), -_state.pos(1), &est_lat, &est_lon);
 			map_projection_init_timestamped(&_pos_ref, est_lat, est_lon, _time_last_imu);

--- a/EKF/vel_pos_fusion.cpp
+++ b/EKF/vel_pos_fusion.cpp
@@ -168,6 +168,8 @@ void Ekf::fuseVelPosHeight()
 			// Compute the ratio of innovation to gate size
 			_vel_pos_test_ratio[obs_index] = sq(innovation[obs_index]) / (sq(gate_size[obs_index]) *
 							 _vel_pos_innov_var[obs_index]);
+		}else{
+			_vel_pos_test_ratio[obs_index] = 0;
 		}
 	}
 

--- a/EKF/vel_pos_fusion.cpp
+++ b/EKF/vel_pos_fusion.cpp
@@ -147,7 +147,7 @@ void Ekf::fuseVelPosHeight()
 		} else if (_control_status.flags.ev_hgt) {
 			fuse_map[5] = true;
 			// calculate the innovation assuming the external vision observation is in local NED frame
-			innovation[5] = _state.pos(2) - _ev_sample_delayed.posNED(2);
+			innovation[5] = _state.pos(2) - _ev_sample_delayed.pos(2);
 			// observation variance - defined externally
 			R[5] = fmaxf(_ev_sample_delayed.hgtErr, 0.01f);
 			R[5] = R[5] * R[5];

--- a/EKF/vel_pos_fusion.cpp
+++ b/EKF/vel_pos_fusion.cpp
@@ -67,8 +67,8 @@ void Ekf::fuseVelPosHeight()
 		}
 
 		// Set observation noise variance and innovation consistency check gate size for the NE position observations
-		R[0] = _velObsVarNE(0);
-		R[1] = _velObsVarNE(1);
+		R[0] = _velObsVarNED(0);
+		R[1] = _velObsVarNED(1);
 		gate_size[1] = gate_size[0] = _hvelInnovGate;
 
 	}
@@ -76,12 +76,12 @@ void Ekf::fuseVelPosHeight()
 	if (_fuse_vert_vel) {
 		fuse_map[2] = true;
 		// observation variance - use receiver reported accuracy with parameter setting the minimum value
-		R[2] = fmaxf(_params.gps_vel_noise, 0.01f);
+		R[2] = _velObsVarNED(2);
 		// use scaled horizontal speed accuracy assuming typical ratio of VDOP/HDOP
 		R[2] = 1.5f * fmaxf(R[2], _gps_sample_delayed.sacc);
 		R[2] = R[2] * R[2];
 		// innovation gate size
-		gate_size[2] = fmaxf(_params.vel_innov_gate, 1.0f);
+		gate_size[2] = _vvelInnovGate;
 	}
 
 	if (_fuse_pos) {
@@ -152,7 +152,7 @@ void Ekf::fuseVelPosHeight()
 			R[5] = fmaxf(_ev_sample_delayed.hgtErr, 0.01f);
 			R[5] = R[5] * R[5];
 			// innovation gate size
-			gate_size[5] = fmaxf(_params.ev_innov_gate, 1.0f);
+                        gate_size[5] = fmaxf(_params.ev_pos_innov_gate, 1.0f);
 		}
 
 		// update innovation class variable for logging purposes

--- a/EKF/vel_pos_fusion.cpp
+++ b/EKF/vel_pos_fusion.cpp
@@ -152,7 +152,7 @@ void Ekf::fuseVelPosHeight()
 			R[5] = fmaxf(_ev_sample_delayed.hgtErr, 0.01f);
 			R[5] = R[5] * R[5];
 			// innovation gate size
-                        gate_size[5] = fmaxf(_params.ev_pos_innov_gate, 1.0f);
+			gate_size[5] = fmaxf(_params.ev_pos_innov_gate, 1.0f);
 		}
 
 		// update innovation class variable for logging purposes


### PR DESCRIPTION
This PR allows ECL to fuse velocity measurements from an external vision sensor such as the Realsense T265. In addition, it also improves on the external vision position fusion, such that the external vision measurement fusion is no usable with several EKF_AID_MASK configurations. 

Supported configuration for the EKF_AID_MASK are:
1      -     GPS
73    -     GPS + EV_POS + ROTATE_EV (incremental ev pos fusion, not recommended, use EV_VEL instead)
321  -     GPS + EV_VEL  + ROTATE_EV (recommended)
24    -     EV_POS + EV_YAW
72    -     EV_POS + ROTATE_EV
272  -     EV_VEL + EV_YAW
320  -     EV_VEL + ROTATE_EV
280  -     EV_POS + EV_VEL + EV_YAW
328  -     EV_POS + EV_VEL + ROTATE_EV

If you use no GPS information, you are now free to decide if you want your EKF reference frame to be aligned with true ENU frame (use ROTATE_EV) or aligned with the external vision reference frame (use EV_YAW).

The EKF_AID_MASK = 9 (GPS + EV_POS) is not supported and should not be used.

All these configurations are tested in EKF replay on log: https://review.px4.io/plot_app?log=bd994025-2312-4ee9-a7b2-f6ab2d65c6b8 and the majority of the configurations were validated on real world test flights.
Make sure to have EVV_NOISE=0.1, EVV_GATE=3, EVP_NOISE=0.1 and EVP_GATE=5.

@priseborough Thank you very much for your great help and your valuable inputs.
#631 #397 