### PR TITLE
Move baro downsampling and dynamic pressure comp to ECL

### DIFF
--- a/EKF/common.h
+++ b/EKF/common.h
@@ -342,6 +342,15 @@ struct parameters {
 
 	int32_t valid_timeout_max{5000000};	///< amount of time spent inertial dead reckoning before the estimator reports the state estimates as invalid (uSec)
 
+	// static barometer pressure position error coefficient along body axes
+	float static_pressure_coef_xp {0.0f};
+	float static_pressure_coef_xn {0.0f};
+	float static_pressure_coef_yp {0.0f};
+	float static_pressure_coef_yn {0.0f};
+	float static_pressure_coef_z {0.0f};
+	// upper limit on airspeed used for correction  (m/s**2)
+	float max_correction_airspeed {20.0f};
+
 	// multi-rotor drag specific force fusion
 	float drag_noise{2.5f};			///< observation noise variance for drag specific force measurements (m/sec**2)**2
 	float bcoef_x{25.0f};			///< ballistic coefficient along the X-axis (kg/m**2)
@@ -371,7 +380,7 @@ struct stateSample {
 	Vector3f    delta_vel_bias;	///< delta velocity bias estimate in m/s
 	Vector3f    mag_I;	///< NED earth magnetic field in gauss
 	Vector3f    mag_B;	///< magnetometer bias estimate in body frame in gauss
-	Vector2f    wind_vel;	///< wind velocity in m/s
+	Vector2f    wind_vel;	///< horizontal wind velocity in earth frame in m/s
 };
 
 union fault_status_u {

--- a/EKF/ekf.h
+++ b/EKF/ekf.h
@@ -636,6 +636,8 @@ private:
 	// and a scalar innovation value
 	void fuse(float *K, float innovation);
 
+	float compensateBaroForDynamicPressure(float baro_alt_uncompensated) override;
+
 	// calculate the earth rotation vector from a given latitude
 	Vector3f calcEarthRateNED(float lat_rad) const;
 

--- a/EKF/estimator_interface.cpp
+++ b/EKF/estimator_interface.cpp
@@ -231,7 +231,7 @@ void EstimatorInterface::setGpsData(uint64_t time_usec, const gps_message &gps)
 	}
 }
 
-void EstimatorInterface::setBaroData(uint64_t time_usec, float data)
+void EstimatorInterface::setBaroData(uint64_t time_usec, float baro_alt_meter)
 {
 	if (!_initialised || _baro_buffer_fail) {
 		return;
@@ -248,19 +248,30 @@ void EstimatorInterface::setBaroData(uint64_t time_usec, float data)
 		}
 	}
 
+	// downsample to highest possible sensor rate
+	// by baro data by taking the average of incoming sample
+	_baro_sample_count++;
+	_baro_alt_sum += baro_alt_meter;
+
 	// limit data rate to prevent data being lost
 	if ((time_usec - _time_last_baro) > _min_obs_interval_us) {
 
+		const float baro_alt_avg = _baro_alt_sum / (float)_baro_sample_count;
+
 		baroSample baro_sample_new;
-		baro_sample_new.hgt = data;
-		baro_sample_new.time_us = time_usec - _params.baro_delay_ms * 1000;
+		baro_sample_new.hgt = compensateBaroForDynamicPressure(baro_alt_avg);
 
+		// Use the time in the middle of the downsampling interval for the sample
+		baro_sample_new.time_us = _time_last_baro + (time_usec - _time_last_baro) / 2;
+		baro_sample_new.time_us -= _params.baro_delay_ms * 1000;
 		baro_sample_new.time_us -= FILTER_UPDATE_PERIOD_MS * 1000 / 2;
-		_time_last_baro = time_usec;
-
 		baro_sample_new.time_us = math::max(baro_sample_new.time_us, _imu_sample_delayed.time_us);
 
 		_baro_buffer.push(baro_sample_new);
+
+		_time_last_baro = time_usec;
+		_baro_sample_count = 0;
+		_baro_alt_sum = 0.0f;
 	}
 }
 

--- a/EKF/estimator_interface.h
+++ b/EKF/estimator_interface.h
@@ -544,6 +544,9 @@ protected:
 	//last time the baro ground effect compensation was turned on externally (uSec)
 	uint64_t _time_last_gnd_effect_on{0};
 
+	// Used to down sample barometer data
+	float _baro_alt_sum {0.0f};			///< summed pressure altitude readings (m)
+	uint8_t _baro_sample_count {0};		///< number of barometric altitude measurements summed
 
 	fault_status_u _fault_status{};
 
@@ -570,6 +573,8 @@ protected:
 
 	inline void computeVibrationMetric();
 	inline bool checkIfVehicleAtRest(float dt);
+
+	virtual float compensateBaroForDynamicPressure(const float baro_alt_uncompensated) = 0;
 
 	void printBufferAllocationFailed(const char * buffer_name);
 };


### PR DESCRIPTION
ECL should handle the down sampling the sensor data to match its limitation in buffer size. This PR brings the down sampling of the barometer data and its compensation of sensed dynamic pressure to ECL. Previously this was done on the Firmware side.

**Firmware PR:** https://github.com/PX4/Firmware/pull/13895

**Testing:**
any ideas how we can test it?