### PR TITLE
Auto-formatting

### DIFF
--- a/.github/workflows/format_checks.yml
+++ b/.github/workflows/format_checks.yml
@@ -1,0 +1,12 @@
+name: Format Checks
+
+on: [push]
+
+jobs:
+  format_checks:
+    runs-on: ubuntu-latest
+    container: px4io/px4-dev-base-bionic:2020-01-13
+    steps:
+    - uses: actions/checkout@v1
+    - name: make check_format
+      run: make check_format

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@
 
 .cache/
 build/
+astyle/*/*
+astyle/*.txt
 
 */*.a
 .ninja_deps

--- a/EKF/AlphaFilter.hpp
+++ b/EKF/AlphaFilter.hpp
@@ -49,7 +49,7 @@ public:
 
 	void update(const T &input, float tau, float dt)
 	{
-		const float alpha = dt / tau; 
+		const float alpha = dt / tau;
 		update(input, alpha);
 	}
 
@@ -64,7 +64,7 @@ public:
 		update(input, 0.1f);
 	}
 
-	const T& getState() const { return _x; }
+	const T &getState() const { return _x; }
 
 private:
 	T _x{}; ///< current state of the filter

--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,8 @@
 FIRST_ARG := $(firstword $(MAKECMDGOALS))
 ARGS := $(wordlist 2,$(words $(MAKECMDGOALS)),$(MAKECMDGOALS))
 j ?= 4
+BLUE='\033[1;36m'
+NC='\033[0m' # No Color
 
 NINJA_BIN := ninja
 ifndef NO_NINJA_BUILD
@@ -123,6 +125,27 @@ coverage_html: coverage_build
 
 coverage_html_view: coverage_build
 	@cmake --build $(SRC_DIR)/build/coverage_build --target coverage_html_view
+
+# Code formatting
+# --------------------------------------------------------------------
+.PHONY: check_format format astyle
+
+astyle:
+	@echo -e ${BLUE}Install astyle${NC}
+	@mkdir -p $(SRC_DIR)/astyle/src
+	@cd $(SRC_DIR)/astyle/src
+	@wget http://sourceforge.net/projects/astyle/files/astyle/astyle%202.06/astyle_2.06_linux.tar.gz -O /tmp/astyle.tar.gz
+	@tar -xvf /tmp/astyle.tar.gz
+	@cd astyle/src && make -f ../build/gcc/Makefile
+	@cd $(SRC_DIR)
+
+check_format: astyle
+	@echo -e ${BLUE}Checking formatting with astyle${NC}
+	@$(SRC_DIR)/astyle/format.sh $(SRC_DIR)/astyle/src/bin/astyle $(SRC_DIR)/astyle/astylerc 0
+
+format: astyle
+	@echo -e ${BLUE}Formatting with astyle${NC}
+	@$(SRC_DIR)/astyle/format.sh $(SRC_DIR)/astyle/src/bin/astyle $(SRC_DIR)/astyle/astylerc 1
 
 # Cleanup
 # --------------------------------------------------------------------

--- a/astyle/astylerc
+++ b/astyle/astylerc
@@ -1,0 +1,20 @@
+# copied from Firmware
+indent=force-tab=8
+style=linux
+indent-preprocessor
+indent-cases
+break-blocks=all
+pad-oper
+pad-header
+unpad-paren
+keep-one-line-blocks
+keep-one-line-statements
+align-pointer=name
+align-reference=name
+-n #--suffix=none
+ignore-exclude-errors-x
+lineend=linux
+exclude=EASTL
+add-brackets
+max-code-length=120
+

--- a/astyle/format.sh
+++ b/astyle/format.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+echo pwd:$PWD
+astyle_executable=$1
+astylerc=$2
+do_format=$3
+files_to_format="""
+EKF/AlphaFilter.hpp
+EKF/RingBuffer.h
+"""
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+if [[ $do_format -eq 1 ]]
+then
+    echo formatting
+    $astyle_executable ${files_to_format} --options=${astylerc} --preserve-date\
+    echo -e ${GREEN}Formatting finished${NC}
+else
+    echo checking format...
+    $astyle_executable --dry-run ${files_to_format} --options=${astylerc} --preserve-date | grep Formatted &>/dev/null
+    if [[ $? -eq 0 ]]
+    then
+        echo -e ${RED}Error: need to format${NC}
+        echo -e ${YELLOW}From cmake build directory run: 'make format'${NC}
+        exit 1
+    fi
+    echo -e ${GREEN}no formatting needed${NC}
+    exit 0
+fi
+
+# vim: set et fenc=utf-8 ff=unix sts=0 sw=4 ts=4 :


### PR DESCRIPTION
This PR brings auto-formatting to ECL. It adds a few Makefile targets, which provide installation of astyle, checking the format and formatting the code. 

The formatting rules are copied from Firmware and are specified in `astyle/astylerc`. The files on which the auto-formatting is required, is specified in `astyle/format.sh`. At the moment it is only added for `EKF/RingBuffer.h` and `EKF/AlphaFilter.hpp`

A github action that checks if the format is according to the rules is also added.