### PR TITLE
Replace implementation of heading jacobian

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,7 +38,7 @@ project(ECL CXX)
 if(NOT CMAKE_BUILD_TYPE)
 	# force debug builds if we test ECL as standalone
 	if(BUILD_TESTING AND CMAKE_SOURCE_DIR STREQUAL PROJECT_SOURCE_DIR)
-		set(CMAKE_BUILD_TYPE "Debug" CACHE STRING "Build type" FORCE)
+		set(CMAKE_BUILD_TYPE "RelWithDebInfo" CACHE STRING "Build type" FORCE)
 	else()
 		set(CMAKE_BUILD_TYPE "RelWithDebInfo" CACHE STRING "Build type" FORCE)
 	endif()
@@ -132,7 +132,7 @@ if(CMAKE_SOURCE_DIR STREQUAL PROJECT_SOURCE_DIR)
 	include(ExternalProject)
 	ExternalProject_Add(matrix
 			GIT_REPOSITORY "https://github.com/PX4/Matrix.git"
-			GIT_TAG d18be0d0fa17d9a0b60ab34bad3e33160f907b09
+			GIT_TAG a37b91c96a9726cd8336af2d3463e717007e60a5
 			UPDATE_COMMAND ""
 			PATCH_COMMAND ""
 			CONFIGURE_COMMAND ""

--- a/EKF/ekf.h
+++ b/EKF/ekf.h
@@ -44,6 +44,8 @@
 
 #include "estimator_interface.h"
 
+typedef matrix::Dual<float, 4> Dual4f;
+
 class Ekf : public EstimatorInterface
 {
 public:
@@ -768,6 +770,10 @@ private:
 	void updateRangeDataContinuity();
 
 	bool isRangeDataContinuous() { return _dt_last_range_update_filt_us < 2e6f; }
+
+	Dual4f yaw321FromQuaterion(matrix::Quaternion<Dual4f> q) const;
+
+	Dual4f yaw312FromQuaterion(matrix::Quaternion<Dual4f> q) const;
 
 	// Increase the yaw error variance of the quaternions
 	// Argument is additional yaw variance in rad**2

--- a/EKF/ekf.h
+++ b/EKF/ekf.h
@@ -44,8 +44,6 @@
 
 #include "estimator_interface.h"
 
-typedef matrix::Dual<float, 4> Dual4f;
-
 class Ekf : public EstimatorInterface
 {
 public:
@@ -771,9 +769,9 @@ private:
 
 	bool isRangeDataContinuous() { return _dt_last_range_update_filt_us < 2e6f; }
 
-	Dual4f yaw321FromQuaterion(matrix::Quaternion<Dual4f> q) const;
+	Dual4f yaw321FromQuaterion(const matrix::Quaternion<Dual4f>& q) const;
 
-	Dual4f yaw312FromQuaterion(matrix::Quaternion<Dual4f> q) const;
+	Dual4f yaw312FromQuaterion(const matrix::Quaternion<Dual4f>& q) const;
 
 	// Increase the yaw error variance of the quaternions
 	// Argument is additional yaw variance in rad**2

--- a/EKF/estimator_interface.h
+++ b/EKF/estimator_interface.h
@@ -53,6 +53,8 @@
 
 using namespace estimator;
 
+typedef matrix::Dual<float, 4> Dual4f;
+
 class EstimatorInterface
 {
 

--- a/EKF/mag_fusion.cpp
+++ b/EKF/mag_fusion.cpp
@@ -44,6 +44,18 @@
 #include <ecl.h>
 #include <mathlib/mathlib.h>
 
+Dual4f Ekf::yaw321FromQuaterion(matrix::Quaternion<Dual4f> q) const
+{
+	return atan2(Dual4f(2) * (q(0) * q(3) + q(1) * q(2)),
+			q(0) * q(0) + q(1) * q(1) - q(2) * q(2) - q(3) * q(3));
+}
+
+Dual4f Ekf::yaw312FromQuaterion(matrix::Quaternion<Dual4f> q) const
+{
+	return atan2(Dual4f(-2) * (q(1) * q(2) - q(0) * q(3)),
+			q(0) * q(0) - q(1) * q(1) + q(2) * q(2) - q(3) * q(3));
+}
+
 void Ekf::fuseMag()
 {
 	// assign intermediate variables
@@ -445,41 +457,16 @@ void Ekf::fuseHeading()
 
 	float R_YAW = 1.0f;
 	float predicted_hdg;
-	float H_YAW[4];
+	matrix::Vector<float, 4> H_YAW;
 	Vector3f mag_earth_pred;
 	float measured_hdg;
 
 	// determine if a 321 or 312 Euler sequence is best
 	if (fabsf(_R_to_earth(2, 0)) < fabsf(_R_to_earth(2, 1))) {
 		// calculate observation jacobian when we are observing the first rotation in a 321 sequence
-		float t9 = q0*q3;
-		float t10 = q1*q2;
-		float t2 = t9+t10;
-		float t3 = q0*q0;
-		float t4 = q1*q1;
-		float t5 = q2*q2;
-		float t6 = q3*q3;
-		float t7 = t3+t4-t5-t6;
-		float t8 = t7*t7;
-		if (t8 > 1e-6f) {
-			t8 = 1.0f/t8;
-		} else {
-			return;
-		}
-		float t11 = t2*t2;
-		float t12 = t8*t11*4.0f;
-		float t13 = t12+1.0f;
-		float t14;
-		if (fabsf(t13) > 1e-6f) {
-			t14 = 1.0f/t13;
-		} else {
-			return;
-		}
-
-		H_YAW[0] = t8*t14*(q3*t3-q3*t4+q3*t5+q3*t6+q0*q1*q2*2.0f)*-2.0f;
-		H_YAW[1] = t8*t14*(-q2*t3+q2*t4+q2*t5+q2*t6+q0*q1*q3*2.0f)*-2.0f;
-		H_YAW[2] = t8*t14*(q1*t3+q1*t4+q1*t5-q1*t6+q0*q2*q3*2.0f)*2.0f;
-		H_YAW[3] = t8*t14*(q0*t3+q0*t4-q0*t5+q0*t6+q1*q2*q3*2.0f)*2.0f;
+		matrix::Quaternion<Dual4f> q(Dual4f(q0, 0),Dual4f(q1, 1),Dual4f(q2, 2),Dual4f(q3, 3));
+		Dual4f yaw = yaw321FromQuaterion(q);
+		H_YAW = yaw.derivative;
 
 		// rotate the magnetometer measurement into earth frame
 		Eulerf euler321(_state.quat_nominal);
@@ -523,35 +510,9 @@ void Ekf::fuseHeading()
 
 	} else {
 		// calculate observation jacobian when we are observing a rotation in a 312 sequence
-		float t9 = q0*q3;
-		float t10 = q1*q2;
-		float t2 = t9-t10;
-		float t3 = q0*q0;
-		float t4 = q1*q1;
-		float t5 = q2*q2;
-		float t6 = q3*q3;
-		float t7 = t3-t4+t5-t6;
-		float t8 = t7*t7;
-		if (t8 > 1e-6f) {
-			t8 = 1.0f/t8;
-		} else {
-			return;
-		}
-		float t11 = t2*t2;
-		float t12 = t8*t11*4.0f;
-		float t13 = t12+1.0f;
-		float t14;
-
-		if (fabsf(t13) > 1e-6f) {
-			t14 = 1.0f/t13;
-		} else {
-			return;
-		}
-
-		H_YAW[0] = t8*t14*(q3*t3+q3*t4-q3*t5+q3*t6-q0*q1*q2*2.0f)*-2.0f;
-		H_YAW[1] = t8*t14*(q2*t3+q2*t4+q2*t5-q2*t6-q0*q1*q3*2.0f)*-2.0f;
-		H_YAW[2] = t8*t14*(-q1*t3+q1*t4+q1*t5+q1*t6-q0*q2*q3*2.0f)*2.0f;
-		H_YAW[3] = t8*t14*(q0*t3-q0*t4+q0*t5+q0*t6-q1*q2*q3*2.0f)*2.0f;
+		matrix::Quaternion<Dual4f> q(Dual4f(q0, 0),Dual4f(q1, 1),Dual4f(q2, 2),Dual4f(q3, 3));
+		Dual4f yaw_dual = yaw312FromQuaterion(q);
+		H_YAW = yaw_dual.derivative;
 
 		/* Calculate the 312 sequence euler angles that rotate from earth to body frame
 		 * Derived from https://github.com/PX4/ecl/blob/master/matlab/scripts/Inertial%20Nav%20EKF/quat2yaw312.m
@@ -561,7 +522,7 @@ void Ekf::fuseHeading()
 		[ cos(pitch)*sin(yaw) + cos(yaw)*sin(pitch)*sin(roll),  cos(roll)*cos(yaw), sin(pitch)*sin(yaw) - cos(pitch)*cos(yaw)*sin(roll)]
 		[                               -cos(roll)*sin(pitch),           sin(roll),                                cos(pitch)*cos(roll)]
 		*/
-		float yaw = atan2f(-_R_to_earth(0, 1), _R_to_earth(1, 1)); // first rotation (yaw)
+		float yaw = yaw_dual.value; // first rotation (yaw)
 		const float roll = asinf(_R_to_earth(2, 1)); // second rotation (roll)
 		const float pitch = atan2f(-_R_to_earth(2, 0), _R_to_earth(2, 2)); // third rotation (pitch)
 
@@ -676,10 +637,10 @@ void Ekf::fuseHeading()
 		PH[row] = 0.0f;
 
 		for (uint8_t col = 0; col <= 3; col++) {
-			PH[row] += P(row,col) * H_YAW[col];
+			PH[row] += P(row,col) * H_YAW(col);
 		}
 
-		_heading_innov_var += H_YAW[row] * PH[row];
+		_heading_innov_var += H_YAW(row) * PH[row];
 	}
 
 	float heading_innov_var_inv;
@@ -708,7 +669,7 @@ void Ekf::fuseHeading()
 		Kfusion[row] = 0.0f;
 
 		for (uint8_t col = 0; col <= 3; col++) {
-			Kfusion[row] += P(row,col) * H_YAW[col];
+			Kfusion[row] += P(row,col) * H_YAW(col);
 		}
 
 		Kfusion[row] *= heading_innov_var_inv;
@@ -719,7 +680,7 @@ void Ekf::fuseHeading()
 			Kfusion[row] = 0.0f;
 
 			for (uint8_t col = 0; col <= 3; col++) {
-				Kfusion[row] += P(row,col) * H_YAW[col];
+				Kfusion[row] += P(row,col) * H_YAW(col);
 			}
 
 			Kfusion[row] *= heading_innov_var_inv;
@@ -760,10 +721,10 @@ void Ekf::fuseHeading()
 
 	for (unsigned row = 0; row < _k_num_states; row++) {
 
-		KH[0] = Kfusion[row] * H_YAW[0];
-		KH[1] = Kfusion[row] * H_YAW[1];
-		KH[2] = Kfusion[row] * H_YAW[2];
-		KH[3] = Kfusion[row] * H_YAW[3];
+		KH[0] = Kfusion[row] * H_YAW(0);
+		KH[1] = Kfusion[row] * H_YAW(1);
+		KH[2] = Kfusion[row] * H_YAW(2);
+		KH[3] = Kfusion[row] * H_YAW(3);
 
 		for (unsigned column = 0; column < _k_num_states; column++) {
 			float tmp = KH[0] * P(0,column);

--- a/EKF/mag_fusion.cpp
+++ b/EKF/mag_fusion.cpp
@@ -44,13 +44,13 @@
 #include <ecl.h>
 #include <mathlib/mathlib.h>
 
-Dual4f Ekf::yaw321FromQuaterion(matrix::Quaternion<Dual4f> q) const
+Dual4f Ekf::yaw321FromQuaterion(const matrix::Quaternion<Dual4f>& q) const
 {
 	return atan2(Dual4f(2) * (q(0) * q(3) + q(1) * q(2)),
 			q(0) * q(0) + q(1) * q(1) - q(2) * q(2) - q(3) * q(3));
 }
 
-Dual4f Ekf::yaw312FromQuaterion(matrix::Quaternion<Dual4f> q) const
+Dual4f Ekf::yaw312FromQuaterion(const matrix::Quaternion<Dual4f>& q) const
 {
 	return atan2(Dual4f(-2) * (q(1) * q(2) - q(0) * q(3)),
 			q(0) * q(0) - q(1) * q(1) + q(2) * q(2) - q(3) * q(3));

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -45,6 +45,7 @@ set(SRCS
 	test_EKF_initialization.cpp
 	test_EKF_externalVision.cpp
 	test_EKF_airspeed.cpp
+	test_EKF_jacobian.cpp
    )
 add_executable(ECL_GTESTS ${SRCS})
 

--- a/test/test_EKF_jacobian.cpp
+++ b/test/test_EKF_jacobian.cpp
@@ -1,0 +1,200 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2019 ECL Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#include <gtest/gtest.h>
+#include <cmath>
+#include <matrix/math.hpp>
+#include "EKF/ekf.h"
+
+using matrix::Vector3f;
+using matrix::Quaternion;
+using matrix::Dual;
+using matrix::Eulerf;
+
+class EkfJacobianTest : public ::testing::Test {
+ public:
+	Dual<float, 4> yaw321FromQuaterion(Quaternion<Dual<float,4 >> q)
+	{
+		return atan2(Dual<float, 4>(2) * (q(0) * q(3) + q(1) * q(2)),
+			      q(0) * q(0) + q(1) * q(1) - q(2) * q(2) - q(3) * q(3));
+		// matrix::Dcm<Dual<float, 4>> R_to_earth(q); // this is slower
+		// return atan2(R_to_earth(1, 0), R_to_earth(0, 0));
+	}
+
+	Dual<float, 4> yaw312FromQuaterion(Quaternion<Dual<float,4 >> q)
+	{
+		return atan2(Dual<float, 4>(-2) * (q(1) * q(2) - q(0) * q(3)),
+			      q(0) * q(0) - q(1) * q(1) + q(2) * q(2) - q(3) * q(3));
+		// matrix::Dcm<Dual<float, 4>> R_to_earth(q); // this is slower
+		// return atan2(-R_to_earth(0, 1), R_to_earth(1, 1));
+	}
+};
+
+TEST_F(EkfJacobianTest, jacobianWith321EulerAngles)
+{
+
+	for(float roll = -89.0f; roll <= 90.0f; roll+=45.0f)
+	{
+		for(float pitch = -89.0f; pitch <= 90.0f; pitch+=45.0f)
+		{
+			for(float heading = -180.0f; heading <= 180.0f; heading+=45.0f)
+			{
+				Quaternion<float> quat(Eulerf(math::radians(roll), math::radians(pitch), math::radians(heading)));
+
+				const float q0 = quat(0);
+				const float q1 = quat(1);
+				const float q2 = quat(2);
+				const float q3 = quat(3);
+
+				float t9 = q0*q3;
+				float t10 = q1*q2;
+				float t2 = t9+t10;
+				float t3 = q0*q0;
+				float t4 = q1*q1;
+				float t5 = q2*q2;
+				float t6 = q3*q3;
+				float t7 = t3+t4-t5-t6;
+				float t8 = t7*t7;
+				if (t8 > 1e-6f) {
+					t8 = 1.0f/t8;
+				} else {
+					// return;
+					t8 = 1.0f/t8;
+				}
+				float t11 = t2*t2;
+				float t12 = t8*t11*4.0f;
+				float t13 = t12+1.0f;
+				float t14;
+				if (fabsf(t13) > 1e-6f) {
+					t14 = 1.0f/t13;
+				} else {
+					// return;
+					t14 = 1.0f/t13;
+				}
+
+				matrix::Vector<float, 4> H_YAW;
+				H_YAW(0) = t8*t14*(q3*t3-q3*t4+q3*t5+q3*t6+q0*q1*q2*2.0f)*-2.0f;
+				H_YAW(1) = t8*t14*(-q2*t3+q2*t4+q2*t5+q2*t6+q0*q1*q3*2.0f)*-2.0f;
+				H_YAW(2) = t8*t14*(q1*t3+q1*t4+q1*t5-q1*t6+q0*q2*q3*2.0f)*2.0f;
+				H_YAW(3) = t8*t14*(q0*t3+q0*t4-q0*t5+q0*t6+q1*q2*q3*2.0f)*2.0f;
+
+
+				// alternative way
+				using D4 = Dual<float, 4>;
+				Quaternion<Dual<float, 4>> q(D4(q0, 0),D4(q1, 1),D4(q2, 2),D4(q3, 3));
+				Dual<float, 4> yaw = yaw321FromQuaterion(q);
+
+				EXPECT_TRUE(matrix::isEqual(H_YAW, yaw.derivative)) << "yaw " << heading << std::endl << H_YAW(0) << " "
+														<< H_YAW(1) << " "
+														<< H_YAW(2) << " "
+														<< H_YAW(3) << std::endl
+														<< yaw.derivative(0) << " "
+														<< yaw.derivative(1) << " "
+														<< yaw.derivative(2) << " "
+														<< yaw.derivative(3);
+
+				EXPECT_NEAR(math::degrees(yaw.value), heading, 0.1f) << "roll: " << roll << ", pitch" << pitch << std::endl;
+			}
+		}
+	}
+}
+
+TEST_F(EkfJacobianTest, jacobianWith312EulerAngles)
+{
+
+
+	for(float roll = -89.0f; roll <= 90.0f; roll+=45.0f)
+	{
+		for(float pitch = -89.0f; pitch <= 90.0f; pitch+=45.0f)
+		{
+			for(float heading = -180.0f; heading <= 180.0f; heading+=45.0f)
+			{
+				Quaternion<float> quat(Eulerf(math::radians(roll), math::radians(pitch), math::radians(heading)));
+
+				const float q0 = quat(0);
+				const float q1 = quat(1);
+				const float q2 = quat(2);
+				const float q3 = quat(3);
+
+				// calculate observation jacobian when we are observing a rotation in a 312 sequence
+				float t9 = q0*q3;
+				float t10 = q1*q2;
+				float t2 = t9-t10;
+				float t3 = q0*q0;
+				float t4 = q1*q1;
+				float t5 = q2*q2;
+				float t6 = q3*q3;
+				float t7 = t3-t4+t5-t6;
+				float t8 = t7*t7;
+				if (t8 > 1e-6f) {
+					t8 = 1.0f/t8;
+				} else {
+					t8 = 1.0f/t8;
+				}
+				float t11 = t2*t2;
+				float t12 = t8*t11*4.0f;
+				float t13 = t12+1.0f;
+				float t14;
+
+				if (fabsf(t13) > 1e-6f) {
+					t14 = 1.0f/t13;
+				} else {
+					t14 = 1.0f/t13;
+				}
+
+				matrix::Vector<float, 4> H_YAW;
+				H_YAW(0) = t8*t14*(q3*t3+q3*t4-q3*t5+q3*t6-q0*q1*q2*2.0f)*-2.0f;
+				H_YAW(1) = t8*t14*(q2*t3+q2*t4+q2*t5-q2*t6-q0*q1*q3*2.0f)*-2.0f;
+				H_YAW(2) = t8*t14*(-q1*t3+q1*t4+q1*t5+q1*t6-q0*q2*q3*2.0f)*2.0f;
+				H_YAW(3) = t8*t14*(q0*t3-q0*t4+q0*t5+q0*t6-q1*q2*q3*2.0f)*2.0f;
+
+				// alternative way
+				using D4 = Dual<float, 4>;
+				Quaternion<Dual<float, 4>> q(D4(q0, 0),D4(q1, 1),D4(q2, 2),D4(q3, 3));
+				Dual<float, 4> yaw = yaw312FromQuaterion(q);
+
+				EXPECT_TRUE(matrix::isEqual(H_YAW, yaw.derivative)) << "yaw " << heading << std::endl << H_YAW(0) << " "
+														<< H_YAW(1) << " "
+														<< H_YAW(2) << " "
+														<< H_YAW(3) << std::endl
+														<< yaw.derivative(0) << " "
+														<< yaw.derivative(1) << " "
+														<< yaw.derivative(2) << " "
+														<< yaw.derivative(3);
+
+				// This test will fail very likely as we swap the euler angle sequence.
+				// EXPECT_NEAR(math::degrees(yaw.value), heading, 0.1f) << "roll: " << roll << ", pitch" << pitch << std::endl;
+			}
+		}
+	}
+}

--- a/test/test_EKF_jacobian.cpp
+++ b/test/test_EKF_jacobian.cpp
@@ -43,7 +43,7 @@ using matrix::Eulerf;
 
 class EkfJacobianTest : public ::testing::Test {
  public:
-	Dual<float, 4> yaw321FromQuaterion(Quaternion<Dual<float,4 >> q)
+	Dual<float, 4> yaw321FromQuaterion(const Quaternion<Dual<float,4 >>& q)
 	{
 		return atan2(Dual<float, 4>(2) * (q(0) * q(3) + q(1) * q(2)),
 			      q(0) * q(0) + q(1) * q(1) - q(2) * q(2) - q(3) * q(3));
@@ -51,7 +51,7 @@ class EkfJacobianTest : public ::testing::Test {
 		// return atan2(R_to_earth(1, 0), R_to_earth(0, 0));
 	}
 
-	Dual<float, 4> yaw312FromQuaterion(Quaternion<Dual<float,4 >> q)
+	Dual<float, 4> yaw312FromQuaterion(const Quaternion<Dual<float,4 >>& q)
 	{
 		return atan2(Dual<float, 4>(-2) * (q(1) * q(2) - q(0) * q(3)),
 			      q(0) * q(0) - q(1) * q(1) + q(2) * q(2) - q(3) * q(3));


### PR DESCRIPTION
The previous computation of the heading jacobian had singularities at roll=0, pitch=0, yaw=+/-90 degrees. We therefore needed to stop the heading fusion in this orientation. This PR uses dual numbers to compute the jacobian with automatic differentiation. With this the singularity can be avoided.

**Testing:**
- unit testing shows no difference between the existing version and the proposed version except for previous singularity case.
- unit tests are failing at the moment to show how the proposed implementation is performing. Tests need to be removed before merging.
- SITL mission test: [log](https://review.px4.io/plot_app?log=1f97a874-6774-47ca-9c4d-deed7428962d)

**Issues:**
- This adds 700 Bytes of flash memory, since it needs to create multiple templated matrix functions with "Dual" as type.
- The automatic derivative approach seems to be 10 times slower. I profiled the test_EKF_jacobian.cpp file. The question is if this matters in relation to the rest of the load.
![Screenshot from 2020-01-16 13-59-54](https://user-images.githubusercontent.com/23532607/72527427-0718aa80-3869-11ea-83e5-6e9ec81b3b49.png)

**Profiling:**
Previous
![Screenshot from 2020-01-16 15-13-41](https://user-images.githubusercontent.com/23532607/72532092-0edd4c80-3873-11ea-9082-16398939783d.png)

Proposed
![Screenshot from 2020-01-16 15-13-29](https://user-images.githubusercontent.com/23532607/72532107-156bc400-3873-11ea-9188-d1104ddd0c1a.png)

Ekf::update()
![Screenshot from 2020-01-16 15-18-09](https://user-images.githubusercontent.com/23532607/72532330-80b59600-3873-11ea-824a-7068ffcfe50e.png)



https://github.com/PX4/ecl/issues/705