### PR TITLE
start*Fusion and refactor reset velocity/position function

### DIFF
--- a/EKF/common.h
+++ b/EKF/common.h
@@ -465,6 +465,7 @@ union filter_control_status_u {
 		uint32_t mag_aligned_in_flight   : 1; ///< 23 - true when the in-flight mag field alignment has been completed
 		uint32_t ev_vel      : 1; ///< 24 - true when local earth frame velocity data from external vision measurements are being fused
 		uint32_t synthetic_mag_z : 1; ///< 25 - true when we are using a synthesized measurement for the magnetometer Z component
+		uint32_t aux_vel     : 1; ///< 25 - true when auxiliary horizontal velocity data fusion is intended
 	} flags;
 	uint32_t value;
 };

--- a/EKF/common.h
+++ b/EKF/common.h
@@ -209,6 +209,7 @@ struct auxVelSample {
 #define BARO_MAX_INTERVAL (uint64_t)2e5	///< Maximum allowable time interval between pressure altitude measurements (uSec)
 #define RNG_MAX_INTERVAL  (uint64_t)2e5	///< Maximum allowable time interval between range finder  measurements (uSec)
 #define EV_MAX_INTERVAL   (uint64_t)2e5	///< Maximum allowable time interval between external vision system measurements (uSec)
+#define AUXVEL_MAX_INTERVAL (uint64_t)2e5	///< Maximum allowable time interval between auxiliary velocity measurements (uSec)
 
 // bad accelerometer detection and mitigation
 #define BADACC_PROBATION  (uint64_t)10e6	///< Period of time that accel data declared bad must continuously pass checks to be declared good again (uSec)

--- a/EKF/control.cpp
+++ b/EKF/control.cpp
@@ -1396,6 +1396,7 @@ void Ekf::controlAuxVelFusion()
 {
 	if(_aux_vel_data_ready)
 	{
+		// TODO: add this parameter bit to EKF2_AID_MASK
 		if (/*(_params.fusion_mode & MASK_USE_AUXVEL) &&*/ !_control_status.flags.aux_vel
 			&& (_time_last_imu - _time_last_auxvel) < (2 * EV_MAX_INTERVAL)){
 			resetToAuxiliarHorizontalVelocity();

--- a/EKF/control.cpp
+++ b/EKF/control.cpp
@@ -1398,7 +1398,7 @@ void Ekf::controlAuxVelFusion()
 	{
 		// TODO: add this parameter bit to EKF2_AID_MASK
 		if (/*(_params.fusion_mode & MASK_USE_AUXVEL) &&*/ !_control_status.flags.aux_vel
-			&& (_time_last_imu - _time_last_auxvel) < (2 * EV_MAX_INTERVAL)){
+			&& (_time_last_imu - _time_last_auxvel) < (2 * AUXVEL_MAX_INTERVAL)){
 			resetToAuxiliarHorizontalVelocity();
 			startAuxVelFusion();
 		}

--- a/EKF/control.cpp
+++ b/EKF/control.cpp
@@ -191,7 +191,7 @@ void Ekf::controlExternalVisionFusion()
 				// turn on use of external vision measurements for position
 				if (_params.fusion_mode & MASK_USE_EVPOS && !_control_status.flags.ev_pos) {
 					startEvPosFusion();
-					resetToGeneralHorizontalPosition()
+					resetToGeneralHorizontalPosition();
 				}
 
 				// turn on use of external vision measurements for velocity

--- a/EKF/control.cpp
+++ b/EKF/control.cpp
@@ -190,8 +190,8 @@ void Ekf::controlExternalVisionFusion()
 			if ((_time_last_imu - _time_last_ext_vision) < (2 * EV_MAX_INTERVAL)) {
 				// turn on use of external vision measurements for position
 				if (_params.fusion_mode & MASK_USE_EVPOS && !_control_status.flags.ev_pos) {
-					resetToEvHorizontalPosition();
 					startEvPosFusion();
+					resetToGeneralHorizontalPosition()
 				}
 
 				// turn on use of external vision measurements for velocity

--- a/EKF/ekf.h
+++ b/EKF/ekf.h
@@ -334,6 +334,7 @@ private:
 	bool _baro_data_ready{false};	///< true when new baro height data has fallen behind the fusion time horizon and is available to be fused
 	bool _range_data_ready{false};	///< true when new range finder data has fallen behind the fusion time horizon and is available to be fused
 	bool _flow_data_ready{false};	///< true when the leading edge of the optical flow integration period has fallen behind the fusion time horizon
+	bool _aux_vel_data_ready{false};///< true when new auxiliar velocity data has fallen behind the fusion time horizon and is available to be fused;
 	bool _ev_data_ready{false};	///< true when new external vision system data has fallen behind the fusion time horizon and is available to be fused
 	bool _tas_data_ready{false};	///< true when new true airspeed data has fallen behind the fusion time horizon and is available to be fused
 	bool _flow_for_terrain_data_ready{false}; /// same flag as "_flow_data_ready" but used for separate terrain estimator
@@ -405,6 +406,9 @@ private:
 	Vector3f _rng_hgt_innov {};	///< range hgt innovations (m)
 	Vector3f _rng_hgt_innov_var {};	///< range hgt innovation variances (m**2)
 
+	Vector2f _flow_innov;	///< flow measurement innovation (rad/sec)
+	Vector2f _flow_innov_var;	///< flow innovation variance ((rad/sec)**2)
+
 	Vector3f _aux_vel_innov {};	///< horizontal auxiliary velocity innovations: (m/sec)
 	Vector3f _aux_vel_innov_var {};	///< horizontal auxiliary velocity innovation variances: ((m/sec)**2)
 
@@ -427,8 +431,6 @@ private:
 	float _hagl_innov_var{0.0f};		///< innovation variance for the last height above terrain measurement (m**2)
 
 	// optical flow processing
-	float _flow_innov[2] {};	///< flow measurement innovation (rad/sec)
-	float _flow_innov_var[2] {};	///< flow innovation variance ((rad/sec)**2)
 	Vector3f _flow_gyro_bias;	///< bias errors in optical flow sensor rate gyro outputs (rad/sec)
 	Vector3f _imu_del_ang_of;	///< bias corrected delta angle measurements accumulated across the same time frame as the optical flow rates (rad)
 	float _delta_time_of{0.0f};	///< time in sec that _imu_del_ang_of was accumulated over (sec)
@@ -572,9 +574,6 @@ private:
 	// fuse single velocity and position measurement
 	void fuseVelPosHeight(const float innov, const float innov_var, const int obs_index);
 
-	// reset velocity states of the ekf
-	bool resetVelocity();
-
 	// fuse optical flow line of sight rate measurements
 	void fuseOptFlow();
 
@@ -617,12 +616,6 @@ private:
 
 	// Return the magnetic declination in radians to be used by the alignment and fusion processing
 	float getMagDeclination();
-
-	// reset position states of the ekf (only horizontal position)
-	bool resetPosition();
-
-	// reset height state of the ekf
-	void resetHeight();
 
 	// modify output filter to match the the EKF state at the fusion time horizon
 	void alignOutputFilter();
@@ -818,6 +811,54 @@ private:
 	// calculate a synthetic value for the magnetometer Z component, given the 3D magnetomter
 	// sensor measurement
 	float calculate_synthetic_mag_z_measurement(Vector3f mag_meas, Vector3f mag_earth_predicted);
+
+	bool isTimedOut(uint64_t timestamp, uint64_t timeout);
+
+	void resetToGeneralHorizontalPosition();
+
+	void resetHeight();
+
+	void resetToGpsHorizontalPosition();
+
+	void resetToEvHorizontalPosition();
+
+	void resetToLastKnowHorizontalPosition();
+
+	void resetToZeroHorizontalPosition();
+
+	void resetToGeneralVelocity();
+
+	void resetToGpsVelocity();
+
+	void resetToEvVelocity();
+
+	void resetToOptFlowVelocity();
+
+	void resetToAuxiliarHorizontalVelocity();
+
+	void resetToZeroVelocity();
+
+	void resetHorizontalPosition(const Vector3f &delta_pos);
+
+	void resetVelocity(const Vector3f &delta_vel);
+
+	void startGpsFusion();
+
+	void startGpsPosFusion();
+
+	void startGpsVelFusion();
+
+	void startGpsYawFusion();
+
+	void startEvPosFusion();
+
+	void startEvVelFusion();
+
+	void startEvYawFusion();
+
+	void startAuxVelFusion();
+
+	void startFlowFusion();
 
 	void stopGpsFusion();
 

--- a/EKF/mag_control.cpp
+++ b/EKF/mag_control.cpp
@@ -165,15 +165,15 @@ void Ekf::runInAirYawReset()
 }
 
 bool Ekf::canRealignYawUsingGps() const
-{ 
+{
 	return _control_status.flags.fixed_wing;
 }
 
 void Ekf::runVelPosReset()
 {
 	if (_velpos_reset_request) {
-		resetVelocity();
-		resetPosition();
+		resetToGeneralVelocity();
+		resetToGeneralHorizontalPosition();
 		_velpos_reset_request = false;
 	}
 }
@@ -256,7 +256,7 @@ void Ekf::checkMagDeclRequired()
 void Ekf::checkMagInhibition()
 {
 	_mag_use_inhibit = shouldInhibitMag();
-	if (!_mag_use_inhibit) { 
+	if (!_mag_use_inhibit) {
 		_mag_use_not_inhibit_us = _imu_sample_delayed.time_us;
 	}
 

--- a/EKF/optflow_fusion.cpp
+++ b/EKF/optflow_fusion.cpp
@@ -106,8 +106,8 @@ void Ekf::fuseOptFlow()
 	opt_flow_rate(1) = _flowRadXYcomp(1) / _flow_sample_delayed.dt + _flow_gyro_bias(1);
 
 	if (opt_flow_rate.norm() < _flow_max_rate) {
-		_flow_innov[0] =  vel_body(1) / range - opt_flow_rate(0); // flow around the X axis
-		_flow_innov[1] = -vel_body(0) / range - opt_flow_rate(1); // flow around the Y axis
+		_flow_innov(0) =  vel_body(1) / range - opt_flow_rate(0); // flow around the X axis
+		_flow_innov(1) = -vel_body(0) / range - opt_flow_rate(1); // flow around the Y axis
 
 	} else {
 		return;
@@ -227,7 +227,7 @@ void Ekf::fuseOptFlow()
 			// calculate innovation variance for X axis observation and protect against a badly conditioned calculation
 			if (t77 >= R_LOS) {
 				t78 = 1.0f / t77;
-				_flow_innov_var[0] = t77;
+				_flow_innov_var(0) = t77;
 
 			} else {
 				// we need to reinitialise the covariance matrix and abort this fusion step
@@ -369,7 +369,7 @@ void Ekf::fuseOptFlow()
 			// calculate innovation variance for Y axis observation and protect against a badly conditioned calculation
 			if (t77 >= R_LOS) {
 				t78 = 1.0f / t77;
-				_flow_innov_var[1] = t77;
+				_flow_innov_var(1) = t77;
 
 			} else {
 				// we need to reinitialise the covariance matrix and abort this fusion step
@@ -408,13 +408,13 @@ void Ekf::fuseOptFlow()
 
 	// run the innovation consistency check and record result
 	bool flow_fail = false;
-	float test_ratio[2];
-	test_ratio[0] = sq(_flow_innov[0]) / (sq(math::max(_params.flow_innov_gate, 1.0f)) * _flow_innov_var[0]);
-	test_ratio[1] = sq(_flow_innov[1]) / (sq(math::max(_params.flow_innov_gate, 1.0f)) * _flow_innov_var[1]);
-	_optflow_test_ratio = math::max(test_ratio[0],test_ratio[1]);
+	Vector2f test_ratio;
+	test_ratio(0) = sq(_flow_innov(0)) / (sq(math::max(_params.flow_innov_gate, 1.0f)) * _flow_innov_var(0));
+	test_ratio(1) = sq(_flow_innov(1)) / (sq(math::max(_params.flow_innov_gate, 1.0f)) * _flow_innov_var(1));
+	_optflow_test_ratio = math::max(test_ratio(0),test_ratio(1));
 
 	for (uint8_t obs_index = 0; obs_index <= 1; obs_index++) {
-		if (test_ratio[obs_index] > 1.0f) {
+		if (test_ratio(obs_index) > 1.0f) {
 			flow_fail = true;
 			_innov_check_fail_status.value |= (1 << (obs_index + 10));
 
@@ -505,7 +505,7 @@ void Ekf::fuseOptFlow()
 			fixCovarianceErrors();
 
 			// apply the state corrections
-			fuse(gain, _flow_innov[obs_index]);
+			fuse(gain, _flow_innov(obs_index));
 
 			_time_last_of_fuse = _time_last_imu;
 		}

--- a/EKF/terrain_estimator.cpp
+++ b/EKF/terrain_estimator.cpp
@@ -229,27 +229,27 @@ void Ekf::fuseFlowForTerrain()
 	_terrain_var = fmaxf(_terrain_var, 0.0f);
 
 	// Cacluate innovation variance
-	_flow_innov_var[0] = Hx * Hx * _terrain_var + R_LOS;
+	_flow_innov_var(0) = Hx * Hx * _terrain_var + R_LOS;
 
 	// calculate the kalman gain for the flow x measurement
-	float Kx = _terrain_var * Hx / _flow_innov_var[0];
+	float Kx = _terrain_var * Hx / _flow_innov_var(0);
 
 	// calculate prediced optical flow about x axis
 	float pred_flow_x = vel_body(1) * earth_to_body(2, 2) / pred_hagl;
 
 	// calculate flow innovation (x axis)
-	_flow_innov[0] = pred_flow_x - opt_flow_rate(0);
+	_flow_innov(0) = pred_flow_x - opt_flow_rate(0);
 
 	// calculate correction term for terrain variance
 	float KxHxP =  Kx * Hx * _terrain_var;
 
 	// innovation consistency check
 	float gate_size = fmaxf(_params.flow_innov_gate, 1.0f);
-	float flow_test_ratio = sq(_flow_innov[0]) / (sq(gate_size) * _flow_innov_var[0]);
+	float flow_test_ratio = sq(_flow_innov(0)) / (sq(gate_size) * _flow_innov_var(0));
 
 	// do not perform measurement update if badly conditioned
 	if (flow_test_ratio <= 1.0f) {
-		_terrain_vpos += Kx * _flow_innov[0];
+		_terrain_vpos += Kx * _flow_innov(0);
 		// guard against negative variance
 		_terrain_var = fmaxf(_terrain_var - KxHxP, 0.0f);
 		_time_last_of_fuse = _time_last_imu;
@@ -259,25 +259,25 @@ void Ekf::fuseFlowForTerrain()
 	float Hy = -vel_body(0) * t0 / (pred_hagl * pred_hagl);
 
 	// Calculuate innovation variance
-	_flow_innov_var[1] = Hy * Hy * _terrain_var + R_LOS;
+	_flow_innov_var(1) = Hy * Hy * _terrain_var + R_LOS;
 
 	// calculate the kalman gain for the flow y measurement
-	float Ky = _terrain_var * Hy / _flow_innov_var[1];
+	float Ky = _terrain_var * Hy / _flow_innov_var(1);
 
 	// calculate prediced optical flow about y axis
 	float pred_flow_y = -vel_body(0) * earth_to_body(2, 2) / pred_hagl;
 
 	// calculate flow innovation (y axis)
-	_flow_innov[1] = pred_flow_y - opt_flow_rate(1);
+	_flow_innov(1) = pred_flow_y - opt_flow_rate(1);
 
 	// calculate correction term for terrain variance
 	float KyHyP =  Ky * Hy * _terrain_var;
 
 	// innovation consistency check
-	flow_test_ratio = sq(_flow_innov[1]) / (sq(gate_size) * _flow_innov_var[1]);
+	flow_test_ratio = sq(_flow_innov(1)) / (sq(gate_size) * _flow_innov_var(1));
 
 	if (flow_test_ratio <= 1.0f) {
-		_terrain_vpos += Ky * _flow_innov[1];
+		_terrain_vpos += Ky * _flow_innov(1);
 		// guard against negative variance
 		_terrain_var = fmaxf(_terrain_var - KyHyP, 0.0f);
 		_time_last_of_fuse = _time_last_imu;


### PR DESCRIPTION
A lot of the behavior of the EKF is steered by the control_status flags. Setting on of these fields to true or false is often not enough to change the mode of the EKF correctly. For example to start the heading fusion from the external vision data, the ev_yaw flag has to be set true, while the other heading flags have to be set true. Until now starting a certain type of fusion was managed in `control.cpp` via setting the flags.
This PR is adding separate functions for starting these fusions. which helps to reveal the intend of certain code lines to the reader.

Secondly, it is refactoring the `resetVelocity()` and `resetPosition()` functions. These function resetted the states according to the activated control_status flags. This was an issue for triggering a reset to a certain sensor source, such as vision velocity. E.g. Vision velocity was  always shadowed by an active GPS velocity.

Current issue: This does not fit on fmu v2. 