### PR TITLE
Jenkins: update container tags; use px4-dev-base-bionic

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,7 +7,7 @@ pipeline {
         stage('Linux GCC') {
           agent {
             docker {
-              image 'px4io/px4-dev-base:2019-01-31'
+              image 'px4io/px4-dev-base-bionic:2019-10-24'
               args '-v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
             }
           }
@@ -27,7 +27,7 @@ pipeline {
         stage('Linux Clang') {
           agent {
             docker {
-              image 'px4io/px4-dev-clang:2019-01-31'
+              image 'px4io/px4-dev-clang:2019-10-24'
               args '-v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
             }
           }
@@ -74,7 +74,7 @@ pipeline {
         stage('coverage') {
           agent {
             docker {
-              image 'px4io/px4-dev-ecl:2019-01-31'
+              image 'px4io/px4-dev-base-bionic:2019-10-24'
               args '-v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
             }
           }
@@ -105,7 +105,7 @@ pipeline {
         stage('test') {
           agent {
             docker {
-              image 'px4io/px4-dev-ecl:2019-01-31'
+              image 'px4io/px4-dev-base-bionic:2019-10-24'
               args '-v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
             }
           }
@@ -122,7 +122,7 @@ pipeline {
         stage('doxygen') {
           agent {
             docker {
-              image 'px4io/px4-dev-base:2019-01-31'
+              image 'px4io/px4-dev-base-bionic:2019-10-24'
               args '-v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
             }
           }
@@ -148,7 +148,7 @@ pipeline {
         stage('PX4/Firmware build') {
           agent {
             docker {
-              image 'px4io/px4-dev-base:2019-01-31'
+              image 'px4io/px4-dev-base-bionic:2019-10-24'
               args '-v ${CCACHE_DIR}:${CCACHE_DIR}:rw'
             }
           }


### PR DESCRIPTION
Purpose: have the containers updated with the current tags. Also, using the `px4-dev-ecl` container doesn't make sense anymore, as it just brought Python dependencies as an extra (https://github.com/PX4/containers/pull/208 removes that container).