### PR TITLE
Remove resetStates(AndCovariances) functions

### DIFF
--- a/EKF/ekf.h
+++ b/EKF/ekf.h
@@ -57,9 +57,6 @@ public:
 	// set the internal states and status to their default value
 	void reset(uint64_t timestamp) override;
 
-	void resetStatesAndCovariances() override;
-	void resetStates() override;
-
 	// should be called every time new data is pushed into the filter
 	bool update() override;
 

--- a/EKF/estimator_interface.h
+++ b/EKF/estimator_interface.h
@@ -63,8 +63,7 @@ public:
 
 	virtual bool init(uint64_t timestamp) = 0;
 	virtual void reset(uint64_t timestamp) = 0;
-	virtual void resetStates() = 0;
-	virtual void resetStatesAndCovariances() = 0;
+
 	virtual bool update() = 0;
 
 	virtual void getGpsVelPosInnov(float hvel[2], float &vvel, float hpos[2], float &vpos) = 0;


### PR DESCRIPTION
The `resetStates()` function did a reset to a unit quaternion.  This is only wanted during a complete reset, together with setting the flag `_filter_initialised` to false. This triggers  than a new tilt and heading alignment.

With this PR I suggest to remove the resetStates(AndCovariances) functions and put their code directly in to their only caller. 

This helps to then to add a new reinitialize method. @bresch 
