### PR TITLE
Enhancement: Increased robustness against 0 signal quality and cleanup range data handling

### DIFF
--- a/EKF/CMakeLists.txt
+++ b/EKF/CMakeLists.txt
@@ -46,6 +46,7 @@ add_library(ecl_EKF
 	terrain_estimator.cpp
 	vel_pos_fusion.cpp
 	gps_yaw_fusion.cpp
+	range_finder_checks.cpp
 )
 
 add_dependencies(ecl_EKF prebuild_targets)

--- a/EKF/common.h
+++ b/EKF/common.h
@@ -298,6 +298,7 @@ struct parameters {
 	float range_aid_innov_gate{1.0f}; 	///< gate size used for innovation consistency checks for range aid fusion
 	float range_cos_max_tilt{0.7071f};	///< cosine of the maximum tilt angle from the vertical that permits use of range finder and flow data
 	float range_stuck_threshold{0.1f};	///< minimum variation in range finder reading required to declare a range finder 'unstuck' when readings recommence after being out of range (m)
+	int32_t range_signal_hysteresis_ms{1000}; 	///< minimum duration during which the reported range finder signal quality needs to be non-zero in order to be declared valid (ms)
 
 	// vision position fusion
         float ev_vel_innov_gate{3.0f};		///< vision velocity fusion innovation consistency gate size (STD)

--- a/EKF/control.cpp
+++ b/EKF/control.cpp
@@ -1176,7 +1176,7 @@ void Ekf::checkRangeAidSuitability()
 				    || _control_status.flags.opt_flow;
 
 	if (_control_status.flags.in_air
-	    && !_rng_hgt_faulty
+	    && _rng_hgt_valid
 	    && isTerrainEstimateValid()
 	    && horz_vel_valid) {
 		// check if we can use range finder measurements to estimate height, use hysteresis to avoid rapid switching

--- a/EKF/ekf.h
+++ b/EKF/ekf.h
@@ -457,7 +457,6 @@ private:
 	float _sin_tilt_rng{0.0f};		///< sine of the range finder tilt rotation about the Y body axis
 	float _cos_tilt_rng{0.0f};		///< cosine of the range finder tilt rotation about the Y body axis
 	float _R_rng_to_earth_2_2{0.0f};	///< 2,2 element of the rotation matrix from sensor frame to earth frame
-	bool _range_data_continuous{false};	///< true when we are receiving range finder data faster than a 2Hz average
 	float _dt_last_range_update_filt_us{0.0f};	///< filtered value of the delta time elapsed since the last range measurement came into the filter (uSec)
 	bool _hagl_valid{false};		///< true when the height above ground estimate is valid
 
@@ -648,8 +647,11 @@ private:
 	void checkRangeAidSuitability();
 	bool isRangeAidSuitable() { return _is_range_aid_suitable; }
 
-	// check for "stuck" range finder measurements when rng was not valid for certain period
+	// update _rng_hgt_valid, which indicates if the current range sample has passed validity checks
 	void updateRangeDataValidity();
+
+	// check for "stuck" range finder measurements when rng was not valid for certain period
+	void updateRangeDataStuck();
 
 	// return the square of two floating point numbers - used in auto coded sections
 	static constexpr float sq(float var) { return var * var; }
@@ -699,6 +701,8 @@ private:
 
 	// check that the range finder data is continuous
 	void updateRangeDataContinuity();
+
+	bool isRangeDataContinuous() { return _dt_last_range_update_filt_us < 2e6f; }
 
 	// Increase the yaw error variance of the quaternions
 	// Argument is additional yaw variance in rad**2

--- a/EKF/ekf.h
+++ b/EKF/ekf.h
@@ -464,8 +464,9 @@ private:
 	// height sensor status
 	bool _baro_hgt_faulty{false};		///< true if valid baro data is unavailable for use
 	bool _gps_hgt_intermittent{false};	///< true if gps height into the buffer is intermittent
-	bool _rng_hgt_faulty{false};		///< true if valid range finder height data is unavailable for use
+	bool _rng_hgt_valid{false};		///< true if range finder sample retrieved from buffer is valid
 	int _primary_hgt_source{VDIST_SENSOR_BARO};	///< specifies primary source of height data
+	uint64_t _time_bad_rng_signal_quality{0};	///< timestamp at which range finder signal quality was 0 (used for hysteresis)
 
 	// imu fault status
 	uint64_t _time_bad_vert_accel{0};	///< last time a bad vertical accel was detected (uSec)
@@ -648,7 +649,7 @@ private:
 	bool isRangeAidSuitable() { return _is_range_aid_suitable; }
 
 	// check for "stuck" range finder measurements when rng was not valid for certain period
-	void checkRangeDataValidity();
+	void updateRangeDataValidity();
 
 	// return the square of two floating point numbers - used in auto coded sections
 	static constexpr float sq(float var) { return var * var; }
@@ -697,7 +698,7 @@ private:
 	void resetWindStates();
 
 	// check that the range finder data is continuous
-	void checkRangeDataContinuity();
+	void updateRangeDataContinuity();
 
 	// Increase the yaw error variance of the quaternions
 	// Argument is additional yaw variance in rad**2

--- a/EKF/range_finder_checks.cpp
+++ b/EKF/range_finder_checks.cpp
@@ -1,0 +1,144 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2019 Estimation and Control Library (ECL). All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name ECL nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * @file range_finder_checks.cpp
+ * Perform checks on range finder data in order to evaluate validity.
+ *
+ *
+ */
+
+#include "ekf.h"
+
+
+#define RNG_BAD_SIG_HYST (uint64_t)3e6	// range finder data needs to have 3 seconds of non-zero signal quality to be valid
+
+// check that the range finder data is continuous
+void Ekf::updateRangeDataContinuity()
+{
+	// update range data continuous flag (1Hz ie 2000 ms)
+	/* Timing in micro seconds */
+
+	/* Apply a 2.0 sec low pass filter to the time delta from the last range finder updates */
+	float alpha = 0.5f * _dt_update;
+	_dt_last_range_update_filt_us = _dt_last_range_update_filt_us * (1.0f - alpha) + alpha *
+					(_imu_sample_delayed.time_us - _range_sample_delayed.time_us);
+
+	_dt_last_range_update_filt_us = fminf(_dt_last_range_update_filt_us, 4e6f);
+
+	if (_dt_last_range_update_filt_us < 2e6f) {
+		_range_data_continuous = true;
+
+	} else {
+		_range_data_continuous = false;
+	}
+}
+
+void Ekf::updateRangeDataValidity()
+{
+	updateRangeDataContinuity();
+
+	// check if out of date
+	if ((_imu_sample_delayed.time_us - _range_sample_delayed .time_us) > 2 * RNG_MAX_INTERVAL) {
+		_rng_hgt_valid = false;
+		return;
+	}
+
+	// Don't allow faulty flag to clear unless range data is continuous
+	if (!_rng_hgt_valid && !_range_data_continuous) {
+		return;
+	}
+
+	// Don't run the checks after this unless we have retrieved new data from the buffer
+	if (!_range_data_ready) {
+		return;
+	}
+
+	if (_range_sample_delayed.quality == 0) {
+		_time_bad_rng_signal_quality = _imu_sample_delayed.time_us;
+		_rng_hgt_valid = false;
+	} else if (_time_bad_rng_signal_quality > 0 && _imu_sample_delayed.time_us - _time_bad_rng_signal_quality > RNG_BAD_SIG_HYST) {
+		_time_bad_rng_signal_quality = 0;
+		_rng_hgt_valid = true;
+	}
+
+	// Check if excessively tilted
+	if (_R_rng_to_earth_2_2 < _params.range_cos_max_tilt) {
+		_rng_hgt_valid = false;
+		return;
+	}
+
+	// Check if out of range
+	if ((_range_sample_delayed.rng > _rng_valid_max_val)
+	|| (_range_sample_delayed.rng < _rng_valid_min_val)) {
+		if (_control_status.flags.in_air) {
+			_rng_hgt_valid = false;
+			return;
+		} else {
+			// Range finders can fail to provide valid readings when resting on the ground
+			// or being handled by the user, which prevents use of as a primary height sensor.
+			// To work around this issue, we replace out of range data with the expected on ground value.
+			_range_sample_delayed.rng = _params.rng_gnd_clearance;
+			return;
+		}
+	}
+
+	// Check for "stuck" range finder measurements when range was not valid for certain period
+	// This handles a failure mode observed with some lidar sensors
+	if (((_range_sample_delayed.time_us - _time_last_rng_ready) > (uint64_t)10e6) &&
+	    _control_status.flags.in_air) {
+
+		// require a variance of rangefinder values to check for "stuck" measurements
+		if (_rng_stuck_max_val - _rng_stuck_min_val > _params.range_stuck_threshold) {
+			_time_last_rng_ready = _range_sample_delayed.time_us;
+			_rng_stuck_min_val = 0.0f;
+			_rng_stuck_max_val = 0.0f;
+			_control_status.flags.rng_stuck = false;
+
+		} else {
+			if (_range_sample_delayed.rng > _rng_stuck_max_val) {
+				_rng_stuck_max_val = _range_sample_delayed.rng;
+			}
+
+			if (_rng_stuck_min_val < 0.1f || _range_sample_delayed.rng < _rng_stuck_min_val) {
+				_rng_stuck_min_val = _range_sample_delayed.rng;
+			}
+
+			_control_status.flags.rng_stuck = true;
+			_rng_hgt_valid = false;
+		}
+
+	} else {
+		_time_last_rng_ready = _range_sample_delayed.time_us;
+	}
+}

--- a/EKF/range_finder_checks.cpp
+++ b/EKF/range_finder_checks.cpp
@@ -90,6 +90,8 @@ void Ekf::updateRangeDataValidity()
 	} else if (_time_bad_rng_signal_quality > 0 && _imu_sample_delayed.time_us - _time_bad_rng_signal_quality > RNG_BAD_SIG_HYST) {
 		_time_bad_rng_signal_quality = 0;
 		_rng_hgt_valid = true;
+	} else if (_time_bad_rng_signal_quality == 0) {
+		_rng_hgt_valid = true;
 	}
 
 	// Check if excessively tilted

--- a/EKF/range_finder_checks.cpp
+++ b/EKF/range_finder_checks.cpp
@@ -40,9 +40,6 @@
 
 #include "ekf.h"
 
-
-#define RNG_BAD_SIG_HYST (uint64_t)3e6	// range finder data needs to have 3 seconds of non-zero signal quality to be valid
-
 // check that the range finder data is continuous
 void Ekf::updateRangeDataContinuity()
 {

--- a/EKF/range_finder_checks.cpp
+++ b/EKF/range_finder_checks.cpp
@@ -80,7 +80,7 @@ void Ekf::updateRangeDataValidity()
 	if (_range_sample_delayed.quality == 0) {
 		_time_bad_rng_signal_quality = _imu_sample_delayed.time_us;
 		_rng_hgt_valid = false;
-	} else if (_imu_sample_delayed.time_us - _time_bad_rng_signal_quality > RNG_BAD_SIG_HYST) {
+	} else if (_imu_sample_delayed.time_us - _time_bad_rng_signal_quality > (unsigned)_params.range_signal_hysteresis_ms) {
 		_rng_hgt_valid = true;
 	}
 

--- a/EKF/terrain_estimator.cpp
+++ b/EKF/terrain_estimator.cpp
@@ -56,7 +56,7 @@ bool Ekf::initHagl()
 		_terrain_var = sq(_params.rng_gnd_clearance);
 		initialized = true;
 
-	} else if (!_rng_hgt_faulty
+	} else if (_rng_hgt_valid
 		   && (_time_last_imu - latest_measurement.time_us) < (uint64_t)2e5
 		   && _R_rng_to_earth_2_2 > _params.range_cos_max_tilt) {
 		// if we have a fresh measurement, use it to initialise the terrain estimator
@@ -87,9 +87,6 @@ bool Ekf::initHagl()
 
 void Ekf::runTerrainEstimator()
 {
-	// Perform a continuity check on range finder data
-	checkRangeDataContinuity();
-
 	// Perform initialisation check and
 	// on ground, continuously reset the terrain estimator
 	if (!_terrain_initialised || !_control_status.flags.in_air) {
@@ -110,7 +107,7 @@ void Ekf::runTerrainEstimator()
 		_terrain_var = math::constrain(_terrain_var, 0.0f, 1e4f);
 
 		// Fuse range finder data if available
-		if (_range_data_ready && !_rng_hgt_faulty) {
+		if (_range_data_ready && _rng_hgt_valid) {
 			fuseHagl();
 
 			// update range sensor angle parameters in case they have changed
@@ -321,20 +318,4 @@ void Ekf::getHaglInnov(float *hagl_innov)
 void Ekf::getHaglInnovVar(float *hagl_innov_var)
 {
 	memcpy(hagl_innov_var, &_hagl_innov_var, sizeof(_hagl_innov_var));
-}
-
-// check that the range finder data is continuous
-void Ekf::checkRangeDataContinuity()
-{
-	// update range data continuous flag (1Hz ie 2000 ms)
-	/* Timing in micro seconds */
-
-	/* Apply a 2.0 sec low pass filter to the time delta from the last range finder updates */
-	float alpha = 0.5f * _dt_update;
-	_dt_last_range_update_filt_us = _dt_last_range_update_filt_us * (1.0f - alpha) + alpha *
-					(_imu_sample_delayed.time_us - _range_sample_delayed.time_us);
-
-	_dt_last_range_update_filt_us = fminf(_dt_last_range_update_filt_us, 4e6f);
-
-	_range_data_continuous = (_dt_last_range_update_filt_us < 2e6f);
 }


### PR DESCRIPTION
This PR attempts to cleanup the checks on the range finder data. Additionally it adds a hysteresis to declaring range finder data valid after signal quality was zero.

Specifically:
- whenever signal quality of the range data was 0 we require non-zero signal quality for 3 seconds before we accept the data to be used. This is to improve robustness against a known sensor failure mode where the signal quality toggles between 0 and non-zero values (see plot below)
- moved range finder data checks to a central location and created new file range_finder_checks.cpp in order to avoid loading control.cpp
- replaced _rng_hgt_faulty with _range_hgt_valid in order to avoid negation all over the place
- use better function name
- moved updateRangeDataContinuity() out of the terrain estimator and into range_finder_checks.cpp

I will provide SITL test data shortly.

Plot of range finder failure mode:

![image](https://user-images.githubusercontent.com/7610489/66732561-c15cd800-ee5c-11e9-9885-6bd05dd3a849.png)

Notice how signal quality erratically jumps between 0 and 95% in the middle of the flight. The height reported by the sensor at that point was completely wrong.



Signed-off-by: RomanBapst <bapstroman@gmail.com>