### PR TITLE
Fix bug causing incorrect covariance initialisation

### DIFF
--- a/EKF/common.h
+++ b/EKF/common.h
@@ -223,7 +223,7 @@ struct parameters {
 
 	// process noise
 	float gyro_bias_p_noise{1.0e-3f};	///< process noise for IMU rate gyro bias prediction (rad/sec**2)
-	float accel_bias_p_noise{6.0e-3f};	///< process noise for IMU accelerometer bias prediction (m/sec**3)
+	float accel_bias_p_noise{1.0e-2f};	///< process noise for IMU accelerometer bias prediction (m/sec**3)
 	float mage_p_noise{1.0e-3f};		///< process noise for earth magnetic field prediction (Gauss/sec)
 	float magb_p_noise{1.0e-4f};		///< process noise for body magnetic field prediction (Gauss/sec)
 	float wind_vel_p_noise{1.0e-1f};	///< process noise for wind velocity prediction (m/sec**2)

--- a/EKF/covariance.cpp
+++ b/EKF/covariance.cpp
@@ -46,6 +46,8 @@
 #include <math.h>
 #include <mathlib/mathlib.h>
 
+// Sets initial values for the covariance matrix
+// Do not call before quaternion states have been initialised
 void Ekf::initialiseCovariance()
 {
 	P.zero();

--- a/EKF/ekf.cpp
+++ b/EKF/ekf.cpp
@@ -67,8 +67,6 @@ void Ekf::reset()
 	_output_new.pos.setZero();
 	_output_new.quat_nominal.setIdentity();
 
-	initialiseCovariance();
-
 	_delta_angle_corr.setZero();
 
 	_imu_updated = false;
@@ -195,7 +193,6 @@ bool Ekf::initialiseFilter()
 		// calculate the initial magnetic field and yaw alignment
 		_control_status.flags.yaw_align = resetMagHeading(_mag_lpf.getState(), false, false);
 
-
 		// update the yaw angle variance using the variance of the measurement
 		if (_params.mag_fusion_type <= MAG_FUSE_TYPE_3D) {
 			// using magnetic heading tuning parameter
@@ -215,6 +212,9 @@ bool Ekf::initialiseFilter()
 
 		// reset the output predictor state history to match the EKF initial values
 		alignOutputFilter();
+
+		// initialise the state covariance matrix now we have starting values for all lthe states
+		initialiseCovariance();
 
 		return true;
 	}

--- a/EKF/ekf.cpp
+++ b/EKF/ekf.cpp
@@ -193,6 +193,9 @@ bool Ekf::initialiseFilter()
 		// calculate the initial magnetic field and yaw alignment
 		_control_status.flags.yaw_align = resetMagHeading(_mag_lpf.getState(), false, false);
 
+		// initialise the state covariance matrix now we have starting values for all the states
+		initialiseCovariance();
+
 		// update the yaw angle variance using the variance of the measurement
 		if (_params.mag_fusion_type <= MAG_FUSE_TYPE_3D) {
 			// using magnetic heading tuning parameter
@@ -212,9 +215,6 @@ bool Ekf::initialiseFilter()
 
 		// reset the output predictor state history to match the EKF initial values
 		alignOutputFilter();
-
-		// initialise the state covariance matrix now we have starting values for all lthe states
-		initialiseCovariance();
 
 		return true;
 	}

--- a/EKF/ekf.h
+++ b/EKF/ekf.h
@@ -746,6 +746,7 @@ private:
 	Vector3f calcRotVecVariances();
 
 	// initialise the quaternion covariances using rotation vector variances
+	// do not call before quaternion states are initialised
 	void initialiseQuatCovariances(Vector3f &rot_vec_var);
 
 	// perform a limited reset of the magnetic field state covariances

--- a/EKF/ekf_helper.cpp
+++ b/EKF/ekf_helper.cpp
@@ -1480,6 +1480,7 @@ Vector3f Ekf::calcRotVecVariances()
 }
 
 // initialise the quaternion covariances using rotation vector variances
+// do not call before quaternion states are initialised
 void Ekf::initialiseQuatCovariances(Vector3f &rot_vec_var)
 {
 	// calculate an equivalent rotation vector from the quaternion


### PR DESCRIPTION
This issue was found by @RomanBapst during a git bisect search to find the cause of a growing Z delta velocity bias estimate and vertical position and velocity innovations

![Screen Shot 2020-01-30 at 5 52 45 pm](https://user-images.githubusercontent.com/3596952/73426807-63132100-4389-11ea-9bc6-e04b45ad7fa3.png)

![Screen Shot 2020-01-30 at 5 53 55 pm](https://user-images.githubusercontent.com/3596952/73426900-a1a8db80-4389-11ea-882e-2caf6a93b231.png)

that had appeared with a hardware setup when the firmware was updated. This search determined that the issue was introduced by https://github.com/PX4/ecl/pull/689/commits/ea3f95a56486a274cc71b549176de8364eea40d5 in a PR that was supposed to be a non functional change.

Because the covariance initialisation is dependent on the quaternion states, the Ekf::initialiseCovariance() function must be called after the states are aligned, not before.

It is also unnecessary to call Ekf::initialiseCovariance() in the Ekf::reset() function because this function sets _filter_initialised to false which causes the Ekf::initialiseFilter() function to be called until the state vector  (and with this change the covariance matrix ) has been reset.

The default value for delta velocity process noise has also been increased to fix poor stability in delta velocity bias estimation with seen in a log.

After these changes, we get the following results with replay of the same log:

![Screen Shot 2020-01-30 at 5 56 50 pm](https://user-images.githubusercontent.com/3596952/73427009-e896d100-4389-11ea-82d8-2ed970cfc160.png)

![Screen Shot 2020-01-30 at 5 56 25 pm](https://user-images.githubusercontent.com/3596952/73426978-d87ef180-4389-11ea-8b9b-10aee6781678.png)

Without the process noise change, the initial bias estimation is poor but fixes when flight commences, eg:

![Screen Shot 2020-01-30 at 5 58 38 pm](https://user-images.githubusercontent.com/3596952/73427118-2f84c680-438a-11ea-9ca8-99ac2c46ddff.png)

An upstream PR is required to change the default value used for this parameter.