### PR TITLE
Remove obsolete code in "initialiseFilter"

### DIFF
--- a/EKF/ekf.cpp
+++ b/EKF/ekf.cpp
@@ -267,11 +267,6 @@ bool Ekf::initialiseFilter()
 			_state.pos(2) = -math::max(_rng_filt_state * _R_rng_to_earth_2_2, _params.rng_gnd_clearance);
 			ECL_INFO_TIMESTAMPED("EKF using range finder height - commencing alignment");
 
-		} else if (_control_status.flags.ev_hgt) {
-			// if we are using external vision data for height, then the vertical position state needs to be reset
-			// because the initialisation position is not the zero datum
-			resetHeight();
-
 		}
 
 		// try to initialise the terrain estimator

--- a/EKF/ekf.cpp
+++ b/EKF/ekf.cpp
@@ -259,16 +259,6 @@ bool Ekf::initialiseFilter()
 			increaseQuatYawErrVariance(sq(fmaxf(_params.mag_heading_noise, 1.0e-2f)));
 		}
 
-		if (_control_status.flags.rng_hgt) {
-			// if we are using the range finder as the primary source, then calculate the baro height at origin so  we can use baro as a backup
-			// so it can be used as a backup ad set the initial height using the range finder
-			const baroSample &baro_newest = _baro_buffer.get_newest();
-			_baro_hgt_offset = baro_newest.hgt;
-			_state.pos(2) = -math::max(_rng_filt_state * _R_rng_to_earth_2_2, _params.rng_gnd_clearance);
-			ECL_INFO_TIMESTAMPED("EKF using range finder height - commencing alignment");
-
-		}
-
 		// try to initialise the terrain estimator
 		_terrain_initialised = initHagl();
 

--- a/EKF/ekf.cpp
+++ b/EKF/ekf.cpp
@@ -177,11 +177,6 @@ bool Ekf::initialiseFilter()
 		}
 	}
 
-	// set the default height source from the adjustable parameter
-	if (_hgt_counter == 0) {
-		_primary_hgt_source = _params.vdist_sensor_type;
-	}
-
 	// accumulate enough height measurements to be confident in the quality of the data
 	// we use baro height initially and switch to GPS/range/EV finder later when it passes checks.
 	if (_baro_buffer.pop_first_older_than(_imu_sample_delayed.time_us, &_baro_sample_delayed)) {

--- a/EKF/ekf.cpp
+++ b/EKF/ekf.cpp
@@ -254,10 +254,7 @@ bool Ekf::initialiseFilter()
 		initialiseCovariance();
 
 		// update the yaw angle variance using the variance of the measurement
-		if (_control_status.flags.ev_yaw) {
-			// using error estimate from external vision data TODO: this is never true
-			increaseQuatYawErrVariance(sq(fmaxf(_ev_sample_delayed.angErr, 1.0e-2f)));
-		} else if (_params.mag_fusion_type <= MAG_FUSE_TYPE_3D) {
+		if (_params.mag_fusion_type <= MAG_FUSE_TYPE_3D) {
 			// using magnetic heading tuning parameter
 			increaseQuatYawErrVariance(sq(fmaxf(_params.mag_heading_noise, 1.0e-2f)));
 		}

--- a/EKF/ekf.cpp
+++ b/EKF/ekf.cpp
@@ -177,26 +177,6 @@ bool Ekf::initialiseFilter()
 		}
 	}
 
-	// Count the number of external vision measurements received
-	if (_ext_vision_buffer.pop_first_older_than(_imu_sample_delayed.time_us, &_ev_sample_delayed)) {
-		if ((_ev_counter == 0) && (_ev_sample_delayed.time_us != 0)) {
-			// initialise the counter
-			_ev_counter = 1;
-
-			// set the height fusion mode to use external vision data when we start getting valid data from the buffer
-			if (_primary_hgt_source == VDIST_SENSOR_EV) {
-				_control_status.flags.baro_hgt = false;
-				_control_status.flags.gps_hgt = false;
-				_control_status.flags.rng_hgt = false;
-				_control_status.flags.ev_hgt = true;
-			}
-
-		} else if ((_ev_counter != 0) && (_ev_sample_delayed.time_us != 0)) {
-			// increment the sample count
-			_ev_counter ++;
-		}
-	}
-
 	// set the default height source from the adjustable parameter
 	if (_hgt_counter == 0) {
 		_primary_hgt_source = _params.vdist_sensor_type;

--- a/EKF/ekf.h
+++ b/EKF/ekf.h
@@ -505,7 +505,6 @@ private:
 	bool _baro_hgt_faulty{false};		///< true if valid baro data is unavailable for use
 	bool _gps_hgt_intermittent{false};	///< true if gps height into the buffer is intermittent
 	bool _rng_hgt_valid{false};		///< true if range finder sample retrieved from buffer is valid
-	int _primary_hgt_source{VDIST_SENSOR_BARO};	///< specifies primary source of height data
 	uint64_t _time_bad_rng_signal_quality{0};	///< timestamp at which range finder signal quality was 0 (used for hysteresis)
 
 	// imu fault status

--- a/EKF/ekf.h
+++ b/EKF/ekf.h
@@ -466,7 +466,6 @@ private:
 	uint32_t _hgt_counter{0};		///< number of height samples read during initialisation
 	float _rng_filt_state{0.0f};		///< filtered height measurement (m)
 	uint32_t _mag_counter{0};		///< number of magnetometer samples read during initialisation
-	uint32_t _ev_counter{0};		///< number of external vision samples read during initialisation
 	uint64_t _time_last_mag{0};		///< measurement time of last magnetomter sample (uSec)
 	AlphaFilterVector3f _mag_lpf;		///< filtered magnetometer measurement (Gauss)
 	Vector3f _delVel_sum;			///< summed delta velocity (m/sec)

--- a/EKF/gps_checks.cpp
+++ b/EKF/gps_checks.cpp
@@ -90,7 +90,7 @@ bool Ekf::collect_gps(const gps_message &gps)
 		_gps_origin_epv = gps.epv;
 
 		// if the user has selected GPS as the primary height source, switch across to using it
-		if (_primary_hgt_source == VDIST_SENSOR_GPS) {
+		if (_params.vdist_sensor_type == VDIST_SENSOR_GPS) {
 			ECL_INFO_TIMESTAMPED("EKF GPS checks passed (WGS-84 origin set, using GPS height)");
 			_control_status.flags.baro_hgt = false;
 			_control_status.flags.gps_hgt = true;

--- a/EKF/gps_checks.cpp
+++ b/EKF/gps_checks.cpp
@@ -92,9 +92,7 @@ bool Ekf::collect_gps(const gps_message &gps)
 		// if the user has selected GPS as the primary height source, switch across to using it
 		if (_params.vdist_sensor_type == VDIST_SENSOR_GPS) {
 			ECL_INFO_TIMESTAMPED("EKF GPS checks passed (WGS-84 origin set, using GPS height)");
-			_control_status.flags.baro_hgt = false;
-			_control_status.flags.gps_hgt = true;
-			_control_status.flags.rng_hgt = false;
+			setControlGPSHeight();
 			// zero the sensor offset
 			_hgt_sensor_offset = 0.0f;
 		} else {


### PR DESCRIPTION
This PR removes three obsolete code pieces during filter initialization. 

1) There was a `_ev_counter` counting incoming vision samples. It was never used.

2) An IF statement is checking the for the `ev_yaw` flag during initialization. The `ev_yaw` flag can not be true before entering the `controlFusionMode()` function, which happens only after successful initialization.

3) We allowed to initialize to vision height directly during initialization. This is not necessary, since the same switch to vision height will happen [here](https://github.com/PX4/ecl/blob/master/EKF/control.cpp#L1116).

4) An IF statement is checking the for the `rng_hgt` flag during initialization. The `rng_hgt` flag can not be true before entering the `controlFusionMode()` function, which happens only after successful initialization. I checked with setting `EKF2_HGT_MODE=range_sensor`.

@dagar This safes 500B of flash. Please wait for pulling this into Firmware. We need the space for ECL changes.