### PR TITLE
mag_fusion: re-introduce delay between mag reset and fusion

### DIFF
--- a/EKF/ekf.h
+++ b/EKF/ekf.h
@@ -473,7 +473,6 @@ private:
 
 	// Variables used to control activation of post takeoff functionality
 	float _last_on_ground_posD{0.0f};	///< last vertical position when the in_air status was false (m)
-	bool _flt_mag_align_converging{false};	///< true when the in-flight mag field post alignment convergence is being performd
 	uint64_t _flt_mag_align_start_time{0};	///< time that inflight magnetic field alignment started (uSec)
 	uint64_t _time_last_mov_3d_mag_suitable{0};	///< last system time that sufficient movement to use 3-axis magnetometer fusion was detected (uSec)
 	float _saved_mag_bf_variance[4] {};	///< magnetic field state variances that have been saved for use at the next initialisation (Gauss**2)

--- a/EKF/mag_fusion.cpp
+++ b/EKF/mag_fusion.cpp
@@ -171,7 +171,9 @@ void Ekf::fuseMag()
 		return;
 	}
 
-	bool update_all_states = !_flt_mag_align_converging;
+	// For the first few seconds after in-flight alignment we allow the magnetic field state estimates to stabilise
+	// before they are used to constrain heading drift
+	const bool update_all_states = ((_imu_sample_delayed.time_us - _flt_mag_align_start_time) > (uint64_t)5e6);
 
 	// update the states and covariance using sequential fusion of the magnetometer components
 	for (uint8_t index = 0; index <= 2; index++) {


### PR DESCRIPTION
This was dropped during the mag fusion refactor PR #662 

I directly added the check in `mag_fusion.cpp` since it is only used there. Is that fine for you @priseborough or this should absolutely not be done in case of 3D mag fusion selected by the user? (before, this check was only done when auto fusion was enabled but not in 3D fusion only)