### PR TITLE
Refactor imu downsampling

### DIFF
--- a/EKF/CMakeLists.txt
+++ b/EKF/CMakeLists.txt
@@ -48,6 +48,7 @@ add_library(ecl_EKF
 	vel_pos_fusion.cpp
 	gps_yaw_fusion.cpp
 	range_finder_checks.cpp
+	imu_down_sampler.cpp
 )
 
 add_dependencies(ecl_EKF prebuild_targets)

--- a/EKF/common.h
+++ b/EKF/common.h
@@ -39,6 +39,7 @@
  * @author Siddharth Bharat Purohit <siddharthbharatpurohit@gmail.com>
  *
  */
+#pragma once
 
 #include <matrix/math.hpp>
 

--- a/EKF/ekf.h
+++ b/EKF/ekf.h
@@ -55,7 +55,7 @@ public:
 	bool init(uint64_t timestamp) override;
 
 	// set the internal states and status to their default value
-	void reset(uint64_t timestamp) override;
+	void reset() override;
 
 	bool initialiseTilt();
 
@@ -163,8 +163,6 @@ public:
 
 	// ask estimator for sensor data collection decision and do any preprocessing if required, returns true if not defined
 	bool collect_gps(const gps_message &gps) override;
-
-	bool collect_imu(const imuSample &imu) override;
 
 	// get the ekf WGS-84 origin position and height and the system time it was last set
 	// return true if the origin is valid
@@ -438,8 +436,6 @@ private:
 
 	// output predictor states
 	Vector3f _delta_angle_corr;	///< delta angle correction vector (rad)
-	imuSample _imu_down_sampled{};	///< down sampled imu data (sensor rate -> filter update rate)
-	Quatf _q_down_sampled;		///< down sampled quaternion (tracking delta angles between ekf update steps)
 	Vector3f _vel_err_integ;	///< integral of velocity tracking error (m)
 	Vector3f _pos_err_integ;	///< integral of position tracking error (m.s)
 	float _output_tracking_error[3] {}; ///< contains the magnitude of the angle, velocity and position track errors (rad, m/s, m)

--- a/EKF/estimator_interface.cpp
+++ b/EKF/estimator_interface.cpp
@@ -171,7 +171,7 @@ void EstimatorInterface::setMagData(uint64_t time_usec, float (&data)[3])
 		_mag_buffer_fail = !_mag_buffer.allocate(_obs_buffer_length);
 
 		if (_mag_buffer_fail) {
-			ECL_ERR_TIMESTAMPED("mag buffer allocation failed");
+			printBufferAllocationFailed("mag");
 			return;
 		}
 	}
@@ -203,7 +203,7 @@ void EstimatorInterface::setGpsData(uint64_t time_usec, const gps_message &gps)
 		_gps_buffer_fail = !_gps_buffer.allocate(_obs_buffer_length);
 
 		if (_gps_buffer_fail) {
-			ECL_ERR_TIMESTAMPED("GPS buffer allocation failed");
+			printBufferAllocationFailed("GPS");
 			return;
 		}
 	}
@@ -264,7 +264,7 @@ void EstimatorInterface::setBaroData(uint64_t time_usec, float data)
 		_baro_buffer_fail = !_baro_buffer.allocate(_obs_buffer_length);
 
 		if (_baro_buffer_fail) {
-			ECL_ERR_TIMESTAMPED("baro buffer allocation failed");
+			printBufferAllocationFailed("baro");
 			return;
 		}
 	}
@@ -297,7 +297,7 @@ void EstimatorInterface::setAirspeedData(uint64_t time_usec, float true_airspeed
 		_airspeed_buffer_fail = !_airspeed_buffer.allocate(_obs_buffer_length);
 
 		if (_airspeed_buffer_fail) {
-			ECL_ERR_TIMESTAMPED("airspeed buffer allocation failed");
+			printBufferAllocationFailed("airspeed");
 			return;
 		}
 	}
@@ -327,7 +327,7 @@ void EstimatorInterface::setRangeData(uint64_t time_usec, float data, int8_t qua
 		_range_buffer_fail = !_range_buffer.allocate(_obs_buffer_length);
 
 		if (_range_buffer_fail) {
-			ECL_ERR_TIMESTAMPED("range finder buffer allocation failed");
+			printBufferAllocationFailed("range");
 			return;
 		}
 	}
@@ -357,7 +357,7 @@ void EstimatorInterface::setOpticalFlowData(uint64_t time_usec, flow_message *fl
 		_flow_buffer_fail = !_flow_buffer.allocate(_imu_buffer_length);
 
 		if (_flow_buffer_fail) {
-			ECL_ERR_TIMESTAMPED("optical flow buffer allocation failed");
+			printBufferAllocationFailed("flow");
 			return;
 		}
 	}
@@ -423,7 +423,7 @@ void EstimatorInterface::setExtVisionData(uint64_t time_usec, ext_vision_message
 		_ev_buffer_fail = !_ext_vision_buffer.allocate(_obs_buffer_length);
 
 		if (_ev_buffer_fail) {
-			ECL_ERR_TIMESTAMPED("external vision buffer allocation failed");
+			printBufferAllocationFailed("vision");
 			return;
 		}
 	}
@@ -459,7 +459,7 @@ void EstimatorInterface::setAuxVelData(uint64_t time_usec, const Vector3f &veloc
 		_auxvel_buffer_fail = !_auxvel_buffer.allocate(_obs_buffer_length);
 
 		if (_auxvel_buffer_fail) {
-			ECL_ERR_TIMESTAMPED("aux vel buffer allocation failed");
+			printBufferAllocationFailed("aux vel");
 			return;
 		}
 	}
@@ -508,30 +508,15 @@ bool EstimatorInterface::initialise_interface(uint64_t timestamp)
 	      _output_buffer.allocate(_imu_buffer_length) &&
 	      _output_vert_buffer.allocate(_imu_buffer_length))) {
 
-		ECL_ERR_TIMESTAMPED("buffer allocation failed!");
+		printBufferAllocationFailed("");
 		unallocate_buffers();
 		return false;
 	}
 
-	_dt_imu_avg = 0.0f;
-
-	_imu_sample_delayed.delta_ang.setZero();
-	_imu_sample_delayed.delta_vel.setZero();
-	_imu_sample_delayed.delta_ang_dt = 0.0f;
-	_imu_sample_delayed.delta_vel_dt = 0.0f;
 	_imu_sample_delayed.time_us = timestamp;
 
-	_initialised = false;
-
-	_time_last_imu = 0;
-	_time_last_gps = 0;
-	_time_last_mag = 0;
-	_time_last_baro = 0;
-	_time_last_range = 0;
-	_time_last_airspeed = 0;
-	_time_last_optflow = 0;
 	_fault_status.value = 0;
-	_time_last_ext_vision = 0;
+
 	return true;
 }
 
@@ -558,6 +543,14 @@ bool EstimatorInterface::local_position_is_valid()
 	return !_deadreckon_time_exceeded;
 }
 
+void EstimatorInterface::printBufferAllocationFailed(const char * buffer_name)
+{
+	if(buffer_name)
+	{
+		ECL_ERR_TIMESTAMPED("%s buffer allocation failed", buffer_name);
+	}
+}
+
 void EstimatorInterface::print_status()
 {
 	ECL_INFO("local position valid: %s", local_position_is_valid() ? "yes" : "no");
@@ -570,7 +563,7 @@ void EstimatorInterface::print_status()
 	ECL_INFO("range buffer: %d (%d Bytes)", _range_buffer.get_length(), _range_buffer.get_total_size());
 	ECL_INFO("airspeed buffer: %d (%d Bytes)", _airspeed_buffer.get_length(), _airspeed_buffer.get_total_size());
 	ECL_INFO("flow buffer: %d (%d Bytes)", _flow_buffer.get_length(), _flow_buffer.get_total_size());
-	ECL_INFO("ext vision buffer: %d (%d Bytes)", _ext_vision_buffer.get_length(), _ext_vision_buffer.get_total_size());
+	ECL_INFO("vision buffer: %d (%d Bytes)", _ext_vision_buffer.get_length(), _ext_vision_buffer.get_total_size());
 	ECL_INFO("output buffer: %d (%d Bytes)", _output_buffer.get_length(), _output_buffer.get_total_size());
 	ECL_INFO("output vert buffer: %d (%d Bytes)", _output_vert_buffer.get_length(), _output_vert_buffer.get_total_size());
 	ECL_INFO("drag buffer: %d (%d Bytes)", _drag_buffer.get_length(), _drag_buffer.get_total_size());

--- a/EKF/estimator_interface.h
+++ b/EKF/estimator_interface.h
@@ -566,9 +566,10 @@ protected:
 	// calculate the inverse rotation matrix from a quaternion rotation
 	Matrix3f quat_to_invrotmat(const Quatf &quat);
 
-	void setDragData();
+	inline void setDragData();
 
-	void computeVibrationMetric();
-	bool checkIfVehicleAtRest(float dt);
+	inline void computeVibrationMetric();
+	inline bool checkIfVehicleAtRest(float dt);
+
 	void printBufferAllocationFailed(const char * buffer_name);
 };

--- a/EKF/estimator_interface.h
+++ b/EKF/estimator_interface.h
@@ -174,35 +174,27 @@ public:
 	// accumulate and downsample IMU data to the EKF prediction rate
 	virtual bool collect_imu(const imuSample &imu) = 0;
 
-	// set delta angle imu data
 	void setIMUData(const imuSample &imu_sample);
 
 	// legacy interface for compatibility (2018-09-14)
 	void setIMUData(uint64_t time_usec, uint64_t delta_ang_dt, uint64_t delta_vel_dt, float (&delta_ang)[3], float (&delta_vel)[3]);
 
-	// set magnetometer data
 	void setMagData(uint64_t time_usec, float (&data)[3]);
 
-	// set gps data
 	void setGpsData(uint64_t time_usec, const gps_message &gps);
 
-	// set baro data
 	void setBaroData(uint64_t time_usec, float data);
 
-	// set airspeed data
 	void setAirspeedData(uint64_t time_usec, float true_airspeed, float eas2tas);
 
-	// set range data
 	void setRangeData(uint64_t time_usec, float data, int8_t quality);
 
-	// set optical flow data
 	// if optical flow sensor gyro delta angles are not available, set gyroXYZ vector fields to NaN and the EKF will use its internal delta angle data instead
 	void setOpticalFlowData(uint64_t time_usec, flow_message *flow);
 
 	// set external vision position and attitude data
 	void setExtVisionData(uint64_t time_usec, ext_vision_message *evdata);
 
-	// set auxiliary velocity data
 	void setAuxVelData(uint64_t time_usec, const Vector3f &vel, const Vector3f &variance);
 
 	// return a address to the parameters struct
@@ -574,4 +566,5 @@ protected:
 	// calculate the inverse rotation matrix from a quaternion rotation
 	Matrix3f quat_to_invrotmat(const Quatf &quat);
 
+	void printBufferAllocationFailed(const char * buffer_name);
 };

--- a/EKF/imu_down_sampler.cpp
+++ b/EKF/imu_down_sampler.cpp
@@ -13,6 +13,7 @@ ImuDownSampler::~ImuDownSampler()
 }
 
 // integrate imu samples until target dt reached
+// assumes that dt of the gyroscope is close to the dt of the accelerometer
 // returns true if target dt is reached
 bool ImuDownSampler::update(imuSample imu_sample_new)
 {

--- a/EKF/imu_down_sampler.cpp
+++ b/EKF/imu_down_sampler.cpp
@@ -1,0 +1,73 @@
+#include "imu_down_sampler.hpp"
+
+ImuDownSampler::ImuDownSampler(float target_dt_sec):
+_target_dt{target_dt_sec},
+_imu_collection_time_adj{0.0f}
+{
+	reset();
+	_imu_down_sampled.time_us = 0.0f;
+}
+
+ImuDownSampler::~ImuDownSampler()
+{
+}
+
+// integrate imu samples until target dt reached
+// returns true if target dt is reached
+bool ImuDownSampler::update(imuSample imu_sample_new)
+{
+	if(_do_reset)
+	{
+		reset();
+	}
+	// accumulate time deltas
+	_imu_down_sampled.delta_ang_dt += imu_sample_new.delta_ang_dt;
+	_imu_down_sampled.delta_vel_dt += imu_sample_new.delta_vel_dt;
+	_imu_down_sampled.time_us = imu_sample_new.time_us;
+
+	// use a quaternion to accumulate delta angle data
+	// this quaternion represents the rotation from the start to end of the accumulation period
+	const Quatf delta_q(AxisAnglef(imu_sample_new.delta_ang));
+	_delta_angle_accumulated = _delta_angle_accumulated * delta_q;
+	_delta_angle_accumulated.normalize();
+
+	// rotate the accumulated delta velocity data forward each time so it is always in the updated rotation frame
+	const Dcmf delta_R(delta_q.inversed());
+	_imu_down_sampled.delta_vel = delta_R * _imu_down_sampled.delta_vel;
+
+	// accumulate the most recent delta velocity data at the updated rotation frame
+	// assume effective sample time is halfway between the previous and current rotation frame
+	_imu_down_sampled.delta_vel += (imu_sample_new.delta_vel + delta_R * imu_sample_new.delta_vel) * 0.5f;
+
+	// check if the target time delta between filter prediction steps has been exceeded
+	if (_imu_down_sampled.delta_ang_dt >= _target_dt - _imu_collection_time_adj) {
+
+		// accumulate the amount of time to advance the IMU collection time so that we meet the
+		// average EKF update rate requirement
+		_imu_collection_time_adj += 0.01f * (_imu_down_sampled.delta_ang_dt - _target_dt);
+		_imu_collection_time_adj = math::constrain(_imu_collection_time_adj, -0.5f * _target_dt, 0.5f * _target_dt);
+
+		_imu_down_sampled.delta_ang = _delta_angle_accumulated.to_axis_angle();
+
+		return true;
+
+	} else {
+		return false;
+	}
+}
+
+imuSample ImuDownSampler::getDownSampledImuAndTriggerReset()
+{
+	_do_reset = true;
+	return _imu_down_sampled;
+}
+
+void ImuDownSampler::reset()
+{
+	_imu_down_sampled.delta_ang.setZero();
+	_imu_down_sampled.delta_vel.setZero();
+	_imu_down_sampled.delta_ang_dt = 0.0f;
+	_imu_down_sampled.delta_vel_dt = 0.0f;
+	_delta_angle_accumulated.setIdentity();
+	_do_reset = false;
+}

--- a/EKF/imu_down_sampler.hpp
+++ b/EKF/imu_down_sampler.hpp
@@ -1,0 +1,66 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2019 Estimation and Control Library (ECL). All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name ECL nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * Downsamples IMU data to a lower rate such that EKF predicition can happen less frequent
+ * @author Kamil Ritz <ka.ritz@hotmail.com>
+ */
+#pragma once
+
+#include <matrix/math.hpp>
+#include <mathlib/mathlib.h>
+
+#include "common.h"
+
+using namespace estimator;
+
+class ImuDownSampler
+{
+public:
+	ImuDownSampler(float target_dt_sec);
+	~ImuDownSampler();
+
+	bool update(imuSample imu_sample_new);
+	imuSample getDownSampledImuAndTriggerReset();
+
+private:
+	imuSample _imu_down_sampled;
+	Quatf _delta_angle_accumulated;
+	const float _target_dt; // [sec]
+	float _imu_collection_time_adj;
+	bool _do_reset;
+
+	void reset();
+
+};
+

--- a/test/test_EKF_imuSampling.cpp
+++ b/test/test_EKF_imuSampling.cpp
@@ -34,8 +34,9 @@
 #include <gtest/gtest.h>
 #include <math.h>
 #include "EKF/ekf.h"
+#include "EKF/imu_down_sampler.hpp"
 
-class EkfSamplingTestParametrized : public ::testing::TestWithParam<std::tuple<float,float>>
+class EkfImuSamplingTest : public ::testing::TestWithParam<std::tuple<float,float,Vector3f, Vector3f>>
 {
  public:
 
@@ -56,7 +57,7 @@ class EkfSamplingTestParametrized : public ::testing::TestWithParam<std::tuple<f
 	}
 };
 
-TEST_P(EkfSamplingTestParametrized, imuSamplingAtMultipleRates)
+TEST_P(EkfImuSamplingTest, imuSamplingAtMultipleRates)
 {
 	// WHEN: adding imu samples at a higher rate than the update loop
 	// THEN: imu sample should be down sampled
@@ -66,12 +67,12 @@ TEST_P(EkfSamplingTestParametrized, imuSamplingAtMultipleRates)
 	uint32_t dt_us = std::get<0>(GetParam()) * (_ekf.FILTER_UPDATE_PERIOD_MS * 1000);
 	uint32_t expected_dt_us = std::get<1>(GetParam()) * (_ekf.FILTER_UPDATE_PERIOD_MS * 1000);
 
-	Vector3f ang_vel{0.0f,0.0f,0.0f};
-	Vector3f accel{-0.46f,0.87f,0.0f};
+	Vector3f ang_vel= std::get<2>(GetParam());
+	Vector3f accel = std::get<3>(GetParam());
 	imuSample imu_sample;
-	imu_sample.delta_ang_dt = dt_us * 1.e-6f;
+	imu_sample.delta_ang_dt = dt_us * 1.0e-6f;
 	imu_sample.delta_ang = ang_vel * imu_sample.delta_ang_dt;
-	imu_sample.delta_vel_dt = dt_us * 1.e-6f;
+	imu_sample.delta_vel_dt = dt_us * 1.0e-6f;
 	imu_sample.delta_vel = accel * imu_sample.delta_vel_dt;
 
 	// The higher the imu rate is the more measurements we have to set before reaching the FILTER_UPDATE_PERIOD
@@ -89,19 +90,123 @@ TEST_P(EkfSamplingTestParametrized, imuSamplingAtMultipleRates)
 
 	// WHEN: downsampling the imu measurement
 	// THEN: the delta vel should be accumulated correctly
-	EXPECT_NEAR(ang_vel(0), imu_sample_buffered.delta_ang(0)/imu_sample_buffered.delta_ang_dt, 1e-3f);
-	EXPECT_NEAR(ang_vel(1), imu_sample_buffered.delta_ang(1)/imu_sample_buffered.delta_ang_dt, 1e-3f);
-	EXPECT_NEAR(ang_vel(2), imu_sample_buffered.delta_ang(2)/imu_sample_buffered.delta_ang_dt, 1e-3f);
-	EXPECT_NEAR(accel(0), imu_sample_buffered.delta_vel(0)/imu_sample_buffered.delta_vel_dt, 1e-3f);
-	EXPECT_NEAR(accel(1), imu_sample_buffered.delta_vel(1)/imu_sample_buffered.delta_vel_dt, 1e-3f);
-	EXPECT_NEAR(accel(2), imu_sample_buffered.delta_vel(2)/imu_sample_buffered.delta_vel_dt, 1e-3f);
-
+	EXPECT_TRUE(matrix::isEqual(ang_vel, imu_sample_buffered.delta_ang/imu_sample_buffered.delta_ang_dt, 1e-7f));
+	EXPECT_TRUE(matrix::isEqual(accel, imu_sample_buffered.delta_vel/imu_sample_buffered.delta_vel_dt, 1e-7f));
 }
 
 INSTANTIATE_TEST_CASE_P(imuSamplingAtMultipleRates,
-			EkfSamplingTestParametrized,
+			EkfImuSamplingTest,
 			::testing::Values(
-				std::make_tuple<float,float>(1.0f,1.0f),
-				std::make_tuple<float,float>(1.6f,1.6f),
-				std::make_tuple<float,float>(0.333f,1.0f)
+				std::make_tuple<float,float,Vector3f,Vector3f>(1.0f,  1.0f,Vector3f{0.0f,0.0f,0.0f},Vector3f{-0.46f,0.87f,0.20f}),
+				std::make_tuple<float,float,Vector3f,Vector3f>(0.5f,  1.0f,Vector3f{0.0f,0.0f,0.0f},Vector3f{-0.46f,0.87f,0.20f}),
+				std::make_tuple<float,float,Vector3f,Vector3f>(1.6f,  1.6f,Vector3f{0.0f,0.0f,0.0f},Vector3f{-0.46f,0.87f,0.20f}),
+				std::make_tuple<float,float,Vector3f,Vector3f>(0.333f,1.0f,Vector3f{0.0f,0.0f,0.0f},Vector3f{-0.46f,0.87f,0.20f}),
+				std::make_tuple<float,float,Vector3f,Vector3f>(1.0f,  1.0f,Vector3f{1.0f,0.0f,0.0f},Vector3f{0.0f,0.0f,0.0f}),
+				std::make_tuple<float,float,Vector3f,Vector3f>(0.5f,  1.0f,Vector3f{1.0f,0.0f,0.0f},Vector3f{0.0f,0.0f,0.0f}),
+				std::make_tuple<float,float,Vector3f,Vector3f>(1.6f,  1.6f,Vector3f{1.0f,0.0f,0.0f},Vector3f{0.0f,0.0f,0.0f}),
+				std::make_tuple<float,float,Vector3f,Vector3f>(0.333f,1.0f,Vector3f{1.0f,0.0f,0.0f},Vector3f{0.0f,0.0f,0.0f}),
+				std::make_tuple<float,float,Vector3f,Vector3f>(1.0f,  1.0f,Vector3f{0.0f,1.0f,0.0f},Vector3f{0.0f,0.0f,0.0f}),
+				std::make_tuple<float,float,Vector3f,Vector3f>(0.5f,  1.0f,Vector3f{0.0f,1.0f,0.0f},Vector3f{0.0f,0.0f,0.0f}),
+				std::make_tuple<float,float,Vector3f,Vector3f>(1.6f,  1.6f,Vector3f{0.0f,1.0f,0.0f},Vector3f{0.0f,0.0f,0.0f}),
+				std::make_tuple<float,float,Vector3f,Vector3f>(0.333f,1.0f,Vector3f{0.0f,1.0f,0.0f},Vector3f{0.0f,0.0f,0.0f}),
+				std::make_tuple<float,float,Vector3f,Vector3f>(1.0f,  1.0f,Vector3f{0.0f,0.0f,1.0f},Vector3f{0.0f,0.0f,0.0f}),
+				std::make_tuple<float,float,Vector3f,Vector3f>(0.5f,  1.0f,Vector3f{0.0f,0.0f,1.0f},Vector3f{0.0f,0.0f,0.0f}),
+				std::make_tuple<float,float,Vector3f,Vector3f>(1.6f,  1.6f,Vector3f{0.0f,0.0f,1.0f},Vector3f{0.0f,0.0f,0.0f}),
+				std::make_tuple<float,float,Vector3f,Vector3f>(0.333f,1.0f,Vector3f{0.0f,0.0f,1.0f},Vector3f{0.0f,0.0f,0.0f})
 			));
+
+TEST_F(EkfImuSamplingTest, accelDownSampling)
+{
+	ImuDownSampler sampler(0.008f);
+
+	Vector3f ang_vel{0.0f,0.0f,0.0f};
+	Vector3f accel{-0.46f,0.87f,0.0f};
+	imuSample input_sample;
+	input_sample.delta_ang_dt = 0.004f;
+	input_sample.delta_ang = ang_vel * input_sample.delta_ang_dt;
+	input_sample.delta_vel_dt = 0.004f;
+	input_sample.delta_vel = accel * input_sample.delta_vel_dt;
+	input_sample.time_us = 0;
+
+	// WHEN: adding samples at the double rate as the target rate
+	EXPECT_FALSE(sampler.update(input_sample));
+	input_sample.time_us = 4000;
+
+	// THEN: after two samples a first downsampled sample is ready
+	EXPECT_TRUE(sampler.update(input_sample));
+
+	// THEN: downsampled sample should fit to input data
+	imuSample output_sample = sampler.getDownSampledImuAndTriggerReset();
+	EXPECT_FLOAT_EQ(output_sample.delta_ang_dt, 0.008f);
+	EXPECT_FLOAT_EQ(output_sample.delta_vel_dt, 0.008f);
+	EXPECT_TRUE(matrix::isEqual(ang_vel * 0.008f, output_sample.delta_ang, 1e-10f));
+	EXPECT_TRUE(matrix::isEqual(accel * 0.008f, output_sample.delta_vel, 1e-10f));
+}
+
+TEST_F(EkfImuSamplingTest, gyroDownSampling)
+{
+	ImuDownSampler sampler(0.008f);
+
+	Vector3f ang_vel{0.0f,0.0f,1.0f};
+	Vector3f accel{0.0f,0.0f,0.0f};
+	imuSample input_sample;
+
+	input_sample.delta_ang_dt = 0.004f;
+	input_sample.delta_ang = ang_vel * input_sample.delta_ang_dt;
+	input_sample.delta_vel_dt = 0.004f;
+	input_sample.delta_vel = accel * input_sample.delta_vel_dt;
+	input_sample.time_us = 0;
+
+	// WHEN: adding samples at the double rate as the target rate
+	EXPECT_FALSE(sampler.update(input_sample));
+	input_sample.time_us += 4000;
+
+	// THEN: after two samples a first downsampled sample is ready
+	EXPECT_TRUE(sampler.update(input_sample));
+	input_sample.time_us += 4000;
+
+	// THEN: downsampled sample should fit to input data
+	imuSample output_sample = sampler.getDownSampledImuAndTriggerReset();
+	EXPECT_FLOAT_EQ(output_sample.delta_ang_dt, 0.008f);
+	EXPECT_FLOAT_EQ(output_sample.delta_vel_dt, 0.008f);
+	EXPECT_TRUE(matrix::isEqual(ang_vel * 0.008f, output_sample.delta_ang, 1e-10f));
+	EXPECT_TRUE(matrix::isEqual(accel * 0.008f, output_sample.delta_vel, 1e-10f));
+
+	ang_vel = Vector3f{0.0f,1.0f,0.0f};
+	input_sample.delta_ang = ang_vel * input_sample.delta_ang_dt;
+	input_sample.delta_vel = accel * input_sample.delta_vel_dt;
+
+	// WHEN: adding samples at the double rate as the target rate
+	EXPECT_FALSE(sampler.update(input_sample));
+	input_sample.time_us += 4000;
+
+	// THEN: after two more samples a second downsampled sample is ready
+	EXPECT_TRUE(sampler.update(input_sample));
+	input_sample.time_us += 4000;
+
+	// THEN: downsampled sample should fit the adapted input data
+	output_sample = sampler.getDownSampledImuAndTriggerReset();
+	EXPECT_FLOAT_EQ(output_sample.delta_ang_dt, 0.008f);
+	EXPECT_FLOAT_EQ(output_sample.delta_vel_dt, 0.008f);
+	EXPECT_TRUE(matrix::isEqual(ang_vel * 0.008f, output_sample.delta_ang, 1e-10f));
+	EXPECT_TRUE(matrix::isEqual(accel * 0.008f, output_sample.delta_vel, 1e-10f));
+
+	ang_vel = Vector3f{1.0f,0.0f,0.0f};
+	input_sample.delta_ang = ang_vel * input_sample.delta_ang_dt;
+	input_sample.delta_vel = accel * input_sample.delta_vel_dt;
+
+	// WHEN: adding samples at the double rate as the target rate
+	EXPECT_FALSE(sampler.update(input_sample));
+	input_sample.time_us += 4000;
+
+	// THEN: after two more samples a second downsampled sample is ready
+	EXPECT_TRUE(sampler.update(input_sample));
+	input_sample.time_us += 4000;
+
+	// THEN: downsampled sample should fit the adapted input data
+	output_sample = sampler.getDownSampledImuAndTriggerReset();
+	EXPECT_FLOAT_EQ(output_sample.delta_ang_dt, 0.008f);
+	EXPECT_FLOAT_EQ(output_sample.delta_vel_dt, 0.008f);
+	EXPECT_TRUE(matrix::isEqual(ang_vel * 0.008f, output_sample.delta_ang, 1e-10f));
+	EXPECT_TRUE(matrix::isEqual(accel * 0.008f, output_sample.delta_vel, 1e-10f));
+}


### PR DESCRIPTION
This pulls out the down sampling of the IMU into a separate class. This is nice as we can hide a few variables inside the class.

Additionally it increases code readability introducing two new functions: `computeVibrationMetrics()` and `checkIfVehicleAtRest()`.

This increased the flash space by ~800 Bytes. Therefore I removed duplicated initialization of variable and reduced the number of repeatedly stored strings.

Current added flash space: 344 Bytes

**Testing:**
- Through unit tests and SITL mission test
- Flight tested in [here](https://github.com/PX4/Firmware/pull/13870)