### PR TITLE
remove <cmath> usage

### DIFF
--- a/ecl.h
+++ b/ecl.h
@@ -96,5 +96,5 @@ using ecl_abstime = uint64_t;
 
 #endif /* PX4_POSIX || PX4_NUTTX */
 
-#include <cmath>
+#include <math.h>
 #define ISFINITE(x) __builtin_isfinite(x)

--- a/test/test_EKF_basics.cpp
+++ b/test/test_EKF_basics.cpp
@@ -32,7 +32,7 @@
  ****************************************************************************/
 
 #include <gtest/gtest.h>
-#include <cmath>
+#include <math.h>
 #include "EKF/ekf.h"
 
 class EkfInitializationTest : public ::testing::Test {

--- a/test/test_EKF_imuSampling.cpp
+++ b/test/test_EKF_imuSampling.cpp
@@ -32,7 +32,7 @@
  ****************************************************************************/
 
 #include <gtest/gtest.h>
-#include <cmath>
+#include <math.h>
 #include "EKF/ekf.h"
 
 class EkfSamplingTestParametrized : public ::testing::TestWithParam<std::tuple<float,float>>

--- a/test/test_EKF_ringbuffer.cpp
+++ b/test/test_EKF_ringbuffer.cpp
@@ -32,7 +32,7 @@
  ****************************************************************************/
 
 #include <gtest/gtest.h>
-#include <cmath>
+#include <math.h>
 #include "EKF/ekf.h"
 
 struct sample {

--- a/test/test_EKF_sampling.cpp
+++ b/test/test_EKF_sampling.cpp
@@ -32,7 +32,7 @@
  ****************************************************************************/
 
 #include <gtest/gtest.h>
-#include <cmath>
+#include <math.h>
 #include "EKF/ekf.h"
 
 class EkfImuSamplingTestParametrized : public ::testing::TestWithParam<std::tuple<float,float>>

--- a/validation/data_validator.h
+++ b/validation/data_validator.h
@@ -41,7 +41,7 @@
 
 #pragma once
 
-#include <cmath>
+#include <math.h>
 #include <stdint.h>
 
 class DataValidator


### PR DESCRIPTION
The NuttX c++ library is incomplete, let's avoid including <cmath> until we have a real standard library in place.