### PR TITLE
Updating optical flow interface

### DIFF
--- a/EKF/common.h
+++ b/EKF/common.h
@@ -73,13 +73,6 @@ struct gps_message {
 	float pdop;		///< position dilution of precision
 };
 
-struct flow_message {
-	uint8_t quality;	///< Quality of Flow data
-	Vector2f flowdata;	///< Optical flow rates about the X and Y body axes (rad/sec)
-	Vector3f gyrodata;	///< Gyro rates about the XYZ body axes (rad/sec)
-	uint32_t dt;		///< integration time of flow samples (microseconds)
-};
-
 struct ext_vision_message {
 	Vector3f pos;	///< XYZ position in external vision's local reference frame (m) - Z must be aligned with down axis
 	Vector3f vel;	///< XYZ velocity in external vision's local reference frame (m/sec) - Z must be aligned with down axis

--- a/EKF/control.cpp
+++ b/EKF/control.cpp
@@ -132,12 +132,8 @@ void Ekf::controlFusionModes()
 		_range_sample_delayed.rng += pos_offset_earth(2) / _R_rng_to_earth_2_2;
 	}
 
-	// We don't fuse flow data immediately because we have to wait for the mid integration point to fall behind the fusion time horizon.
-	// This means we stop looking for new data until the old data has been fused.
-	if (!_flow_data_ready) {
-		_flow_data_ready = _flow_buffer.pop_first_older_than(_imu_sample_delayed.time_us, &_flow_sample_delayed)
+	_flow_data_ready = _flow_buffer.pop_first_older_than(_imu_sample_delayed.time_us, &_flow_sample_delayed)
 				   && (_R_to_earth(2, 2) > _params.range_cos_max_tilt);
-	}
 
 	// check if we should fuse flow data for terrain estimation
 	if (!_flow_for_terrain_data_ready && _flow_data_ready && _control_status.flags.in_air) {

--- a/EKF/control.cpp
+++ b/EKF/control.cpp
@@ -535,23 +535,15 @@ void Ekf::controlOpticalFlowFusion()
 				_flowRadXYcomp(0) = _flow_sample_delayed.flowRadXY(0) - _flow_sample_delayed.gyroXYZ(0);
 				_flowRadXYcomp(1) = _flow_sample_delayed.flowRadXY(1) - _flow_sample_delayed.gyroXYZ(1);
 			}
-		} else {
-			// don't use this flow data and wait for the next data to arrive
-			_flow_data_ready = false;
-		}
-	}
 
-	// Wait until the midpoint of the flow sample has fallen behind the fusion time horizon
-	if (_flow_data_ready && (_imu_sample_delayed.time_us > _flow_sample_delayed.time_us - uint32_t(1e6f * _flow_sample_delayed.dt) / 2)) {
-		// Fuse optical flow LOS rate observations into the main filter only if height above ground has been updated recently
-		// but use a relaxed time criteria to enable it to coast through bad range finder data
-		if (_control_status.flags.opt_flow && ((_time_last_imu - _time_last_hagl_fuse) < (uint64_t)10e6)) {
-			fuseOptFlow();
-			_last_known_posNE(0) = _state.pos(0);
-			_last_known_posNE(1) = _state.pos(1);
+			// Fuse optical flow LOS rate observations into the main filter only if height above ground has been updated recently
+			// but use a relaxed time criteria to enable it to coast through bad range finder data
+			if (_control_status.flags.opt_flow && ((_time_last_imu - _time_last_hagl_fuse) < (uint64_t)10e6)) {
+				fuseOptFlow();
+				_last_known_posNE(0) = _state.pos(0);
+				_last_known_posNE(1) = _state.pos(1);
+			}
 		}
-
-		_flow_data_ready = false;
 	}
 }
 

--- a/EKF/estimator_interface.cpp
+++ b/EKF/estimator_interface.cpp
@@ -323,7 +323,6 @@ void EstimatorInterface::setRangeData(uint64_t time_usec, float data, int8_t qua
 	}
 }
 
-// TODO: Change pointer to constant reference
 void EstimatorInterface::setOpticalFlowData(const flowSample& flow)
 {
 	if (!_initialised || _flow_buffer_fail) {

--- a/EKF/estimator_interface.cpp
+++ b/EKF/estimator_interface.cpp
@@ -324,7 +324,7 @@ void EstimatorInterface::setRangeData(uint64_t time_usec, float data, int8_t qua
 }
 
 // TODO: Change pointer to constant reference
-void EstimatorInterface::setOpticalFlowData(uint64_t time_usec, flow_message *flow)
+void EstimatorInterface::setOpticalFlowData(const flowSample& flow)
 {
 	if (!_initialised || _flow_buffer_fail) {
 		return;
@@ -342,10 +342,10 @@ void EstimatorInterface::setOpticalFlowData(uint64_t time_usec, flow_message *fl
 	}
 
 	// limit data rate to prevent data being lost
-	if ((time_usec - _time_last_optflow) > _min_obs_interval_us) {
+	if ((flow.time_us - _time_last_optflow) > _min_obs_interval_us) {
 		// check if enough integration time and fail if integration time is less than 50%
 		// of min arrival interval because too much data is being lost
-		float delta_time = 1e-6f * (float)flow->dt; // in seconds
+		float delta_time = flow.dt; // in seconds
 		const float delta_time_min = 0.5e-6f * (float)_min_obs_interval_us;
 		bool delta_time_good = delta_time >= delta_time_min;
 
@@ -355,7 +355,7 @@ void EstimatorInterface::setOpticalFlowData(uint64_t time_usec, flow_message *fl
 			// check magnitude is within sensor limits
 			// use this to prevent use of a saturated flow sensor
 			// when there are other aiding sources available
-			const float flow_rate_magnitude = flow->flowdata.norm() / delta_time;
+			const float flow_rate_magnitude = flow.flowRadXY.norm() / delta_time;
 			flow_magnitude_good = (flow_rate_magnitude <= _flow_max_rate);
 		} else {
 			// protect against overflow caused by division with very small delta_time
@@ -364,25 +364,22 @@ void EstimatorInterface::setOpticalFlowData(uint64_t time_usec, flow_message *fl
 
 		const bool relying_on_flow = !_control_status.flags.gps && !_control_status.flags.ev_pos && !_control_status.flags.ev_vel;
 
-		const bool flow_quality_good = (flow->quality >= _params.flow_qual_min);
+		const bool flow_quality_good = (flow.quality >= _params.flow_qual_min);
 
 		// Check data validity and write to buffers
 		// Invalid flow data is allowed when on ground and is handled as a special case in controlOpticalFlowFusion()
 		bool use_flow_data_to_navigate = delta_time_good && flow_quality_good && (flow_magnitude_good || relying_on_flow);
 		if (use_flow_data_to_navigate || (!_control_status.flags.in_air && relying_on_flow)) {
-			flowSample optflow_sample_new;
-			// calculate the system time-stamp for the trailing edge of the flow data integration period
-			optflow_sample_new.time_us = time_usec - _params.flow_delay_ms * 1000;
 
-			optflow_sample_new.quality = flow->quality;
+			_time_last_optflow = flow.time_us;
 
-			// NOTE: the EKF uses the reverse sign convention to the flow sensor. EKF assumes positive LOS rate
-			// is produced by a RH rotation of the image about the sensor axis.
-			optflow_sample_new.gyroXYZ = - flow->gyrodata;
-			optflow_sample_new.flowRadXY = -flow->flowdata;
+			flowSample optflow_sample_new = flow;
+
+			// compensate time-stamp for the trailing edge of the flow data integration period
+			optflow_sample_new.time_us -= _params.flow_delay_ms * 1000;
+			optflow_sample_new.time_us -= FILTER_UPDATE_PERIOD_MS * 1000 / 2;
 
 			optflow_sample_new.dt = delta_time;
-			_time_last_optflow = time_usec;
 
 			_flow_buffer.push(optflow_sample_new);
 		}

--- a/EKF/estimator_interface.h
+++ b/EKF/estimator_interface.h
@@ -188,7 +188,7 @@ public:
 	void setRangeData(uint64_t time_usec, float data, int8_t quality);
 
 	// if optical flow sensor gyro delta angles are not available, set gyroXYZ vector fields to NaN and the EKF will use its internal delta angle data instead
-	void setOpticalFlowData(uint64_t time_usec, flow_message *flow);
+	void setOpticalFlowData(const flowSample& flow);
 
 	// set external vision position and attitude data
 	void setExtVisionData(uint64_t time_usec, ext_vision_message *evdata);

--- a/test/sensor_simulator/flow.cpp
+++ b/test/sensor_simulator/flow.cpp
@@ -16,22 +16,24 @@ Flow::~Flow()
 void Flow::send(uint64_t time)
 {
 	_flow_data.dt = time - _time_last_data_sent;
-	_ekf->setOpticalFlowData(time, &_flow_data);
+	_flow_data.time_us = time;
+	_ekf->setOpticalFlowData(_flow_data);
 }
 
-void Flow::setData(const flow_message& flow)
+void Flow::setData(const flowSample& flow)
 {
 	_flow_data = flow;
 
 }
 
-flow_message Flow::dataAtRest()
+flowSample Flow::dataAtRest()
 {
-	flow_message _flow_at_rest;
-	_flow_at_rest.dt = 20000;
-	_flow_at_rest.flowdata = Vector2f{0.0f, 0.0f};
-	_flow_at_rest.gyrodata = Vector3f{0.0f, 0.0f, 0.0f};
+	flowSample _flow_at_rest;
+	_flow_at_rest.dt = 0.02f;
+	_flow_at_rest.flowRadXY = Vector2f{0.0f, 0.0f};
+	_flow_at_rest.gyroXYZ = Vector3f{0.0f, 0.0f, 0.0f};
 	_flow_at_rest.quality = 255;
+	_flow_at_rest.time_us = 0;
 	return _flow_at_rest;
 }
 

--- a/test/sensor_simulator/flow.h
+++ b/test/sensor_simulator/flow.h
@@ -50,11 +50,11 @@ public:
 	Flow(std::shared_ptr<Ekf> ekf);
 	~Flow();
 
-	void setData(const flow_message& flow);
-	flow_message dataAtRest();
+	void setData(const flowSample& flow);
+	flowSample dataAtRest();
 
 private:
-	flow_message _flow_data;
+	flowSample _flow_data;
 
 	void send(uint64_t time) override;
 

--- a/test/sensor_simulator/range_finder.h
+++ b/test/sensor_simulator/range_finder.h
@@ -51,7 +51,6 @@ public:
 	~RangeFinder();
 
 	void setData(float range_data, int8_t range_quality);
-	flow_message dataAtRest();
 
 private:
 	float _range_data{0.0f};

--- a/test/test_EKF_fusionLogic.cpp
+++ b/test/test_EKF_fusionLogic.cpp
@@ -161,8 +161,7 @@ TEST_F(EkfFusionLogicTest, doFlowFusion)
 
 	// WHEN: Flow data is not send and we enable flow fusion
 	_sensor_simulator.stopFlow();
-	_sensor_simulator.runSeconds(3); // TODO: without this line tests fail
-	// probably there are still values in the buffer.
+	_sensor_simulator.runSeconds(1); // empty buffer
 	_ekf_wrapper.enableFlowFusion();
 	_sensor_simulator.runSeconds(3);
 


### PR DESCRIPTION
Previously we had two different types that can store optical flow data: `flowSample` and `flow_message`. The only difference is that flow_message has no time_us field, since the time was passed separately to `setOpticalFlowDate(time, flow_message)`.
This PR removes the `flow_message` and changes the function to `setOpticalFlowData(flow_sample)`. 

Previously we also had some logic in place to only pop flowSamples from the buffer if the previous one was used. We waited for using the flow_sample until the midpoint of the flow sample was fallen behind the fusion horizon. I argue that we should compensate for half of the flow dt before sending it to the EKF. Therefore every time we pop a flow sample from the buffer it is actually time to use it. As it is done for all the other sensors.

**Firmware PR:** https://github.com/PX4/Firmware/pull/13988

**Testing:**
SITL log replay shows a small diff only visible if toggling between the logs

BEFORE:
![Screenshot from 2020-01-20 14-17-04](https://user-images.githubusercontent.com/23532607/72731008-05b1ef80-3b93-11ea-82f1-4dc31442e1bd.png)
[Log](https://review.px4.io/plot_app?log=8bcc5994-677f-4fdc-842e-554d303556ba)

AFTER:
![Screenshot from 2020-01-20 14-17-39](https://user-images.githubusercontent.com/23532607/72731003-0185d200-3b93-11ea-90b5-893746826e99.png)
[Log](https://review.px4.io/plot_app?log=aef16413-f24e-4840-b266-4cb8d6c8a2ea)