### PR TITLE
range_finder_checks: fix validity flag

### DIFF
--- a/EKF/control.cpp
+++ b/EKF/control.cpp
@@ -453,7 +453,7 @@ void Ekf::controlOpticalFlowFusion()
 		if (!_inhibit_flow_use && _control_status.flags.opt_flow) {
 			// inhibit use of optical flow if motion is unsuitable and we are not reliant on it for flight navigation
 			bool preflight_motion_not_ok = !_control_status.flags.in_air && ((_imu_sample_delayed.time_us - _time_good_motion_us) > (uint64_t)1E5);
-			bool flight_motion_not_ok = _control_status.flags.in_air && !isRangeAidSuitable();
+			bool flight_motion_not_ok = _control_status.flags.in_air && !isTerrainEstimateValid();
 			if ((preflight_motion_not_ok || flight_motion_not_ok) && !flow_required) {
 				_inhibit_flow_use = true;
 			}

--- a/EKF/range_finder_checks.cpp
+++ b/EKF/range_finder_checks.cpp
@@ -104,7 +104,7 @@ void Ekf::updateRangeDataValidity()
 
 	updateRangeDataStuck();
 
-	_rng_hgt_valid = !_control_status.flags.rng_stuck;
+	_rng_hgt_valid = _rng_hgt_valid && !_control_status.flags.rng_stuck;
 }
 
 void Ekf::updateRangeDataStuck()


### PR DESCRIPTION
The result of the "range stuck" detection logic was overriding the current validity of the range finder data. This means that even if the quality of the data is 0, if it is not "stuck", the validity was set to true.

@RomanBapst I think we messed it up in https://github.com/PX4/ecl/pull/655