### PR TITLE
Random cleanup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -132,7 +132,7 @@ if(CMAKE_SOURCE_DIR STREQUAL PROJECT_SOURCE_DIR)
 	include(ExternalProject)
 	ExternalProject_Add(matrix
 			GIT_REPOSITORY "https://github.com/PX4/Matrix.git"
-			GIT_TAG 2f6398168d04451998cbb60b44d7f4898279caf0
+			GIT_TAG 4f3565da94d00c4cd1feb560f1f72a81296522f8
 			UPDATE_COMMAND ""
 			PATCH_COMMAND ""
 			CONFIGURE_COMMAND ""

--- a/EKF/common.h
+++ b/EKF/common.h
@@ -66,7 +66,7 @@ struct gps_message {
 	float epv;		///< GPS vertical position accuracy in m
 	float sacc;		///< GPS speed accuracy in m/s
 	float vel_m_s;		///< GPS ground speed (m/sec)
-	float vel_ned[3];	///< GPS ground speed NED
+	float vel_ned[3];	///< GPS ground speed NED - TODO: make Vector3f
 	bool vel_ned_valid;	///< GPS ground speed is valid
 	uint8_t nsats;		///< number of satellites used
 	float pdop;		///< position dilution of precision

--- a/EKF/control.cpp
+++ b/EKF/control.cpp
@@ -415,7 +415,7 @@ void Ekf::controlOpticalFlowFusion()
 
 		const bool motion_is_excessive = ((accel_norm > (CONSTANTS_ONE_G * 1.5f)) // upper g limit
 					    || (accel_norm < (CONSTANTS_ONE_G * 0.5f)) // lower g limit
-					    || (_ang_rate_mag_filt > _flow_max_rate) // angular rate exceeds flow sensor limit
+					    || (_ang_rate_magnitude_filt > _flow_max_rate) // angular rate exceeds flow sensor limit
 					    || (_R_to_earth(2,2) < cosf(math::radians(30.0f)))); // tilted excessively
 
 		if (motion_is_excessive) {
@@ -1136,7 +1136,7 @@ void Ekf::controlHeightFusion()
 				_hgt_sensor_offset = 0.0f;
 			}
 		}
-		// TODO: Add EV normal case here
+
 		// determine if we should use the vertical position observation
 		if (_control_status.flags.ev_hgt) {
 			_fuse_height = true;

--- a/EKF/covariance.cpp
+++ b/EKF/covariance.cpp
@@ -161,12 +161,12 @@ void Ekf::predictCovariance()
 	// inhibit learning of imu accel bias if the manoeuvre levels are too high to protect against the effect of sensor nonlinearities or bad accel data is detected
 	float alpha = math::constrain((dt / _params.acc_bias_learn_tc), 0.0f, 1.0f);
 	float beta = 1.0f - alpha;
-	_ang_rate_mag_filt = fmaxf(dt_inv * _imu_sample_delayed.delta_ang.norm(), beta * _ang_rate_mag_filt);
-	_accel_mag_filt = fmaxf(dt_inv * _imu_sample_delayed.delta_vel.norm(), beta * _accel_mag_filt);
+	_ang_rate_magnitude_filt = fmaxf(dt_inv * _imu_sample_delayed.delta_ang.norm(), beta * _ang_rate_magnitude_filt);
+	_accel_magnitude_filt = fmaxf(dt_inv * _imu_sample_delayed.delta_vel.norm(), beta * _accel_magnitude_filt);
 	_accel_vec_filt = alpha * dt_inv * _imu_sample_delayed.delta_vel + beta * _accel_vec_filt;
 
-	if (_ang_rate_mag_filt > _params.acc_bias_learn_gyr_lim
-	    || _accel_mag_filt > _params.acc_bias_learn_acc_lim
+	if (_ang_rate_magnitude_filt > _params.acc_bias_learn_gyr_lim
+	    || _accel_magnitude_filt > _params.acc_bias_learn_acc_lim
 	    || _bad_vert_accel_detected) {
 
 		// store the bias state variances to be reinstated later

--- a/EKF/ekf.cpp
+++ b/EKF/ekf.cpp
@@ -192,7 +192,7 @@ bool Ekf::initialiseFilter()
 		setControlBaroHeight();
 
 		// reset variables that are shared with post alignment GPS checks
-		_gps_pos_derived_filt(2) = 0.0f;
+		_gps_pos_deriv_filt(2) = 0.0f;
 		_gps_alt_ref = 0.0f;
 
 		if(!initialiseTilt()){

--- a/EKF/ekf.cpp
+++ b/EKF/ekf.cpp
@@ -95,8 +95,8 @@ void Ekf::reset(uint64_t timestamp)
 	_fault_status.value = 0;
 	_innov_check_fail_status.value = 0;
 
-	_accel_mag_filt = 0.0f;
-	_ang_rate_mag_filt = 0.0f;
+	_accel_magnitude_filt = 0.0f;
+	_ang_rate_magnitude_filt = 0.0f;
 	_prev_dvel_bias_var.zero();
 }
 

--- a/EKF/ekf.cpp
+++ b/EKF/ekf.cpp
@@ -192,7 +192,7 @@ bool Ekf::initialiseFilter()
 		setControlBaroHeight();
 
 		// reset variables that are shared with post alignment GPS checks
-		_gps_drift_velD = 0.0f;
+		_gps_pos_derived_filt(2) = 0.0f;
 		_gps_alt_ref = 0.0f;
 
 		if(!initialiseTilt()){

--- a/EKF/ekf.cpp
+++ b/EKF/ekf.cpp
@@ -248,13 +248,6 @@ bool Ekf::initialiseTilt()
 
 void Ekf::predictState()
 {
-	if (!_earth_rate_initialised) {
-		if (_NED_origin_initialised) {
-			calcEarthRateNED(_earth_rate_NED, (float)_pos_ref.lat_rad);
-			_earth_rate_initialised = true;
-		}
-	}
-
 	// apply imu bias corrections
 	Vector3f corrected_delta_ang = _imu_sample_delayed.delta_ang - _state.delta_ang_bias;
 	Vector3f corrected_delta_vel = _imu_sample_delayed.delta_vel - _state.delta_vel_bias;

--- a/EKF/ekf.h
+++ b/EKF/ekf.h
@@ -444,12 +444,9 @@ private:
 	float _output_tracking_error[3] {}; ///< contains the magnitude of the angle, velocity and position track errors (rad, m/s, m)
 
 	// variables used for the GPS quality checks
-	float _gpsDriftVelN{0.0f};		///< GPS north position derivative (m/sec)
-	float _gpsDriftVelE{0.0f};		///< GPS east position derivative (m/sec)
-	float _gps_drift_velD{0.0f};		///< GPS down position derivative (m/sec)
+	Vector3f _gps_pos_derived_filt;	///< GPS NED position derivative (m/sec)
+	Vector2f _gps_velNE_filt;	///< filtered GPS North and East velocity (m/sec)
 	float _gps_velD_diff_filt{0.0f};	///< GPS filtered Down velocity (m/sec)
-	float _gps_velN_filt{0.0f};		///< GPS filtered North velocity (m/sec)
-	float _gps_velE_filt{0.0f};		///< GPS filtered East velocity (m/sec)
 	uint64_t _last_gps_fail_us{0};		///< last system time in usec that the GPS failed it's checks
 	uint64_t _last_gps_pass_us{0};		///< last system time in usec that the GPS passed it's checks
 	float _gps_error_norm{1.0f};		///< normalised gps error

--- a/EKF/ekf.h
+++ b/EKF/ekf.h
@@ -336,11 +336,9 @@ private:
 	bool _tas_data_ready{false};	///< true when new true airspeed data has fallen behind the fusion time horizon and is available to be fused
 	bool _flow_for_terrain_data_ready{false}; /// same flag as "_flow_data_ready" but used for separate terrain estimator
 
-	uint64_t _time_last_fake_pos{0};	///< last time we faked position measurements to constrain tilt errors during operation without external aiding (uSec)
 	uint64_t _time_ins_deadreckon_start{0};	///< amount of time we have been doing inertial only deadreckoning (uSec)
 	bool _using_synthetic_position{false};	///< true if we are using a synthetic position to constrain drift
 
-	// TODO: Split those into sensor and measurement specifics
 	uint64_t _time_last_hor_pos_fuse{0};	///< time the last fusion of horizontal position measurements was performed (uSec)
 	uint64_t _time_last_hgt_fuse{0};	///< time the last fusion of vertical position measurements was performed (uSec)
 	uint64_t _time_last_hor_vel_fuse{0};	///< time the last fusion of horizontal velocity measurements was performed (uSec)
@@ -350,6 +348,9 @@ private:
 	uint64_t _time_last_arsp_fuse{0};	///< time the last fusion of airspeed measurements were performed (uSec)
 	uint64_t _time_last_beta_fuse{0};	///< time the last fusion of synthetic sideslip measurements were performed (uSec)
 	uint64_t _time_last_rng_ready{0};	///< time the last range finder measurement was ready (uSec)
+	uint64_t _time_last_mag{0};		///< measurement time of last magnetomter sample (uSec)
+	uint64_t _time_last_fake_pos{0};	///< last time we faked position measurements to constrain tilt errors during operation without external aiding (uSec)
+
 	Vector2f _last_known_posNE;		///< last known local NE position vector (m)
 	float _imu_collection_time_adj{0.0f};	///< the amount of time the IMU collection needs to be advanced to meet the target set by FILTER_UPDATE_PERIOD_MS (sec)
 
@@ -461,7 +462,6 @@ private:
 	bool _is_first_imu_sample{true};
 	uint32_t _baro_counter{0};		///< number of baro samples read during initialisation
 	uint32_t _mag_counter{0};		///< number of magnetometer samples read during initialisation
-	uint64_t _time_last_mag{0};		///< measurement time of last magnetomter sample (uSec)
 	AlphaFilterVector3f _mag_lpf;		///< filtered magnetometer measurement for instant reset(Gauss)
 	AlphaFilterVector3f _accel_lpf;		///< filtered accelerometer measurement for instant reset(Gauss)
 	float _hgt_sensor_offset{0.0f};		///< set as necessary if desired to maintain the same height after a height reset (m)
@@ -481,8 +481,8 @@ private:
 	// variables used to inhibit accel bias learning
 	bool _accel_bias_inhibit{false};	///< true when the accel bias learning is being inhibited
 	Vector3f _accel_vec_filt;		///< acceleration vector after application of a low pass filter (m/sec**2)
-	float _accel_mag_filt{0.0f};	///< acceleration magnitude after application of a decaying envelope filter (rad/sec)
-	float _ang_rate_mag_filt{0.0f};		///< angular rate magnitude after application of a decaying envelope filter (rad/sec)
+	float _accel_magnitude_filt{0.0f};	///< acceleration magnitude after application of a decaying envelope filter (rad/sec)
+	float _ang_rate_magnitude_filt{0.0f};		///< angular rate magnitude after application of a decaying envelope filter (rad/sec)
 	Vector3f _prev_dvel_bias_var;		///< saved delta velocity XYZ bias variances (m/sec)**2
 
 	// Terrain height state estimation

--- a/EKF/ekf.h
+++ b/EKF/ekf.h
@@ -309,7 +309,6 @@ private:
 	stateSample _state{};		///< state struct of the ekf running at the delayed time horizon
 
 	bool _filter_initialised{false};	///< true when the EKF sttes and covariances been initialised
-	bool _earth_rate_initialised{false};	///< true when we know the earth rotatin rate (requires GPS)
 
 	bool _fuse_height{false};	///< true when baro height data should be fused
 	bool _fuse_pos{false};		///< true when gps position data should be fused

--- a/EKF/ekf.h
+++ b/EKF/ekf.h
@@ -445,7 +445,7 @@ private:
 	float _output_tracking_error[3] {}; ///< contains the magnitude of the angle, velocity and position track errors (rad, m/s, m)
 
 	// variables used for the GPS quality checks
-	Vector3f _gps_pos_derived_filt;	///< GPS NED position derivative (m/sec)
+	Vector3f _gps_pos_deriv_filt;	///< GPS NED position derivative (m/sec)
 	Vector2f _gps_velNE_filt;	///< filtered GPS North and East velocity (m/sec)
 	float _gps_velD_diff_filt{0.0f};	///< GPS filtered Down velocity (m/sec)
 	uint64_t _last_gps_fail_us{0};		///< last system time in usec that the GPS failed it's checks

--- a/EKF/gps_checks.cpp
+++ b/EKF/gps_checks.cpp
@@ -145,12 +145,12 @@ bool Ekf::gps_is_good(const gps_message &gps)
 	double lon = gps.lon * 1.0e-7;
 	if (!_control_status.flags.in_air && _vehicle_at_rest) {
 		// Calculate position movement since last measurement
-		float delta_posN = 0.0f;
+		float delta_pos_n = 0.0f;
 		float delta_pos_e = 0.0f;
 
 		// calculate position movement since last GPS fix
 		if (_gps_pos_prev.timestamp > 0) {
-			map_projection_project(&_gps_pos_prev, lat, lon, &delta_posN, &delta_pos_e);
+			map_projection_project(&_gps_pos_prev, lat, lon, &delta_pos_n, &delta_pos_e);
 
 		} else {
 			// no previous position has been set
@@ -160,7 +160,7 @@ bool Ekf::gps_is_good(const gps_message &gps)
 
 		// Calculate the horizontal and vertical drift velocity components and limit to 10x the threshold
 		const Vector3f vel_limit(_params.req_hdrift, _params.req_hdrift, _params.req_vdrift);
-		Vector3f pos_derived(delta_posN, delta_pos_e, (_gps_alt_prev - 1e-3f * (float)gps.alt));
+		Vector3f pos_derived(delta_pos_n, delta_pos_e, (_gps_alt_prev - 1e-3f * (float)gps.alt));
 		pos_derived = matrix::constrain(pos_derived / dt, -10.0f * vel_limit, 10.0f * vel_limit);
 
 		// Apply a low pass filter

--- a/EKF/gps_checks.cpp
+++ b/EKF/gps_checks.cpp
@@ -76,6 +76,7 @@ bool Ekf::collect_gps(const gps_message &gps)
 		// Take the current GPS height and subtract the filter height above origin to estimate the GPS height of the origin
 		_gps_alt_ref = 1e-3f * (float)gps.alt + _state.pos(2);
 		_NED_origin_initialised = true;
+		calcEarthRateNED(_earth_rate_NED, (float)_pos_ref.lat_rad);
 		_last_gps_origin_time_us = _time_last_imu;
 
 		// set the magnetic field data returned by the geo library using the current GPS position

--- a/EKF/mag_control.cpp
+++ b/EKF/mag_control.cpp
@@ -165,7 +165,7 @@ void Ekf::runInAirYawReset()
 }
 
 bool Ekf::canRealignYawUsingGps() const
-{ 
+{
 	return _control_status.flags.fixed_wing;
 }
 
@@ -256,7 +256,7 @@ void Ekf::checkMagDeclRequired()
 void Ekf::checkMagInhibition()
 {
 	_mag_use_inhibit = shouldInhibitMag();
-	if (!_mag_use_inhibit) { 
+	if (!_mag_use_inhibit) {
 		_mag_use_not_inhibit_us = _imu_sample_delayed.time_us;
 	}
 


### PR DESCRIPTION
This PR contains three cleanups:

1) Some variables containing the acronym *mag*  for magnitude are renamed to avoid confusion.
On top, some class variables are relocated.

2) Once we acquire a Gps location we can compute the earth rotation vector in our local coordinate system. This was done in the `predictState()` function. **Misplaced responsibility**. Porting this to gps_checks.cpp save one variable.

3) While on ground we check GPS signal for drift. Previously we had a variable for each component of the position derivative. This PR adds vector quantities to reduce number of variables, lines of code and increase the readability of the code.

SITL mission test: [Log](https://review.px4.io/plot_app?log=55106fda-c011-48ee-a8cf-7958e853fa64)