### PR TITLE
Remove filtering on external vision alignment

### DIFF
--- a/EKF/control.cpp
+++ b/EKF/control.cpp
@@ -205,14 +205,6 @@ void Ekf::controlExternalVisionFusion()
 					resetVelocity();
 					ECL_INFO_TIMESTAMPED("commencing external vision velocity fusion");
 				}
-
-				if ((_params.fusion_mode & MASK_ROTATE_EV) && !(_params.fusion_mode & MASK_USE_EVYAW)
-					&& !_R_ev_to_ekf_initialised)  {
-					// Reset transformation between EV and EKF navigation frames when starting fusion
-					resetExtVisRotMat();
-					_R_ev_to_ekf_initialised = true;
-					ECL_INFO_TIMESTAMPED("external vision aligned");
-				}
 			}
 		}
 

--- a/EKF/ekf.h
+++ b/EKF/ekf.h
@@ -319,10 +319,7 @@ private:
 	Vector3f _pos_meas_prev;		///< previous value of NED position measurement fused using odometry assumption (m)
 	Vector2f _hpos_pred_prev;		///< previous value of NE position state used by odometry fusion (m)
 	bool _hpos_prev_available{false};	///< true when previous values of the estimate and measurement are available for use
-	AxisAnglef _ev_rot_vec_filt;		///< filtered rotation vector defining the rotation EV to EKF reference, initiliazied to zero rotation  (rad)
 	Dcmf _R_ev_to_ekf;			///< transformation matrix that rotates observations from the EV to the EKF navigation frame, initialized with Identity
-	uint64_t _ev_rot_last_time_us{0};	///< previous time that the calculation of the EV to EKF rotation matrix was updated (uSec)
-	bool _R_ev_to_ekf_initialised{0};	///< _R_ev_to_ekf should only be initialised once in the beginning through the reset function
 
 	// booleans true when fresh sensor data is available at the fusion time horizon
 	bool _gps_data_ready{false};	///< true when new GPS data has fallen behind the fusion time horizon and is available to be fused
@@ -615,14 +612,8 @@ private:
 	// modify output filter to match the the EKF state at the fusion time horizon
 	void alignOutputFilter();
 
-	// update the estimated angular misalignment vector between the EV naigration frame and the EKF navigation frame
-	// and update the rotation matrix which transforms EV navigation frame measurements into NED
+	// update the rotation matrix which transforms EV navigation frame measurements into NED
 	void calcExtVisRotMat();
-
-
-	// reset the estimated angular misalignment vector between the EV naigration frame and the EKF navigation frame
-	// and reset the rotation matrix which transforms EV navigation frame measurements into NED
-	void resetExtVisRotMat();
 
 	// limit the diagonal of the covariance matrix
 	// force symmetry when the argument is true

--- a/EKF/gps_yaw_fusion.cpp
+++ b/EKF/gps_yaw_fusion.cpp
@@ -393,11 +393,6 @@ bool Ekf::resetGpsAntYaw()
 			// update transformation matrix from body to world frame using the current estimate
 			_R_to_earth = Dcmf(_state.quat_nominal);
 
-			// reset the rotation from the EV to EKF frame of reference if it is being used
-			if ((_params.fusion_mode & MASK_ROTATE_EV) && (_params.fusion_mode & MASK_USE_EVPOS)) {
-				resetExtVisRotMat();
-			}
-
 			// update the yaw angle variance using the variance of the measurement
 			increaseQuatYawErrVariance(sq(fmaxf(_params.mag_heading_noise, 1.0e-2f)));
 


### PR DESCRIPTION
As suggest by @nicovanduijn and @bresch in https://github.com/PX4/ecl/pull/709, it is beneficial to remove the filtering on the vision reference frame alignment. Quickly changes in heading state due to magnetic interference was causing the toilet boiling as the filtering of the vision alignment introduced to delay. A VIO estimate is not really noisy, as it is most likely an output of an estimator itself, therefore it is reasonable to remove the filter on the alignment.

**Testing:**
@bresch do you still have a log?