### PR TITLE
Auto Formatting with clang-format-6.0

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -44,7 +44,7 @@ BreakConstructorInitializersBeforeComma: false
 BreakConstructorInitializers: BeforeColon
 BreakAfterJavaFieldAnnotations: false
 BreakStringLiterals: true
-ColumnLimit:     80
+ColumnLimit:     120
 CommentPragmas:  '^ IWYU pragma:'
 CompactNamespaces: false
 ConstructorInitializerAllOnOneLineOrOnePerLine: true

--- a/.clang-format
+++ b/.clang-format
@@ -1,7 +1,7 @@
 ---
 Language:        Cpp
 # BasedOnStyle:  Google
-AccessModifierOffset: -4 # Modified
+AccessModifierOffset: -8 # Modified
 AlignAfterOpenBracket: Align
 AlignConsecutiveAssignments: false
 AlignConsecutiveDeclarations: false
@@ -72,7 +72,7 @@ IncludeCategories:
 IncludeIsMainRegex: '([-_](test|unittest))?$'
 IndentCaseLabels: true
 IndentPPDirectives: None
-IndentWidth:     4 # Modified
+IndentWidth:     8 # Modified
 IndentWrappedFunctionNames: false
 JavaScriptQuotes: Leave
 JavaScriptWrapImports: true
@@ -111,7 +111,7 @@ SpacesInCStyleCastParentheses: false
 SpacesInParentheses: false
 SpacesInSquareBrackets: false
 Standard:        Auto
-TabWidth:        4 # Modified
+TabWidth:        8 # Modified
 UseTab:          Always # Modified
 ...
 

--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,117 @@
+---
+Language:        Cpp
+# BasedOnStyle:  Google
+AccessModifierOffset: -4 # Modified
+AlignAfterOpenBracket: Align
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlines: Left
+AlignOperands:   true
+AlignTrailingComments: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortBlocksOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: true
+AllowShortLoopsOnASingleLine: true
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: true
+AlwaysBreakTemplateDeclarations: true
+BinPackArguments: true
+BinPackParameters: true
+BraceWrapping:
+  AfterClass:      false
+  AfterControlStatement: false
+  AfterEnum:       false
+  AfterFunction:   false
+  AfterNamespace:  false
+  AfterObjCDeclaration: false
+  AfterStruct:     false
+  AfterUnion:      false
+  AfterExternBlock: false
+  BeforeCatch:     false
+  BeforeElse:      false
+  IndentBraces:    false
+  SplitEmptyFunction: true
+  SplitEmptyRecord: true
+  SplitEmptyNamespace: true
+BreakBeforeBinaryOperators: None
+BreakBeforeBraces: Attach
+BreakBeforeInheritanceComma: false
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: false
+BreakConstructorInitializers: BeforeColon
+BreakAfterJavaFieldAnnotations: false
+BreakStringLiterals: true
+ColumnLimit:     80
+CommentPragmas:  '^ IWYU pragma:'
+CompactNamespaces: false
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DerivePointerAlignment: true
+DisableFormat:   false
+ExperimentalAutoDetectBinPacking: false
+FixNamespaceComments: true
+ForEachMacros:
+  - foreach
+  - Q_FOREACH
+  - BOOST_FOREACH
+IncludeBlocks:   Preserve
+IncludeCategories:
+  - Regex:           '^<ext/.*\.h>'
+    Priority:        2
+  - Regex:           '^<.*\.h>'
+    Priority:        1
+  - Regex:           '^<.*'
+    Priority:        2
+  - Regex:           '.*'
+    Priority:        3
+IncludeIsMainRegex: '([-_](test|unittest))?$'
+IndentCaseLabels: true
+IndentPPDirectives: None
+IndentWidth:     4 # Modified
+IndentWrappedFunctionNames: false
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLinesAtTheStartOfBlocks: false
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+ObjCBlockIndentWidth: 2
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: false
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 1
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 200
+PointerAlignment: Left
+RawStringFormats:
+  - Delimiter:       pb
+    Language:        TextProto
+    BasedOnStyle:    google
+ReflowComments:  true
+SortIncludes:    true
+SortUsingDeclarations: true
+SpaceAfterCStyleCast: false
+SpaceAfterTemplateKeyword: true
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeParens: ControlStatements
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 2
+SpacesInAngles:  false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+Standard:        Auto
+TabWidth:        4 # Modified
+UseTab:          Always # Modified
+...
+

--- a/.github/workflows/format_checks.yml
+++ b/.github/workflows/format_checks.yml
@@ -1,0 +1,15 @@
+name: Format Checks
+
+on: [push, pull_request]
+
+jobs:
+  format_checks:
+    runs-on: ubuntu-latest
+    container: px4io/px4-dev-clang:2019-10-24
+    steps:
+    - uses: actions/checkout@v1
+    - name: install clang-format-6.0
+      run: apt install -y clang-format-6.0
+    - name: check_format
+      run: ./tools/format.sh 0
+

--- a/EKF/AlphaFilter.hpp
+++ b/EKF/AlphaFilter.hpp
@@ -51,9 +51,7 @@ public:
 		update(input, alpha);
 	}
 
-	void update(const T &input, float alpha) {
-		_x = (1.f - alpha) * _x + alpha * input;
-	}
+	void update(const T &input, float alpha) { _x = (1.f - alpha) * _x + alpha * input; }
 
 	// Typical 0.9/0.1 lowpass filter
 	void update(const T &input) { update(input, 0.1f); }

--- a/EKF/AlphaFilter.hpp
+++ b/EKF/AlphaFilter.hpp
@@ -38,34 +38,28 @@
 
 #pragma once
 
-template<typename T>
-class AlphaFilter final
-{
+template <typename T>
+class AlphaFilter final {
 public:
 	AlphaFilter() = default;
 	~AlphaFilter() = default;
 
 	void reset(const T &val) { _x = val; }
 
-	void update(const T &input, float tau, float dt)
-	{
-		const float alpha = dt / tau; 
+	void update(const T &input, float tau, float dt) {
+		const float alpha = dt / tau;
 		update(input, alpha);
 	}
 
-	void update(const T &input, float alpha)
-	{
+	void update(const T &input, float alpha) {
 		_x = (1.f - alpha) * _x + alpha * input;
 	}
 
 	// Typical 0.9/0.1 lowpass filter
-	void update(const T &input)
-	{
-		update(input, 0.1f);
-	}
+	void update(const T &input) { update(input, 0.1f); }
 
-	const T& getState() const { return _x; }
+	const T &getState() const { return _x; }
 
 private:
-	T _x{}; ///< current state of the filter
+	T _x{};  ///< current state of the filter
 };

--- a/EKF/RingBuffer.h
+++ b/EKF/RingBuffer.h
@@ -119,16 +119,13 @@ public:
 
 	uint8_t get_oldest_index() const { return _tail; }
 
-	bool pop_first_older_than(const uint64_t &timestamp,
-				  data_type *sample) {
+	bool pop_first_older_than(const uint64_t &timestamp, data_type *sample) {
 		// start looking from newest observation data
 		for (uint8_t i = 0; i < _size; i++) {
 			int index = (_head - i);
 			index = index < 0 ? _size + index : index;
 
-			if (timestamp >= _buffer[index].time_us &&
-			    timestamp - _buffer[index].time_us <
-				(uint64_t)1e5) {
+			if (timestamp >= _buffer[index].time_us && timestamp - _buffer[index].time_us < (uint64_t)1e5) {
 				*sample = _buffer[index];
 
 				// Now we can set the tail to the item which
@@ -157,9 +154,7 @@ public:
 		return false;
 	}
 
-	int get_total_size() {
-		return sizeof(*this) + sizeof(data_type) * _size;
-	}
+	int get_total_size() { return sizeof(*this) + sizeof(data_type) * _size; }
 
 private:
 	data_type *_buffer{nullptr};

--- a/EKF/RingBuffer.h
+++ b/EKF/RingBuffer.h
@@ -75,8 +75,8 @@ public:
 		_head = 0;
 		_tail = 0;
 
-		// set the time elements to zero so that bad data is not retrieved from
-		// the buffers
+		// set the time elements to zero so that bad data is not
+		// retrieved from the buffers
 		for (uint8_t index = 0; index < _size; index++) {
 			_buffer[index] = {};
 		}
@@ -119,19 +119,21 @@ public:
 
 	uint8_t get_oldest_index() const { return _tail; }
 
-	bool pop_first_older_than(const uint64_t &timestamp, data_type *sample) {
+	bool pop_first_older_than(const uint64_t &timestamp,
+				  data_type *sample) {
 		// start looking from newest observation data
 		for (uint8_t i = 0; i < _size; i++) {
 			int index = (_head - i);
 			index = index < 0 ? _size + index : index;
 
 			if (timestamp >= _buffer[index].time_us &&
-				timestamp - _buffer[index].time_us < (uint64_t)1e5) {
+			    timestamp - _buffer[index].time_us <
+				(uint64_t)1e5) {
 				*sample = _buffer[index];
 
-				// Now we can set the tail to the item which comes after the one
-				// we removed since we don't want to have any older data in the
-				// buffer
+				// Now we can set the tail to the item which
+				// comes after the one we removed since we don't
+				// want to have any older data in the buffer
 				if (index == _head) {
 					_tail = _head;
 					_first_write = true;
@@ -146,7 +148,8 @@ public:
 			}
 
 			if (index == _tail) {
-				// we have reached the tail and haven't got a match
+				// we have reached the tail and haven't got a
+				// match
 				return false;
 			}
 		}
@@ -154,7 +157,9 @@ public:
 		return false;
 	}
 
-	int get_total_size() { return sizeof(*this) + sizeof(data_type) * _size; }
+	int get_total_size() {
+		return sizeof(*this) + sizeof(data_type) * _size;
+	}
 
 private:
 	data_type *_buffer{nullptr};

--- a/EKF/RingBuffer.h
+++ b/EKF/RingBuffer.h
@@ -42,11 +42,9 @@
 #include <cstring>
 
 template <typename data_type>
-class RingBuffer
-{
+class RingBuffer {
 public:
-	RingBuffer()
-	{
+	RingBuffer() {
 		if (allocate(1)) {
 			// initialize with one empty sample
 			data_type d = {};
@@ -61,8 +59,7 @@ public:
 	RingBuffer(RingBuffer &&) = delete;
 	RingBuffer &operator=(RingBuffer &&) = delete;
 
-	bool allocate(uint8_t size)
-	{
+	bool allocate(uint8_t size) {
 		if (_buffer != nullptr) {
 			delete[] _buffer;
 		}
@@ -78,7 +75,8 @@ public:
 		_head = 0;
 		_tail = 0;
 
-		// set the time elements to zero so that bad data is not retrieved from the buffers
+		// set the time elements to zero so that bad data is not retrieved from
+		// the buffers
 		for (uint8_t index = 0; index < _size; index++) {
 			_buffer[index] = {};
 		}
@@ -88,14 +86,12 @@ public:
 		return true;
 	}
 
-	void unallocate()
-	{
+	void unallocate() {
 		delete[] _buffer;
 		_buffer = nullptr;
 	}
 
-	void push(const data_type &sample)
-	{
+	void push(const data_type &sample) {
 		uint8_t head_new = _head;
 
 		if (!_first_write) {
@@ -123,19 +119,19 @@ public:
 
 	uint8_t get_oldest_index() const { return _tail; }
 
-	bool pop_first_older_than(const uint64_t &timestamp, data_type *sample)
-	{
+	bool pop_first_older_than(const uint64_t &timestamp, data_type *sample) {
 		// start looking from newest observation data
 		for (uint8_t i = 0; i < _size; i++) {
 			int index = (_head - i);
 			index = index < 0 ? _size + index : index;
 
-			if (timestamp >= _buffer[index].time_us && timestamp - _buffer[index].time_us < (uint64_t)1e5) {
-
+			if (timestamp >= _buffer[index].time_us &&
+				timestamp - _buffer[index].time_us < (uint64_t)1e5) {
 				*sample = _buffer[index];
 
-				// Now we can set the tail to the item which comes after the one we removed
-				// since we don't want to have any older data in the buffer
+				// Now we can set the tail to the item which comes after the one
+				// we removed since we don't want to have any older data in the
+				// buffer
 				if (index == _head) {
 					_tail = _head;
 					_first_write = true;

--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,8 @@
 FIRST_ARG := $(firstword $(MAKECMDGOALS))
 ARGS := $(wordlist 2,$(words $(MAKECMDGOALS)),$(MAKECMDGOALS))
 j ?= 4
+BLUE='\033[1;36m'
+NC='\033[0m' # No Color
 
 NINJA_BIN := ninja
 ifndef NO_NINJA_BUILD
@@ -95,7 +97,7 @@ doxygen:
 # Testing
 # --------------------------------------------------------------------
 
-.PHONY: test_build test test_EKF
+.PHONY: test_build test
 
 test_build:
 	@$(call cmake-build,$@,$(SRC_DIR), "-DBUILD_TESTING=ON")
@@ -123,6 +125,22 @@ coverage_html: coverage_build
 
 coverage_html_view: coverage_build
 	@cmake --build $(SRC_DIR)/build/coverage_build --target coverage_html_view
+
+# Code formatting
+# --------------------------------------------------------------------
+.PHONY: check_format format clang-format
+
+clang-format:
+	@echo -e ${BLUE}Check clang-format-6.0 installation${NC}
+	@if ! hash clang-format-6.0; then sudo apt install clang-format-6.0 -y; fi
+
+check_format: clang-format
+	@echo -e ${BLUE}Checking formatting with clang-format${NC}
+	@$(SRC_DIR)/tools/format.sh 0
+
+format: clang-format
+	@echo -e ${BLUE}Formatting with clang-format${NC}
+	@$(SRC_DIR)/tools/format.sh 1
 
 # Cleanup
 # --------------------------------------------------------------------

--- a/tools/format.sh
+++ b/tools/format.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+do_format=$1
+files_to_format="""
+EKF/AlphaFilter.hpp
+EKF/RingBuffer.h
+"""
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+if ! hash clang-format-6.0
+then
+    echo -e ${RED}Error: No clang-format-6.0 installed${NC}
+    exit 1
+fi
+
+if [[ $do_format -eq 1 ]]
+then
+    # formatting
+    clang-format-6.0 -i -style=file ${files_to_format}
+    echo -e ${GREEN}Formatting finished${NC}
+else
+    # checking format...
+    clang-format-6.0 -style=file  -output-replacements-xml ${files_to_format} | grep -c "<replacement " > /dev/null
+    if [[ $? -eq 0 ]]
+    then
+        echo -e ${RED}Error: need to format${NC}
+        echo -e ${YELLOW}From cmake build directory run: 'make format'${NC}
+        exit 1
+    fi
+    echo -e ${GREEN}no formatting needed${NC}
+    exit 0
+fi


### PR DESCRIPTION
This PR brings auto-formatting with clang-format-6.0 to ECL. It adds a few Makefile targets, which provide installation of clang-format, checking the format and formatting the code.

The formatting rules are based on google style guide. Except for some indentation modifcation to stay closer to appearance of the Firmware. The following options were adapted:
```
AccessModifierOffset: -4
IndentWidth: 4
TabWidth: 4
UseTab: Always
```

The files on which the auto-formatting is required, is specified in tools/format.sh. At the moment it is only added for EKF/RingBuffer.h and EKF/AlphaFilter.hpp

A github action that checks if the format is according to the rules is also added.