### PR TITLE
Support full vision variance 

### DIFF
--- a/EKF/common.h
+++ b/EKF/common.h
@@ -167,8 +167,8 @@ struct dragSample {
 };
 
 struct auxVelSample {
-	Vector2f velNE;		///< measured NE velocity relative to the local origin (m/sec)
-	Vector2f velVarNE;	///< estimated error variance of the NE velocity (m/sec)**2
+	Vector3f vel;		///< measured NE velocity relative to the local origin (m/sec)
+	Vector3f velVar;	///< estimated error variance of the NE velocity (m/sec)**2
 	uint64_t time_us;	///< timestamp of the measurement (uSec)
 };
 

--- a/EKF/common.h
+++ b/EKF/common.h
@@ -83,10 +83,9 @@ struct ext_vision_message {
 	Vector3f pos;	///< XYZ position in external vision's local reference frame (m) - Z must be aligned with down axis
 	Vector3f vel;	///< XYZ velocity in external vision's local reference frame (m/sec) - Z must be aligned with down axis
 	Quatf quat;		///< quaternion defining rotation from body to earth frame
-	float posErr;		///< 1-Sigma horizontal position accuracy (m)
-	float hgtErr;		///< 1-Sigma height accuracy (m)
-	float velErr;		///< 1-Sigma velocity accuracy (m/sec)
-	float angErr;		///< 1-Sigma angular error (rad)
+	Vector3f posVar;	///< XYZ position variances (m**2)
+	Vector3f velVar;	///< XYZ velocity variances ((m/sec)**2)
+	float angVar;		///< angular heading variance (rad**2)
 };
 
 struct outputSample {
@@ -156,10 +155,9 @@ struct extVisionSample {
 	Vector3f pos;	///< XYZ position in external vision's local reference frame (m) - Z must be aligned with down axis
 	Vector3f vel;	///< XYZ velocity in external vision's local reference frame (m/sec) - Z must be aligned with down axis
 	Quatf quat;		///< quaternion defining rotation from body to earth frame
-	float posErr;		///< 1-Sigma horizontal position accuracy (m)
-	float hgtErr;		///< 1-Sigma height accuracy (m)
-	float velErr;		///< 1-Sigma velocity accuracy (m/sec)
-	float angErr;		///< 1-Sigma angular error (rad)
+	Vector3f posVar;	///< XYZ position variances (m**2)
+	Vector3f velVar;	///< XYZ velocity variances ((m/sec)**2)
+	float angVar;		///< angular heading variance (rad**2)
 	uint64_t time_us;	///< timestamp of the measurement (uSec)
 };
 

--- a/EKF/control.cpp
+++ b/EKF/control.cpp
@@ -1398,14 +1398,16 @@ void Ekf::controlAuxVelFusion()
 		Vector2f aux_vel_innov_gate;
 		Vector3f aux_vel_obs_var;
 
-		_aux_vel_innov(0) = _state.vel(0) - _auxvel_sample_delayed.velNE(0);
-		_aux_vel_innov(1) = _state.vel(1) - _auxvel_sample_delayed.velNE(1);
+		_aux_vel_innov = _state.vel - _auxvel_sample_delayed.vel;
+		aux_vel_obs_var = _auxvel_sample_delayed.velVar;
 		aux_vel_innov_gate(0) = _params.auxvel_gate;
-		aux_vel_obs_var(0) = _auxvel_sample_delayed.velVarNE(0);
-		aux_vel_obs_var(1) = _auxvel_sample_delayed.velVarNE(1);
 
 		fuseHorizontalVelocity(_aux_vel_innov, aux_vel_innov_gate, aux_vel_obs_var,
 				_aux_vel_innov_var, _aux_vel_test_ratio);
+
+		// Can be enabled after bit for this is added to EKF_AID_MASK
+		// fuseVerticalVelocity(_aux_vel_innov, aux_vel_innov_gate, aux_vel_obs_var,
+		//		_aux_vel_innov_var, _aux_vel_test_ratio);
 
 	}
 }

--- a/EKF/control.cpp
+++ b/EKF/control.cpp
@@ -59,30 +59,29 @@ void Ekf::controlFusionModes()
 			_control_status.flags.tilt_align = true;
 			_control_status.flags.yaw_align = resetMagHeading(_mag_lpf.getState()); // TODO: is this needed?
 
-
 			// send alignment status message to the console
+			const char* height_source = nullptr;
 			if (_control_status.flags.baro_hgt) {
-				ECL_INFO("%llu: EKF aligned, (pressure height, IMU buf: %i, OBS buf: %i)",
-					(unsigned long long)_imu_sample_delayed.time_us, (int)_imu_buffer_length, (int)_obs_buffer_length);
+				height_source = "baro";
 
 			} else if (_control_status.flags.ev_hgt) {
-				ECL_INFO("%llu: EKF aligned, (EV height, IMU buf: %i, OBS buf: %i)",
-					(unsigned long long)_imu_sample_delayed.time_us, (int)_imu_buffer_length, (int)_obs_buffer_length);
+				height_source = "ev";
 
 			} else if (_control_status.flags.gps_hgt) {
-				ECL_INFO("%llu: EKF aligned, (GPS height, IMU buf: %i, OBS buf: %i)",
-					(unsigned long long)_imu_sample_delayed.time_us, (int)_imu_buffer_length, (int)_obs_buffer_length);
+				height_source = "gps";
 
 			} else if (_control_status.flags.rng_hgt) {
-				ECL_INFO("%llu: EKF aligned, (range height, IMU buf: %i, OBS buf: %i)",
-					(unsigned long long)_imu_sample_delayed.time_us, (int)_imu_buffer_length, (int)_obs_buffer_length);
+				height_source = "range";
+
 			} else {
-				ECL_ERR("%llu: EKF aligned, (unknown height, IMU buf: %i, OBS buf: %i)",
-					(unsigned long long)_imu_sample_delayed.time_us, (int)_imu_buffer_length, (int)_obs_buffer_length);
+				height_source = "unknown";
+
 			}
-
+			if(height_source){
+				ECL_INFO("%llu: EKF aligned, (%s height, IMU buf: %i, OBS buf: %i)",
+					(unsigned long long)_imu_sample_delayed.time_us, height_source, (int)_imu_buffer_length, (int)_obs_buffer_length);
+			}
 		}
-
 	}
 
 	// check for intermittent data (before pop_first_older_than)

--- a/EKF/ekf_helper.cpp
+++ b/EKF/ekf_helper.cpp
@@ -100,7 +100,7 @@ bool Ekf::resetVelocity()
 			_ev_vel = _R_ev_to_ekf *_ev_sample_delayed.vel;
 		}
 		_state.vel = _ev_vel;
-		P.uncorrelateCovarianceSetVariance<3>(4, sq(_ev_sample_delayed.velErr));
+		P.uncorrelateCovarianceSetVariance<3>(4, _ev_sample_delayed.velVar);
 	} else {
 		ECL_INFO_TIMESTAMPED("reset velocity to zero");
 		// Used when falling back to non-aiding mode of operation
@@ -165,7 +165,7 @@ bool Ekf::resetPosition()
 		_state.pos(1) = _ev_pos(1);
 
 		// use EV accuracy to reset variances
-		P.uncorrelateCovarianceSetVariance<2>(7, sq(_ev_sample_delayed.posErr));
+		P.uncorrelateCovarianceSetVariance<2>(7, _ev_sample_delayed.posVar.slice<2, 1>(0, 0));
 
 	} else if (_control_status.flags.opt_flow) {
 		ECL_INFO_TIMESTAMPED("reset position to last known position");
@@ -705,7 +705,7 @@ bool Ekf::resetMagHeading(const Vector3f &mag_init, bool increase_yaw_var, bool 
 		// update the yaw angle variance using the variance of the measurement
 		if (_control_status.flags.ev_yaw) {
 			// using error estimate from external vision data
-			increaseQuatYawErrVariance(sq(fmaxf(_ev_sample_delayed.angErr, 1.0e-2f)));
+			increaseQuatYawErrVariance(fmaxf(_ev_sample_delayed.angVar, sq(1.0e-2f)));
 		} else if (_params.mag_fusion_type <= MAG_FUSE_TYPE_3D) {
 			// using magnetic heading tuning parameter
 			increaseQuatYawErrVariance(sq(fmaxf(_params.mag_heading_noise, 1.0e-2f)));

--- a/EKF/estimator_interface.cpp
+++ b/EKF/estimator_interface.cpp
@@ -434,10 +434,9 @@ void EstimatorInterface::setExtVisionData(uint64_t time_usec, ext_vision_message
 		// calculate the system time-stamp for the mid point of the integration period
 		ev_sample_new.time_us = time_usec - _params.ev_delay_ms * 1000;
 
-		ev_sample_new.angErr = evdata->angErr;
-		ev_sample_new.posErr = evdata->posErr;
-		ev_sample_new.velErr = evdata->velErr;
-		ev_sample_new.hgtErr = evdata->hgtErr;
+		ev_sample_new.angVar = evdata->angVar;
+		ev_sample_new.posVar = evdata->posVar;
+		ev_sample_new.velVar = evdata->velVar;
 		ev_sample_new.quat = evdata->quat;
 		ev_sample_new.pos = evdata->pos;
 		ev_sample_new.vel = evdata->vel;

--- a/EKF/estimator_interface.cpp
+++ b/EKF/estimator_interface.cpp
@@ -447,7 +447,7 @@ void EstimatorInterface::setExtVisionData(uint64_t time_usec, ext_vision_message
 	}
 }
 
-void EstimatorInterface::setAuxVelData(uint64_t time_usec, float (&data)[2], float (&variance)[2])
+void EstimatorInterface::setAuxVelData(uint64_t time_usec, const Vector3f &velocity, const Vector3f &variance)
 {
 	if (!_initialised || _auxvel_buffer_fail) {
 		return;
@@ -473,8 +473,8 @@ void EstimatorInterface::setAuxVelData(uint64_t time_usec, float (&data)[2], flo
 		auxvel_sample_new.time_us -= FILTER_UPDATE_PERIOD_MS * 1000 / 2;
 		_time_last_auxvel = time_usec;
 
-		auxvel_sample_new.velNE = Vector2f(data);
-		auxvel_sample_new.velVarNE = Vector2f(variance);
+		auxvel_sample_new.vel = velocity;
+		auxvel_sample_new.velVar = variance;
 
 		_auxvel_buffer.push(auxvel_sample_new);
 	}

--- a/EKF/estimator_interface.h
+++ b/EKF/estimator_interface.h
@@ -203,7 +203,7 @@ public:
 	void setExtVisionData(uint64_t time_usec, ext_vision_message *evdata);
 
 	// set auxiliary velocity data
-	void setAuxVelData(uint64_t time_usec, float (&data)[2], float (&variance)[2]);
+	void setAuxVelData(uint64_t time_usec, const Vector3f &vel, const Vector3f &variance);
 
 	// return a address to the parameters struct
 	// in order to give access to the application

--- a/EKF/mag_fusion.cpp
+++ b/EKF/mag_fusion.cpp
@@ -626,7 +626,7 @@ void Ekf::fuseHeading()
 
 	} else if (_control_status.flags.ev_yaw) {
 		// using error estimate from external vision data
-		R_YAW = sq(fmaxf(_ev_sample_delayed.angErr, 1.0e-2f));
+		R_YAW = fmaxf(_ev_sample_delayed.angVar, sq(1.0e-2f));
 
 	} else {
 		// default value

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -43,6 +43,7 @@ set(SRCS
 	test_AlphaFilter.cpp
 	test_EKF_fusionLogic.cpp
 	test_EKF_initialization.cpp
+	test_EKF_externalVision.cpp
    )
 add_executable(ECL_GTESTS ${SRCS})
 

--- a/test/sensor_simulator/CMakeLists.txt
+++ b/test/sensor_simulator/CMakeLists.txt
@@ -42,6 +42,7 @@ set(SRCS
 	gps.cpp
 	flow.cpp
 	range_finder.cpp
+	vio.cpp
    )
 
 add_library(ecl_sensor_sim ${SRCS})

--- a/test/sensor_simulator/ekf_wrapper.cpp
+++ b/test/sensor_simulator/ekf_wrapper.cpp
@@ -44,6 +44,67 @@ bool EkfWrapper::isIntendingFlowFusion() const
 	return control_status.flags.opt_flow;
 }
 
+void EkfWrapper::enableExternalVisionPositionFusion()
+{
+	_ekf_params->fusion_mode |= MASK_USE_EVPOS;
+}
+
+void EkfWrapper::disableExternalVisionPositionFusion()
+{
+	_ekf_params->fusion_mode &= ~MASK_USE_EVPOS;
+}
+
+bool EkfWrapper::isIntendingExternalVisionPositionFusion() const
+{
+	filter_control_status_u control_status;
+	_ekf->get_control_mode(&control_status.value);
+	return control_status.flags.ev_pos;
+}
+
+void EkfWrapper::enableExternalVisionVelocityFusion()
+{
+	_ekf_params->fusion_mode |= MASK_USE_EVVEL;
+}
+
+void EkfWrapper::disableExternalVisionVelocityFusion()
+{
+	_ekf_params->fusion_mode &= ~MASK_USE_EVVEL;
+}
+
+bool EkfWrapper::isIntendingExternalVisionVelocityFusion() const
+{
+	filter_control_status_u control_status;
+	_ekf->get_control_mode(&control_status.value);
+	return control_status.flags.ev_vel;
+}
+
+void EkfWrapper::enableExternalVisionHeadingFusion()
+{
+	_ekf_params->fusion_mode |= MASK_USE_EVYAW;
+}
+
+void EkfWrapper::disableExternalVisionHeadingFusion()
+{
+	_ekf_params->fusion_mode &= ~MASK_USE_EVYAW;
+}
+
+bool EkfWrapper::isIntendingExternalVisionHeadingFusion() const
+{
+	filter_control_status_u control_status;
+	_ekf->get_control_mode(&control_status.value);
+	return control_status.flags.ev_yaw;
+}
+
+void EkfWrapper::enableExternalVisionAlignment()
+{
+	_ekf_params->fusion_mode |= MASK_ROTATE_EV;
+}
+
+void EkfWrapper::disableExternalVisionAlignment()
+{
+	_ekf_params->fusion_mode &= ~MASK_ROTATE_EV;
+}
+
 Vector3f EkfWrapper::getPosition() const
 {
 	float temp[3];
@@ -100,4 +161,11 @@ Vector3f EkfWrapper::getPositionVariance() const
 Vector3f EkfWrapper::getVelocityVariance() const
 {
 	return Vector3f(_ekf->velocity_covariances().diag());
+}
+
+Quatf EkfWrapper::getVisionAlignmentQuaternion() const
+{
+	float temp[4];
+	_ekf->get_ev2ekf_quaternion(temp);
+	return Quatf(temp);
 }

--- a/test/sensor_simulator/ekf_wrapper.h
+++ b/test/sensor_simulator/ekf_wrapper.h
@@ -48,16 +48,27 @@ public:
 	~EkfWrapper();
 
 	void enableGpsFusion();
-
 	void disableGpsFusion();
-
 	bool isIntendingGpsFusion() const;
 
 	void enableFlowFusion();
-
 	void disableFlowFusion();
-
 	bool isIntendingFlowFusion() const;
+
+	void enableExternalVisionPositionFusion();
+	void disableExternalVisionPositionFusion();
+	bool isIntendingExternalVisionPositionFusion() const;
+
+	void enableExternalVisionVelocityFusion();
+	void disableExternalVisionVelocityFusion();
+	bool isIntendingExternalVisionVelocityFusion() const;
+
+	void enableExternalVisionHeadingFusion();
+	void disableExternalVisionHeadingFusion();
+	bool isIntendingExternalVisionHeadingFusion() const;
+
+	void enableExternalVisionAlignment();
+	void disableExternalVisionAlignment();
 
 	Vector3f getPosition() const;
 	Vector3f getVelocity() const;
@@ -69,6 +80,8 @@ public:
 	matrix::Vector<float, 4> getQuaternionVariance() const;
 	Vector3f getPositionVariance() const;
 	Vector3f getVelocityVariance() const;
+
+	Quatf getVisionAlignmentQuaternion() const;
 
 private:
 	std::shared_ptr<Ekf> _ekf;

--- a/test/sensor_simulator/sensor_simulator.cpp
+++ b/test/sensor_simulator/sensor_simulator.cpp
@@ -8,7 +8,8 @@ _mag(ekf),
 _baro(ekf),
 _gps(ekf),
 _flow(ekf),
-_rng(ekf)
+_rng(ekf),
+_vio(ekf)
 {
 	setSensorDataToDefault();
 	setSensorRateToDefault();
@@ -28,6 +29,7 @@ void SensorSimulator::setSensorDataToDefault()
 	_gps.setRateHz(5);
 	_flow.setRateHz(50);
 	_rng.setRateHz(30);
+	_vio.setRateHz(30);
 }
 void SensorSimulator::setSensorRateToDefault()
 {
@@ -38,6 +40,7 @@ void SensorSimulator::setSensorRateToDefault()
 	_gps.setData(_gps.getDefaultGpsData());
 	_flow.setData(_flow.dataAtRest());
 	_rng.setData(0.2f, 100);
+	_vio.setData(_vio.dataAtRest());
 }
 void SensorSimulator::startBasicSensor()
 {
@@ -64,6 +67,7 @@ void SensorSimulator::runMicroseconds(uint32_t duration)
 		_gps.update(_time);
 		_flow.update(_time);
 		_rng.update(_time);
+		_vio.update(_time);
 
 		_ekf->update();
 	}

--- a/test/sensor_simulator/vio.cpp
+++ b/test/sensor_simulator/vio.cpp
@@ -1,0 +1,69 @@
+#include "vio.h"
+
+namespace sensor_simulator
+{
+namespace sensor
+{
+
+Vio::Vio(std::shared_ptr<Ekf> ekf):Sensor(ekf)
+{
+}
+
+Vio::~Vio()
+{
+}
+
+void Vio::send(uint32_t time)
+{
+	_ekf->setExtVisionData(time, &_vio_data);
+}
+
+void Vio::setData(const ext_vision_message& vio_data)
+{
+	_vio_data = vio_data;
+}
+
+void Vio::setVelocityVariance(const Vector3f& velVar)
+{
+	_vio_data.velVar = velVar;
+}
+
+void Vio::setPositionVariance(const Vector3f& posVar)
+{
+	_vio_data.posVar = posVar;
+}
+
+void Vio::setAngularVariance(float angVar)
+{
+	_vio_data.angVar = angVar;
+}
+
+void Vio::setVelocity(const Vector3f& vel)
+{
+	_vio_data.vel = vel;
+}
+
+void Vio::setPosition(const Vector3f& pos)
+{
+	_vio_data.pos = pos;
+}
+
+void Vio::setOrientation(const Quatf& quat)
+{
+	_vio_data.quat = quat;
+}
+
+ext_vision_message Vio::dataAtRest()
+{
+	ext_vision_message vio_data;
+	vio_data.pos = Vector3f{0.0f, 0.0f, 0.0f};;
+	vio_data.vel = Vector3f{0.0f, 0.0f, 0.0f};;
+	vio_data.quat = Quatf{1.0f, 0.0f, 0.0f, 0.0f};
+	vio_data.posVar = Vector3f{0.1f, 0.1f, 0.1f};
+	vio_data.velVar = Vector3f{0.1f, 0.1f, 0.1f};
+	vio_data.angVar = 0.05f;
+	return vio_data;
+}
+
+} // namespace sensor
+} // namespace sensor_simulator

--- a/test/sensor_simulator/vio.h
+++ b/test/sensor_simulator/vio.h
@@ -32,68 +32,40 @@
  ****************************************************************************/
 
 /**
- * This class is providing methods to feed the ECL EKF with measurement.
- * It takes a pointer to the Ekf object and will manipulate the object
- * by call set*Data functions.
- * It simulates the time to allow for sensor data being set at certain rate
- * and also calls the update method of the EKF
+ * Feeds Ekf external vision data
  * @author Kamil Ritz <ka.ritz@hotmail.com>
  */
-
 #pragma once
 
-#include <memory>
+#include "sensor.h"
 
-#include "imu.h"
-#include "mag.h"
-#include "baro.h"
-#include "gps.h"
-#include "flow.h"
-#include "range_finder.h"
-#include "vio.h"
-#include "EKF/ekf.h"
-
-using namespace sensor_simulator::sensor;
-
-class SensorSimulator
+namespace sensor_simulator
+{
+namespace sensor
 {
 
-private:
-	std::shared_ptr<Ekf> _ekf;
-
-	uint32_t _time {0};	// in microseconds
-
-	void setSensorDataToDefault();
-	void setSensorRateToDefault();
-	void startBasicSensor();
-
+class Vio: public Sensor
+{
 public:
-	SensorSimulator(std::shared_ptr<Ekf> ekf);
-	~SensorSimulator();
+	Vio(std::shared_ptr<Ekf> ekf);
+	~Vio();
 
-	void runSeconds(float duration_seconds);
-	void runMicroseconds(uint32_t duration);
+	void setData(const ext_vision_message& vio_data);
+	void setVelocityVariance(const Vector3f& velVar);
+	void setPositionVariance(const Vector3f& posVar);
+	void setAngularVariance(float angVar);
+	void setVelocity(const Vector3f& vel);
+	void setPosition(const Vector3f& pos);
+	void setOrientation(const Quatf& quat);
 
-	void startGps(){ _gps.start(); }
-	void stopGps(){ _gps.stop(); }
+	ext_vision_message dataAtRest();
 
-	void startFlow(){ _flow.start(); }
-	void stopFlow(){ _flow.stop(); }
+private:
+	ext_vision_message _vio_data;
 
-	void startRangeFinder(){ _rng.start(); }
-	void stopRangeFinder(){ _rng.stop(); }
+	void send(uint32_t time) override;
 
-	void startExternalVision(){ _vio.start(); }
-	void stopExternalVision(){ _vio.stop(); }
-
-	void setImuBias(Vector3f accel_bias, Vector3f gyro_bias);
-	void simulateOrientation(Quatf orientation);
-
-	Imu _imu;
-	Mag _mag;
-	Baro _baro;
-	Gps _gps;
-	Flow _flow;
-	RangeFinder _rng;
-	Vio _vio;
 };
+
+} // namespace sensor
+} // namespace sensor_simulator

--- a/test/test_EKF_externalVision.cpp
+++ b/test/test_EKF_externalVision.cpp
@@ -1,0 +1,147 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2019 ECL Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * Test the external vision functionality
+ * @author Kamil Ritz <ka.ritz@hotmail.com>
+ */
+
+#include <gtest/gtest.h>
+#include "EKF/ekf.h"
+#include "sensor_simulator/sensor_simulator.h"
+#include "sensor_simulator/ekf_wrapper.h"
+
+
+class EkfExternalVisionTest : public ::testing::Test {
+ public:
+
+	EkfExternalVisionTest(): ::testing::Test(),
+	_ekf{std::make_shared<Ekf>()},
+	_sensor_simulator(_ekf),
+	_ekf_wrapper(_ekf) {};
+
+	std::shared_ptr<Ekf> _ekf;
+	SensorSimulator _sensor_simulator;
+	EkfWrapper _ekf_wrapper;
+
+	// Setup the Ekf with synthetic measurements
+	void SetUp() override
+	{
+		_ekf->init(0);
+		_sensor_simulator.runSeconds(2);
+	}
+
+	// Use this method to clean up any memory, network etc. after each test
+	void TearDown() override
+	{
+	}
+};
+
+TEST_F(EkfExternalVisionTest, checkVisionFusionLogic)
+{
+	_ekf_wrapper.enableExternalVisionPositionFusion();
+	_sensor_simulator.startExternalVision();
+	_sensor_simulator.runSeconds(2);
+
+	EXPECT_TRUE(_ekf_wrapper.isIntendingExternalVisionPositionFusion());
+	EXPECT_FALSE(_ekf_wrapper.isIntendingExternalVisionVelocityFusion());
+	EXPECT_FALSE(_ekf_wrapper.isIntendingExternalVisionHeadingFusion());
+
+	EXPECT_TRUE(_ekf->local_position_is_valid());
+	EXPECT_FALSE(_ekf->global_position_is_valid());
+
+	_ekf_wrapper.enableExternalVisionVelocityFusion();
+	_sensor_simulator.runSeconds(2);
+
+	EXPECT_TRUE(_ekf_wrapper.isIntendingExternalVisionPositionFusion());
+	EXPECT_TRUE(_ekf_wrapper.isIntendingExternalVisionVelocityFusion());
+	EXPECT_FALSE(_ekf_wrapper.isIntendingExternalVisionHeadingFusion());
+
+	EXPECT_TRUE(_ekf->local_position_is_valid());
+	EXPECT_FALSE(_ekf->global_position_is_valid());
+
+	_ekf_wrapper.enableExternalVisionHeadingFusion();
+	_sensor_simulator.runSeconds(2);
+
+	EXPECT_TRUE(_ekf_wrapper.isIntendingExternalVisionPositionFusion());
+	EXPECT_TRUE(_ekf_wrapper.isIntendingExternalVisionVelocityFusion());
+	EXPECT_TRUE(_ekf_wrapper.isIntendingExternalVisionHeadingFusion());
+
+	EXPECT_TRUE(_ekf->local_position_is_valid());
+	EXPECT_FALSE(_ekf->global_position_is_valid());
+}
+
+TEST_F(EkfExternalVisionTest, visionVarianceCheck)
+{
+	const Vector3f velVar_init = _ekf_wrapper.getVelocityVariance();
+	EXPECT_NEAR(velVar_init(0), velVar_init(1), 0.0001);
+
+	_sensor_simulator._vio.setVelocityVariance(Vector3f{2.0f,0.01f,0.01f});
+	_ekf_wrapper.enableExternalVisionVelocityFusion();
+	_sensor_simulator.startExternalVision();
+	_sensor_simulator.runSeconds(4);
+
+	const Vector3f velVar_new = _ekf_wrapper.getVelocityVariance();
+	EXPECT_TRUE(velVar_new(0) > velVar_new(1));
+}
+
+TEST_F(EkfExternalVisionTest, visionAlignment)
+{
+	// GIVEN: Drone is pointing north, and we use mag (ROTATE_EV)
+	//        Heading of drone in EKF frame is 0°
+
+	// WHEN: Vision frame is rotate +90°. The reported heading is -90°
+	Quatf externalVisionFrameOffset(Eulerf(0.0f,0.0f,math::radians(90.0f)));
+	_sensor_simulator._vio.setOrientation(externalVisionFrameOffset.inversed());
+	_ekf_wrapper.enableExternalVisionAlignment();
+
+	// Simulate high uncertainty on vision x axis which is in this case
+	// the y EKF frame axis
+	_sensor_simulator._vio.setVelocityVariance(Vector3f{2.0f,0.01f,0.01f});
+	_ekf_wrapper.enableExternalVisionVelocityFusion();
+	_sensor_simulator.startExternalVision();
+
+	const Vector3f velVar_init = _ekf_wrapper.getVelocityVariance();
+	EXPECT_NEAR(velVar_init(0), velVar_init(1), 0.0001);
+
+	_sensor_simulator.runSeconds(4);
+
+	// THEN: velocity uncertainty in y should be bigger
+	const Vector3f velVar_new = _ekf_wrapper.getVelocityVariance();
+	EXPECT_TRUE(velVar_new(1) > velVar_new(0));
+
+	// THEN: the frame offset should be estimated correctly
+	Quatf estimatedExternalVisionFrameOffset = _ekf_wrapper.getVisionAlignmentQuaternion();
+	EXPECT_TRUE(matrix::isEqual(externalVisionFrameOffset.canonical(),
+				    estimatedExternalVisionFrameOffset.canonical()));
+}

--- a/test/test_EKF_fusionLogic.cpp
+++ b/test/test_EKF_fusionLogic.cpp
@@ -32,7 +32,7 @@
  ****************************************************************************/
 
 /**
- * Feeds Ekf with Imu data
+ * Test the fusion start and stop logic
  * @author Kamil Ritz <ka.ritz@hotmail.com>
  */
 
@@ -58,7 +58,7 @@ class EkfFusionLogicTest : public ::testing::Test {
 	void SetUp() override
 	{
 		_ekf->init(0);
-		_sensor_simulator.runSeconds(5);
+		_sensor_simulator.runSeconds(2);
 	}
 
 	// Use this method to clean up any memory, network etc. after each test
@@ -74,7 +74,7 @@ TEST_F(EkfFusionLogicTest, doGpsFusion)
 	// WHEN: we enable GPS fusion and we send good quality gps data for 11s
 	_ekf_wrapper.enableGpsFusion();
 	_sensor_simulator.startGps();
-	_sensor_simulator.runSeconds(15);
+	_sensor_simulator.runSeconds(11);
 
 	// THEN: EKF should intend to fuse GPS
 	EXPECT_TRUE(_ekf_wrapper.isIntendingGpsFusion());
@@ -151,7 +151,7 @@ TEST_F(EkfFusionLogicTest, doFlowFusion)
 	// WHEN: sending flow data without having the flow fusion enabled
 	//       flow measurement fusion should not be intended.
 	_sensor_simulator.startFlow();
-	_sensor_simulator.runSeconds(3);
+	_sensor_simulator.runSeconds(4);
 
 	// THEN: EKF should intend to fuse flow measurements
 	EXPECT_FALSE(_ekf_wrapper.isIntendingFlowFusion());


### PR DESCRIPTION
This PR add support to use all variance information in the visual_odometry message. It uses a 3d variance for position and velocity. Since we only fuse visual heading and not attitude, we do only support a one-dimensional uncertainty for the heading. 
Since external vision fusion in ECL is still fusing single measurement sequentially, we can not profit from the covariance values at the moment, so they are not added to the interface.

Secondly, the interface is expanded such that a 3D auxiliary velocity vector is passed instead of 2d vector. The vertical velocity is not fused at the moment. Since the control logic is not in place at the moment. This will be added, when we add finer fusion control granularity for all sensors.

See [here]() for the corresponding Firmware PR.

Unit tested cases:
- fusion start logic for external vision position, velocity and heading
- state's horizontal velocity uncertainty is decreasing faster in direction of smaller uncertainty in vision velocity measurement. Also in case where we have to align vision reference frame
- correct estimation of the alignment of the vision reference