### PR TITLE
Fix github action to work with forks

### DIFF
--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -1,7 +1,7 @@
 
 name: Build Tests
 
-on: [push, pull_request]
+on: [pull_request]
 
 jobs:
   Linux-GCC:

--- a/.github/workflows/firmware_build_test.yml
+++ b/.github/workflows/firmware_build_test.yml
@@ -1,6 +1,6 @@
 name: Firmware Build Test
 
-on: [push, pull_request]
+on: [pull_request]
 
 jobs:
   Firmware-build:
@@ -20,7 +20,9 @@ jobs:
       working-directory: ../Firmware
     - name: Configure Firmware to include current ECL version
       working-directory: ../Firmware/src/lib/ecl
-      run: git checkout ${{ github.sha }}
+      run: |
+        git fetch origin +${{ github.ref }}
+        git checkout ${{ github.sha }}
     - name: Add and commit new ECL version
       run: |
         git config --global user.email "${GIT_COMMITTER_EMAIL}"

--- a/.github/workflows/format_checks.yml
+++ b/.github/workflows/format_checks.yml
@@ -1,6 +1,6 @@
 name: Format Checks
 
-on: [push, pull_request]
+on: [pull_request]
 
 jobs:
   format_checks:

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -1,6 +1,6 @@
 name: Unit Tests
 
-on: [push, pull_request]
+on: [pull_request]
 
 jobs:
   unit_tests:


### PR DESCRIPTION
Previously the Firmware build tests check was not able to checkout the right ECL version on forks. Now it is.
Also were the github actions run twice for upstream branches. Once on push, once on the PR. With changing them to pull_request only. Now they will appear only once.