### PR TITLE
Don't filter EV alignment

### DIFF
--- a/EKF/control.cpp
+++ b/EKF/control.cpp
@@ -200,14 +200,6 @@ void Ekf::controlExternalVisionFusion()
 					resetVelocity();
 					ECL_INFO_TIMESTAMPED("EKF commencing external vision velocity fusion");
 				}
-
-				if ((_params.fusion_mode & MASK_ROTATE_EV) && !(_params.fusion_mode & MASK_USE_EVYAW)
-					&& !_ev_rot_mat_initialised)  {
-					// Reset transformation between EV and EKF navigation frames when starting fusion
-					resetExtVisRotMat();
-					_ev_rot_mat_initialised = true;
-					ECL_INFO_TIMESTAMPED("EKF external vision aligned");
-				}
 			}
 		}
 

--- a/EKF/ekf.h
+++ b/EKF/ekf.h
@@ -309,10 +309,7 @@ private:
 	Vector3f _pos_meas_prev;		///< previous value of NED position measurement fused using odometry assumption (m)
 	Vector2f _hpos_pred_prev;		///< previous value of NE position state used by odometry fusion (m)
 	bool _hpos_prev_available{false};	///< true when previous values of the estimate and measurement are available for use
-	Vector3f _ev_rot_vec_filt;		///< filtered rotation vector defining the rotation EV to EKF reference, initiliazied to zero rotation  (rad)
 	Dcmf _ev_rot_mat;			///< transformation matrix that rotates observations from the EV to the EKF navigation frame, initialized with Identity
-	uint64_t _ev_rot_last_time_us{0};	///< previous time that the calculation of the EV to EKF rotation matrix was updated (uSec)
-	bool _ev_rot_mat_initialised{0};	///< _ev_rot_mat should only be initialised once in the beginning through the reset function
 
 	// booleans true when fresh sensor data is available at the fusion time horizon
 	bool _gps_data_ready{false};	///< true when new GPS data has fallen behind the fusion time horizon and is available to be fused
@@ -583,11 +580,6 @@ private:
 	// update the estimated angular misalignment vector between the EV naigration frame and the EKF navigation frame
 	// and update the rotation matrix which transforms EV navigation frame measurements into NED
 	void calcExtVisRotMat();
-
-
-	// reset the estimated angular misalignment vector between the EV naigration frame and the EKF navigation frame
-	// and reset the rotation matrix which transforms EV navigation frame measurements into NED
-	void resetExtVisRotMat();
 
 	// limit the diagonal of the covariance matrix
 	void fixCovarianceErrors();

--- a/EKF/gps_yaw_fusion.cpp
+++ b/EKF/gps_yaw_fusion.cpp
@@ -397,11 +397,6 @@ bool Ekf::resetGpsAntYaw()
 			// update transformation matrix from body to world frame using the current estimate
 			_R_to_earth = Dcmf(_state.quat_nominal);
 
-			// reset the rotation from the EV to EKF frame of reference if it is being used
-			if ((_params.fusion_mode & MASK_ROTATE_EV) && (_params.fusion_mode & MASK_USE_EVPOS)) {
-				resetExtVisRotMat();
-			}
-
 			// update the yaw angle variance using the variance of the measurement
 			increaseQuatYawErrVariance(sq(fmaxf(_params.mag_heading_noise, 1.0e-2f)));
 


### PR DESCRIPTION
This removes the IIR filter on the attitude offset between vision and EKF frame.
I don't see why this rotation would need to be low pass filtered. Especially if one of the two drifts, this leads to toilet-bowling.

Not sure if I did this right, so any review is appreciated.