### PR TITLE
Add access to EKF state reset

### DIFF
--- a/EKF/ekf.cpp
+++ b/EKF/ekf.cpp
@@ -47,6 +47,13 @@
 bool Ekf::init(uint64_t timestamp)
 {
 	bool ret = initialise_interface(timestamp);
+	reset(timestamp);
+
+	return ret;
+}
+
+void Ekf::reset(uint64_t timestamp)
+{
 	_state.vel.setZero();
 	_state.pos.setZero();
 	_state.gyro_bias.setZero();
@@ -94,8 +101,6 @@ bool Ekf::init(uint64_t timestamp)
 	_accel_mag_filt = 0.0f;
 	_ang_rate_mag_filt = 0.0f;
 	_prev_dvel_bias_var.zero();
-
-	return ret;
 }
 
 bool Ekf::update()

--- a/EKF/ekf.cpp
+++ b/EKF/ekf.cpp
@@ -54,20 +54,7 @@ bool Ekf::init(uint64_t timestamp)
 
 void Ekf::reset(uint64_t timestamp)
 {
-	_state.vel.setZero();
-	_state.pos.setZero();
-	_state.gyro_bias.setZero();
-	_state.accel_bias.setZero();
-	_state.mag_I.setZero();
-	_state.mag_B.setZero();
-	_state.wind_vel.setZero();
-	_state.quat_nominal.setZero();
-	_state.quat_nominal(0) = 1.0f;
-
-	_output_new.vel.setZero();
-	_output_new.pos.setZero();
-	_output_new.quat_nominal.setZero();
-	_output_new.quat_nominal(0) = 1.0f;
+	resetStatesAndCovariances();
 
 	_delta_angle_corr.setZero();
 	_imu_down_sampled.delta_ang.setZero();
@@ -101,6 +88,30 @@ void Ekf::reset(uint64_t timestamp)
 	_accel_mag_filt = 0.0f;
 	_ang_rate_mag_filt = 0.0f;
 	_prev_dvel_bias_var.zero();
+}
+
+void Ekf::resetStatesAndCovariances()
+{
+	resetStates();
+	initialiseCovariance();
+}
+
+void Ekf::resetStates()
+{
+	_state.vel.setZero();
+	_state.pos.setZero();
+	_state.gyro_bias.setZero();
+	_state.accel_bias.setZero();
+	_state.mag_I.setZero();
+	_state.mag_B.setZero();
+	_state.wind_vel.setZero();
+	_state.quat_nominal.setZero();
+	_state.quat_nominal(0) = 1.0f;
+
+	_output_new.vel.setZero();
+	_output_new.pos.setZero();
+	_output_new.quat_nominal.setZero();
+	_output_new.quat_nominal(0) = 1.0f;
 }
 
 bool Ekf::update()

--- a/EKF/ekf.h
+++ b/EKF/ekf.h
@@ -57,6 +57,9 @@ public:
 	// set the internal states and status to their default value
 	void reset(uint64_t timestamp) override;
 
+	void resetStatesAndCovariances() override;
+	void resetStates() override;
+
 	// should be called every time new data is pushed into the filter
 	bool update() override;
 

--- a/EKF/ekf.h
+++ b/EKF/ekf.h
@@ -54,6 +54,9 @@ public:
 	// initialise variables to sane values (also interface class)
 	bool init(uint64_t timestamp) override;
 
+	// set the internal states and status to their default value
+	void reset(uint64_t timestamp) override;
+
 	// should be called every time new data is pushed into the filter
 	bool update() override;
 

--- a/EKF/estimator_interface.h
+++ b/EKF/estimator_interface.h
@@ -60,6 +60,8 @@ public:
 
 	virtual bool init(uint64_t timestamp) = 0;
 	virtual void reset(uint64_t timestamp) = 0;
+	virtual void resetStates() = 0;
+	virtual void resetStatesAndCovariances() = 0;
 	virtual bool update() = 0;
 
 	// gets the innovations of velocity and position measurements

--- a/EKF/estimator_interface.h
+++ b/EKF/estimator_interface.h
@@ -59,6 +59,7 @@ public:
 	virtual ~EstimatorInterface() = default;
 
 	virtual bool init(uint64_t timestamp) = 0;
+	virtual void reset(uint64_t timestamp) = 0;
 	virtual bool update() = 0;
 
 	// gets the innovations of velocity and position measurements
@@ -356,6 +357,8 @@ public:
 	{
 		*val = _fault_status.value;
 	}
+
+	bool isVehicleAtRest() const { return _vehicle_at_rest; }
 
 	// get GPS check status
 	virtual void get_gps_check_status(uint16_t *val) = 0;


### PR DESCRIPTION
I'm creating a logic in PX4/Firmware that checks for motion an resets the states or completely the EKF. To do so, I needed to increase the granularity of the init function.
I also need to know if the vehicle is at rest or not so I created a getter to reuse the "at_rest" variable of EKF2.

Required for https://github.com/PX4/Firmware/pull/13346