### PR TITLE
Updates to interface

### DIFF
--- a/EKF/common.h
+++ b/EKF/common.h
@@ -140,7 +140,7 @@ struct rangeSample {
 
 struct airspeedSample {
 	float       true_airspeed;	///< true airspeed measurement (m/sec)
-	float 		eas2tas;	///< equivalent to true airspeed factor
+	float       eas2tas;		///< equivalent to true airspeed factor
 	uint64_t    time_us;		///< timestamp of the measurement (uSec)
 };
 

--- a/EKF/common.h
+++ b/EKF/common.h
@@ -128,8 +128,8 @@ struct magSample {
 };
 
 struct baroSample {
-	float       hgt{0.0f};	///< pressure altitude above sea level (m)
-	uint64_t    time_us{0};	///< timestamp of the measurement (uSec)
+	float       hgt;	///< pressure altitude above sea level (m)
+	uint64_t    time_us;	///< timestamp of the measurement (uSec)
 };
 
 struct rangeSample {

--- a/EKF/common.h
+++ b/EKF/common.h
@@ -67,7 +67,7 @@ struct gps_message {
 	float epv;		///< GPS vertical position accuracy in m
 	float sacc;		///< GPS speed accuracy in m/s
 	float vel_m_s;		///< GPS ground speed (m/sec)
-	float vel_ned[3];	///< GPS ground speed NED - TODO: make Vector3f
+	Vector3f vel_ned;	///< GPS ground speed NED - TODO: make Vector3f
 	bool vel_ned_valid;	///< GPS ground speed is valid
 	uint8_t nsats;		///< number of satellites used
 	float pdop;		///< position dilution of precision

--- a/EKF/common.h
+++ b/EKF/common.h
@@ -67,7 +67,7 @@ struct gps_message {
 	float epv;		///< GPS vertical position accuracy in m
 	float sacc;		///< GPS speed accuracy in m/s
 	float vel_m_s;		///< GPS ground speed (m/sec)
-	Vector3f vel_ned;	///< GPS ground speed NED - TODO: make Vector3f
+	Vector3f vel_ned;	///< GPS ground speed NED
 	bool vel_ned_valid;	///< GPS ground speed is valid
 	uint8_t nsats;		///< number of satellites used
 	float pdop;		///< position dilution of precision

--- a/EKF/estimator_interface.cpp
+++ b/EKF/estimator_interface.cpp
@@ -245,7 +245,7 @@ void EstimatorInterface::setGpsData(const gps_message &gps)
 	}
 }
 
-void EstimatorInterface::setBaroData(uint64_t time_usec, float baro_alt_meter)
+void EstimatorInterface::setBaroData(const baroSample &baro_sample)
 {
 	if (!_initialised || _baro_buffer_fail) {
 		return;
@@ -265,11 +265,12 @@ void EstimatorInterface::setBaroData(uint64_t time_usec, float baro_alt_meter)
 	// downsample to highest possible sensor rate
 	// by baro data by taking the average of incoming sample
 	_baro_sample_count++;
-	_baro_alt_sum += baro_alt_meter;
-	_baro_timestamp_sum += time_usec / 1000; // Dividing by 1000 to avoid overflow
+	_baro_alt_sum += baro_sample.hgt;
+	_baro_timestamp_sum += baro_sample.time_us / 1000; // Dividing by 1000 to avoid overflow
 
 	// limit data rate to prevent data being lost
-	if ((time_usec - _time_last_baro) > _min_obs_interval_us) {
+	if ((baro_sample.time_us - _time_last_baro) > _min_obs_interval_us) {
+		_time_last_baro = baro_sample.time_us;
 
 		const float baro_alt_avg = _baro_alt_sum / (float)_baro_sample_count;
 
@@ -284,7 +285,6 @@ void EstimatorInterface::setBaroData(uint64_t time_usec, float baro_alt_meter)
 
 		_baro_buffer.push(baro_sample_new);
 
-		_time_last_baro = time_usec;
 		_baro_sample_count = 0;
 		_baro_alt_sum = 0.0f;
 		_baro_timestamp_sum = 0;

--- a/EKF/estimator_interface.cpp
+++ b/EKF/estimator_interface.cpp
@@ -320,7 +320,7 @@ void EstimatorInterface::setAirspeedData(const airspeedSample &airspeed_sample)
 	}
 }
 
-void EstimatorInterface::setRangeData(uint64_t time_usec, float data, int8_t quality)
+void EstimatorInterface::setRangeData(const rangeSample& range_sample)
 {
 	if (!_initialised || _range_buffer_fail) {
 		return;
@@ -338,12 +338,12 @@ void EstimatorInterface::setRangeData(uint64_t time_usec, float data, int8_t qua
 	}
 
 	// limit data rate to prevent data being lost
-	if ((time_usec - _time_last_range) > _min_obs_interval_us) {
+	if ((range_sample.time_us - _time_last_range) > _min_obs_interval_us) {
+		_time_last_range = range_sample.time_us;
+
 		rangeSample range_sample_new;
-		range_sample_new.rng = data;
-		range_sample_new.time_us = time_usec - _params.range_delay_ms * 1000;
-		range_sample_new.quality = quality;
-		_time_last_range = time_usec;
+		range_sample_new.time_us -= _params.range_delay_ms * 1000;
+		range_sample_new.time_us -= FILTER_UPDATE_PERIOD_MS * 1000 / 2;
 
 		_range_buffer.push(range_sample_new);
 	}

--- a/EKF/estimator_interface.cpp
+++ b/EKF/estimator_interface.cpp
@@ -452,7 +452,7 @@ void EstimatorInterface::setExtVisionData(uint64_t time_usec, ext_vision_message
 	}
 }
 
-void EstimatorInterface::setAuxVelData(uint64_t time_usec, const Vector3f &velocity, const Vector3f &variance)
+void EstimatorInterface::setAuxVelData(const auxVelSample& auxvel_sample)
 {
 	if (!_initialised || _auxvel_buffer_fail) {
 		return;
@@ -470,16 +470,13 @@ void EstimatorInterface::setAuxVelData(uint64_t time_usec, const Vector3f &veloc
 	}
 
 	// limit data rate to prevent data being lost
-	if ((time_usec - _time_last_auxvel) > _min_obs_interval_us) {
+	if ((auxvel_sample.time_us - _time_last_auxvel) > _min_obs_interval_us) {
+		_time_last_auxvel = auxvel_sample.time_us;
 
-		auxVelSample auxvel_sample_new;
-		auxvel_sample_new.time_us = time_usec - _params.auxvel_delay_ms * 1000;
+		auxVelSample auxvel_sample_new = auxvel_sample;
 
+		auxvel_sample_new.time_us -= _params.auxvel_delay_ms * 1000;
 		auxvel_sample_new.time_us -= FILTER_UPDATE_PERIOD_MS * 1000 / 2;
-		_time_last_auxvel = time_usec;
-
-		auxvel_sample_new.vel = velocity;
-		auxvel_sample_new.velVar = variance;
 
 		_auxvel_buffer.push(auxvel_sample_new);
 	}

--- a/EKF/estimator_interface.cpp
+++ b/EKF/estimator_interface.cpp
@@ -130,7 +130,7 @@ void EstimatorInterface::setIMUData(uint64_t time_usec, uint64_t delta_ang_dt, u
 	imu_sample_new.delta_ang = Vector3f(delta_ang);
 	imu_sample_new.delta_vel = Vector3f(delta_vel);
 
-	// convert time from us to secs
+void EstimatorInterface::setMagData(const magSample &mag_sample)
 	imu_sample_new.delta_ang_dt = delta_ang_dt / 1e6f;
 	imu_sample_new.delta_vel_dt = delta_vel_dt / 1e6f;
 	imu_sample_new.time_us = time_usec;
@@ -138,7 +138,6 @@ void EstimatorInterface::setIMUData(uint64_t time_usec, uint64_t delta_ang_dt, u
 	setIMUData(imu_sample_new);
 }
 
-void EstimatorInterface::setMagData(uint64_t time_usec, float (&data)[3])
 {
 	if (!_initialised || _mag_buffer_fail) {
 		return;
@@ -158,11 +157,12 @@ void EstimatorInterface::setMagData(uint64_t time_usec, float (&data)[3])
 	// downsample to highest possible sensor rate
 	// by taking the average of incoming sample
 	_mag_sample_count++;
-	_mag_data_sum += Vector3f(data);
-	_mag_timestamp_sum += time_usec / 1000; // Dividing by 1000 to avoid overflow
+	_mag_data_sum += mag_sample.mag;
+	_mag_timestamp_sum += mag_sample.time_us / 1000; // Dividing by 1000 to avoid overflow
 
 	// limit data rate to prevent data being lost
-	if ((time_usec - _time_last_mag) > _min_obs_interval_us) {
+	if ((mag_sample.time_us - _time_last_mag) > _min_obs_interval_us) {
+		_time_last_mag = mag_sample.time_us;
 
 		magSample mag_sample_new;
 
@@ -175,7 +175,6 @@ void EstimatorInterface::setMagData(uint64_t time_usec, float (&data)[3])
 
 		_mag_buffer.push(mag_sample_new);
 
-		_time_last_mag = time_usec;
 		_mag_sample_count = 0;
 		_mag_data_sum.setZero();
 		_mag_timestamp_sum = 0;

--- a/EKF/estimator_interface.cpp
+++ b/EKF/estimator_interface.cpp
@@ -291,7 +291,7 @@ void EstimatorInterface::setBaroData(const baroSample &baro_sample)
 	}
 }
 
-void EstimatorInterface::setAirspeedData(uint64_t time_usec, float true_airspeed, float eas2tas)
+void EstimatorInterface::setAirspeedData(const airspeedSample &airspeed_sample)
 {
 	if (!_initialised || _airspeed_buffer_fail) {
 		return;
@@ -309,13 +309,13 @@ void EstimatorInterface::setAirspeedData(uint64_t time_usec, float true_airspeed
 	}
 
 	// limit data rate to prevent data being lost
-	if ((time_usec - _time_last_airspeed) > _min_obs_interval_us) {
-		airspeedSample airspeed_sample_new;
-		airspeed_sample_new.true_airspeed = true_airspeed;
-		airspeed_sample_new.eas2tas = eas2tas;
-		airspeed_sample_new.time_us = time_usec - _params.airspeed_delay_ms * 1000;
+	if ((airspeed_sample.time_us - _time_last_airspeed) > _min_obs_interval_us) {
+		_time_last_airspeed = airspeed_sample.time_us;
+
+		airspeedSample airspeed_sample_new = airspeed_sample;
+
+		airspeed_sample_new.time_us -= _params.airspeed_delay_ms * 1000;
 		airspeed_sample_new.time_us -= FILTER_UPDATE_PERIOD_MS * 1000 / 2;
-		_time_last_airspeed = time_usec;
 
 		_airspeed_buffer.push(airspeed_sample_new);
 	}

--- a/EKF/estimator_interface.cpp
+++ b/EKF/estimator_interface.cpp
@@ -123,21 +123,8 @@ bool EstimatorInterface::checkIfVehicleAtRest(float dt)
 	}
 }
 
-void EstimatorInterface::setIMUData(uint64_t time_usec, uint64_t delta_ang_dt, uint64_t delta_vel_dt,
-				    float (&delta_ang)[3], float (&delta_vel)[3])
-{
-	imuSample imu_sample_new;
-	imu_sample_new.delta_ang = Vector3f(delta_ang);
-	imu_sample_new.delta_vel = Vector3f(delta_vel);
 
 void EstimatorInterface::setMagData(const magSample &mag_sample)
-	imu_sample_new.delta_ang_dt = delta_ang_dt / 1e6f;
-	imu_sample_new.delta_vel_dt = delta_vel_dt / 1e6f;
-	imu_sample_new.time_us = time_usec;
-
-	setIMUData(imu_sample_new);
-}
-
 {
 	if (!_initialised || _mag_buffer_fail) {
 		return;

--- a/EKF/estimator_interface.h
+++ b/EKF/estimator_interface.h
@@ -179,7 +179,7 @@ public:
 
 	void setMagData(uint64_t time_usec, float (&data)[3]);
 
-	void setGpsData(uint64_t time_usec, const gps_message &gps);
+	void setGpsData(const gps_message &gps);
 
 	void setBaroData(uint64_t time_usec, float data);
 

--- a/EKF/estimator_interface.h
+++ b/EKF/estimator_interface.h
@@ -183,7 +183,7 @@ public:
 
 	void setBaroData(const baroSample &baro_sample);
 
-	void setAirspeedData(uint64_t time_usec, float true_airspeed, float eas2tas);
+	void setAirspeedData(const airspeedSample &airspeed_sample);
 
 	void setRangeData(uint64_t time_usec, float data, int8_t quality);
 

--- a/EKF/estimator_interface.h
+++ b/EKF/estimator_interface.h
@@ -193,7 +193,7 @@ public:
 	// set external vision position and attitude data
 	void setExtVisionData(uint64_t time_usec, ext_vision_message *evdata);
 
-	void setAuxVelData(uint64_t time_usec, const Vector3f &vel, const Vector3f &variance);
+	void setAuxVelData(const auxVelSample& auxvel_sample);
 
 	// return a address to the parameters struct
 	// in order to give access to the application

--- a/EKF/estimator_interface.h
+++ b/EKF/estimator_interface.h
@@ -177,7 +177,7 @@ public:
 	// legacy interface for compatibility (2018-09-14)
 	void setIMUData(uint64_t time_usec, uint64_t delta_ang_dt, uint64_t delta_vel_dt, float (&delta_ang)[3], float (&delta_vel)[3]);
 
-	void setMagData(uint64_t time_usec, float (&data)[3]);
+	void setMagData(const magSample &mag_sample);
 
 	void setGpsData(const gps_message &gps);
 

--- a/EKF/estimator_interface.h
+++ b/EKF/estimator_interface.h
@@ -185,7 +185,7 @@ public:
 
 	void setAirspeedData(const airspeedSample &airspeed_sample);
 
-	void setRangeData(uint64_t time_usec, float data, int8_t quality);
+	void setRangeData(const rangeSample& range_sample);
 
 	// if optical flow sensor gyro delta angles are not available, set gyroXYZ vector fields to NaN and the EKF will use its internal delta angle data instead
 	void setOpticalFlowData(uint64_t time_usec, flow_message *flow);

--- a/EKF/estimator_interface.h
+++ b/EKF/estimator_interface.h
@@ -181,7 +181,7 @@ public:
 
 	void setGpsData(const gps_message &gps);
 
-	void setBaroData(uint64_t time_usec, float data);
+	void setBaroData(const baroSample &baro_sample);
 
 	void setAirspeedData(uint64_t time_usec, float true_airspeed, float eas2tas);
 

--- a/EKF/estimator_interface.h
+++ b/EKF/estimator_interface.h
@@ -174,8 +174,6 @@ public:
 
 	void setIMUData(const imuSample &imu_sample);
 
-	// legacy interface for compatibility (2018-09-14)
-	void setIMUData(uint64_t time_usec, uint64_t delta_ang_dt, uint64_t delta_vel_dt, float (&delta_ang)[3], float (&delta_vel)[3]);
 
 	void setMagData(const magSample &mag_sample);
 

--- a/EKF/gps_checks.cpp
+++ b/EKF/gps_checks.cpp
@@ -175,9 +175,9 @@ bool Ekf::gps_is_good(const gps_message &gps)
 		_gps_check_fail_status.flags.vdrift = (_gps_drift_metrics[1] > _params.req_vdrift);
 
 		// Check the magnitude of the filtered horizontal GPS velocity
-		Vector2f gps_velNE = matrix::constrain(Vector2f(gps.vel_ned[0], gps.vel_ned[1]), // TODO: when vel_ned vector3f use .xy()
-								-10.0f * _params.req_hdrift,
-								 10.0f * _params.req_hdrift);
+		Vector2f gps_velNE = matrix::constrain(Vector2f(gps.vel_ned.xy()),
+							-10.0f * _params.req_hdrift,
+							 10.0f * _params.req_hdrift);
 		_gps_velNE_filt = gps_velNE * filter_coef + _gps_velNE_filt * (1.0f - filter_coef);
 		_gps_drift_metrics[2] = _gps_velNE_filt.norm();
 		_gps_check_fail_status.flags.hspeed = (_gps_drift_metrics[2] > _params.req_hdrift);
@@ -204,7 +204,7 @@ bool Ekf::gps_is_good(const gps_message &gps)
 
 	// Check  the filtered difference between GPS and EKF vertical velocity
 	float vz_diff_limit = 10.0f * _params.req_vdrift;
-	float vertVel = fminf(fmaxf((gps.vel_ned[2] - _state.vel(2)), -vz_diff_limit), vz_diff_limit);
+	float vertVel = fminf(fmaxf((gps.vel_ned(2) - _state.vel(2)), -vz_diff_limit), vz_diff_limit);
 	_gps_velD_diff_filt = vertVel * filter_coef + _gps_velD_diff_filt * (1.0f - filter_coef);
 	_gps_check_fail_status.flags.vspeed = (fabsf(_gps_velD_diff_filt) > _params.req_vdrift);
 

--- a/test/sensor_simulator/airspeed.cpp
+++ b/test/sensor_simulator/airspeed.cpp
@@ -17,8 +17,11 @@ void Airspeed::send(uint64_t time)
 {
 	if(_true_airspeed_data > FLT_EPSILON && _indicated_airspeed_data > FLT_EPSILON)
 	{
-		float eas2tas = _true_airspeed_data / _indicated_airspeed_data;
-		_ekf->setAirspeedData(time, _true_airspeed_data, eas2tas);
+		airspeedSample airspeed_sample;
+		airspeed_sample.time_us = time;
+		airspeed_sample.eas2tas = _true_airspeed_data / _indicated_airspeed_data;
+		airspeed_sample.true_airspeed = _true_airspeed_data;
+		_ekf->setAirspeedData(airspeed_sample);
 	}
 }
 

--- a/test/sensor_simulator/baro.cpp
+++ b/test/sensor_simulator/baro.cpp
@@ -15,7 +15,8 @@ Baro::~Baro()
 
 void Baro::send(uint64_t time)
 {
-	_ekf->setBaroData(time,_baro_data);
+	const baroSample baro_sample {_baro_data, time};
+	_ekf->setBaroData(baro_sample);
 }
 
 void Baro::setData(float baro)

--- a/test/sensor_simulator/gps.cpp
+++ b/test/sensor_simulator/gps.cpp
@@ -16,7 +16,7 @@ Gps::~Gps()
 void Gps::send(uint64_t time)
 {
 	_gps_data.time_usec = time;
-	_ekf->setGpsData(time, _gps_data);
+	_ekf->setGpsData(_gps_data);
 }
 
 void Gps::setData(const gps_message& gps)
@@ -41,9 +41,7 @@ void Gps::setLongitude(int32_t lon)
 
 void Gps::setVelocity(const Vector3f& vel)
 {
-	_gps_data.vel_ned[0] = vel(0);
-	_gps_data.vel_ned[1] = vel(1);
-	_gps_data.vel_ned[2] = vel(2);
+	_gps_data.vel_ned = vel;
 }
 
 void Gps::stepHeightByMeters(float hgt_change)
@@ -79,9 +77,7 @@ gps_message Gps::getDefaultGpsData()
 	gps_data.epv = 0.8f;
 	gps_data.sacc = 0.2f;
 	gps_data.vel_m_s = 0.0;
-	gps_data.vel_ned[0] = 0.0f;
-	gps_data.vel_ned[1] = 0.0f;
-	gps_data.vel_ned[2] = 0.0f;
+	gps_data.vel_ned.setZero();
 	gps_data.vel_ned_valid = 1;
 	gps_data.nsats = 16;
 	gps_data.pdop = 0.0f;

--- a/test/sensor_simulator/mag.cpp
+++ b/test/sensor_simulator/mag.cpp
@@ -15,9 +15,10 @@ Mag::~Mag()
 
 void Mag::send(uint64_t time)
 {
-	float mag[3];
-	_mag_data.copyTo(mag);
-	_ekf->setMagData(time,mag);
+	magSample mag_sample;
+	mag_sample.mag = _mag_data;
+	mag_sample.time_us = time;
+	_ekf->setMagData(mag_sample);
 }
 
 void Mag::setData(const Vector3f& mag)

--- a/test/sensor_simulator/mag.cpp
+++ b/test/sensor_simulator/mag.cpp
@@ -15,9 +15,7 @@ Mag::~Mag()
 
 void Mag::send(uint64_t time)
 {
-	magSample mag_sample;
-	mag_sample.mag = _mag_data;
-	mag_sample.time_us = time;
+	const magSample mag_sample {_mag_data, time};
 	_ekf->setMagData(mag_sample);
 }
 

--- a/test/sensor_simulator/range_finder.cpp
+++ b/test/sensor_simulator/range_finder.cpp
@@ -15,13 +15,14 @@ RangeFinder::~RangeFinder()
 
 void RangeFinder::send(uint64_t time)
 {
-	_ekf->setRangeData(time, _range_data, _range_quality);
+	_range_sample.time_us = time;
+	_ekf->setRangeData(_range_sample);
 }
 
 void RangeFinder::setData(float range_data_meters, int8_t range_quality)
 {
-	_range_data = range_data_meters;
-	_range_quality = range_quality;
+	_range_sample.rng = range_data_meters;
+	_range_sample.quality = range_quality;
 }
 
 } // namespace sensor

--- a/test/sensor_simulator/range_finder.h
+++ b/test/sensor_simulator/range_finder.h
@@ -54,8 +54,7 @@ public:
 	flow_message dataAtRest();
 
 private:
-	float _range_data{0.0f};
-	int8_t _range_quality;
+	rangeSample _range_sample {};
 
 	void send(uint64_t time) override;
 

--- a/test/test_EKF_measurementSampling.cpp
+++ b/test/test_EKF_measurementSampling.cpp
@@ -66,7 +66,8 @@ TEST_F(EkfMeasurementSamplingTest, baroDownSampling)
 			imu_sample.time_us = time;
 			_ekf->setIMUData(imu_sample);
 		}
-		_ekf->setBaroData(time, baro_data);
+		const baroSample baro_sample {baro_data, time};
+		_ekf->setBaroData(baro_sample);
 		baro_data *= -1.0f;
 		time += 1000000 / baro_rate_Hz;
 	}


### PR DESCRIPTION
This PR contains several changes to the interface of ECL. The main goal is to standardize the interface. This is done by forcing all `set<Sensor>Data()` function to accept a `<Sensor>Sample`. Except from standardization this has the advantage that the pretty good documentation of the `<Sensor>Samples` function as part of the documentation of the interface.

Small remarks;
`gps_message` definition is adapted to profit from matrix:Vector
A legacy IMU interface from 2018 is also removed.

**Related Firmware PR:** https://github.com/PX4/Firmware/pull/13999