### PR TITLE
Check PDOP instead of GDOP

### DIFF
--- a/EKF/common.h
+++ b/EKF/common.h
@@ -69,7 +69,7 @@ struct gps_message {
 	float vel_ned[3];	///< GPS ground speed NED
 	bool vel_ned_valid;	///< GPS ground speed is valid
 	uint8_t nsats;		///< number of satellites used
-	float gdop;		///< geometric dilution of precision
+	float pdop;		///< position dilution of precision
 };
 
 struct flow_message {
@@ -317,7 +317,7 @@ struct parameters {
 	float req_vacc{8.0f};			///< maximum acceptable vertical position error (m)
 	float req_sacc{1.0f};			///< maximum acceptable speed error (m/s)
 	int32_t req_nsats{6};			///< minimum acceptable satellite count
-	float req_gdop{2.0f};			///< maximum acceptable geometric dilution of precision
+	float req_pdop{2.0f};			///< maximum acceptable position dilution of precision
 	float req_hdrift{0.3f};			///< maximum acceptable horizontal drift speed (m/s)
 	float req_vdrift{0.5f};			///< maximum acceptable vertical drift speed (m/s)
 
@@ -423,7 +423,7 @@ union gps_check_fail_status_u {
 	struct {
 		uint16_t fix    : 1; ///< 0 - true if the fix type is insufficient (no 3D solution)
 		uint16_t nsats  : 1; ///< 1 - true if number of satellites used is insufficient
-		uint16_t gdop   : 1; ///< 2 - true if geometric dilution of precision is insufficient
+		uint16_t pdop   : 1; ///< 2 - true if position dilution of precision is insufficient
 		uint16_t hacc   : 1; ///< 3 - true if reported horizontal accuracy is insufficient
 		uint16_t vacc   : 1; ///< 4 - true if reported vertical accuracy is insufficient
 		uint16_t sacc   : 1; ///< 5 - true if reported speed accuracy is insufficient

--- a/EKF/gps_checks.cpp
+++ b/EKF/gps_checks.cpp
@@ -47,7 +47,7 @@
 
 // GPS pre-flight check bit locations
 #define MASK_GPS_NSATS  (1<<0)
-#define MASK_GPS_GDOP   (1<<1)
+#define MASK_GPS_PDOP   (1<<1)
 #define MASK_GPS_HACC   (1<<2)
 #define MASK_GPS_VACC   (1<<3)
 #define MASK_GPS_SACC   (1<<4)
@@ -121,8 +121,8 @@ bool Ekf::gps_is_good(const gps_message &gps)
 	// Check the number of satellites
 	_gps_check_fail_status.flags.nsats = (gps.nsats < _params.req_nsats);
 
-	// Check the geometric dilution of precision
-	_gps_check_fail_status.flags.gdop = (gps.gdop > _params.req_gdop);
+	// Check the position dilution of precision
+	_gps_check_fail_status.flags.pdop = (gps.pdop > _params.req_pdop);
 
 	// Check the reported horizontal and vertical position accuracy
 	_gps_check_fail_status.flags.hacc = (gps.eph > _params.req_hacc);
@@ -228,7 +228,7 @@ bool Ekf::gps_is_good(const gps_message &gps)
 	if (
 		_gps_check_fail_status.flags.fix ||
 		(_gps_check_fail_status.flags.nsats   && (_params.gps_check_mask & MASK_GPS_NSATS)) ||
-		(_gps_check_fail_status.flags.gdop    && (_params.gps_check_mask & MASK_GPS_GDOP)) ||
+		(_gps_check_fail_status.flags.pdop    && (_params.gps_check_mask & MASK_GPS_PDOP)) ||
 		(_gps_check_fail_status.flags.hacc    && (_params.gps_check_mask & MASK_GPS_HACC)) ||
 		(_gps_check_fail_status.flags.vacc    && (_params.gps_check_mask & MASK_GPS_VACC)) ||
 		(_gps_check_fail_status.flags.sacc    && (_params.gps_check_mask & MASK_GPS_SACC)) ||

--- a/test/test_EKF_basics.cpp
+++ b/test/test_EKF_basics.cpp
@@ -88,7 +88,7 @@ class EkfInitializationTest : public ::testing::Test {
 		_gps_message.vel_ned[2] = 0.0f;
 		_gps_message.vel_ned_valid = 1;
 		_gps_message.nsats = 16;
-		_gps_message.gdop = 0.0f;
+		_gps_message.pdop = 0.0f;
 
 		update_with_const_sensors(_init_duration_us);
 


### PR DESCRIPTION
 As the TDOP is usually not available from the GNSS receivers, GDOP cannot computed. As a replacement, the position dillution of precision (PDOP), which is a combination of VDOP and HDOP can be computed as follows:
```
PDOP = sqrt(VDOP^2+HDOP^2)
```

(required by https://github.com/PX4/Firmware/pull/13515)
