### PR TITLE
Make test with Clang

### DIFF
--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -27,9 +27,8 @@ jobs:
         run: make
       - name: clean build
         run: make clean
-      # TODO: This is not running at the moment
-      #- name: main test
-      #  run: make test
+      - name: main test
+        run: make test
   Mac-OS:
     runs-on: macos-latest
     steps:
@@ -38,6 +37,5 @@ jobs:
         run: make
       - name: clean build
         run: make clean
-      # TODO: This is not running at the moment
-      #- name: main test
-      #  run: make test
+      - name: main test
+        run: make test

--- a/test/gtest.cmake
+++ b/test/gtest.cmake
@@ -41,10 +41,3 @@ endif()
 
 # Add googletest, defines gtest and gtest_main targets
 add_subdirectory(${CMAKE_CURRENT_BINARY_DIR}/googletest-src ${CMAKE_CURRENT_BINARY_DIR}/googletest-build EXCLUDE_FROM_ALL)
-
-# Remove visibility.h from the compile flags for gtest because of poisoned exit()
-get_target_property(GTEST_COMPILE_FLAGS gtest COMPILE_OPTIONS)
-list(REMOVE_ITEM GTEST_COMPILE_FLAGS "-include")
-list(REMOVE_ITEM GTEST_COMPILE_FLAGS "visibility.h")
-set_target_properties(gtest PROPERTIES COMPILE_OPTIONS "${GTEST_COMPILE_FLAGS}")
-

--- a/test/sensor_simulator/sensor_simulator.h
+++ b/test/sensor_simulator/sensor_simulator.h
@@ -47,6 +47,7 @@
 #include <iostream>
 #include <sstream>
 #include <vector>
+#include <array>
 
 #include "imu.h"
 #include "mag.h"

--- a/test/test_EKF_airspeed.cpp
+++ b/test/test_EKF_airspeed.cpp
@@ -96,7 +96,7 @@ TEST_F(EkfAirspeedTest, testWindVelocityEstimation)
 	EXPECT_TRUE(matrix::isEqual(vel, simulated_velocity_earth));
  	const Vector3f vel_wind_expected = simulated_velocity_earth - R_to_earth_sim * (Vector3f(airspeed_body(0), airspeed_body(1), 0.0f));
 	EXPECT_TRUE(matrix::isEqual(vel_wind_earth, Vector2f(vel_wind_expected.slice<2,1>(0,0))));
-	EXPECT_FLOAT_EQ(height_before_pressure_correction, 0.0f);
+	EXPECT_NEAR(height_before_pressure_correction, 0.0f, 1e-5f);
 
 	// Apply height correction
 	const float static_pressure_coef_xp = 1.0f;

--- a/test/test_EKF_imuSampling.cpp
+++ b/test/test_EKF_imuSampling.cpp
@@ -94,7 +94,7 @@ TEST_P(EkfImuSamplingTest, imuSamplingAtMultipleRates)
 	EXPECT_TRUE(matrix::isEqual(accel, imu_sample_buffered.delta_vel/imu_sample_buffered.delta_vel_dt, 1e-7f));
 }
 
-INSTANTIATE_TEST_CASE_P(imuSamplingAtMultipleRates,
+INSTANTIATE_TEST_SUITE_P(imuSamplingAtMultipleRates,
 			EkfImuSamplingTest,
 			::testing::Values(
 				std::make_tuple<float,float,Vector3f,Vector3f>(1.0f,  1.0f,Vector3f{0.0f,0.0f,0.0f},Vector3f{-0.46f,0.87f,0.20f}),


### PR DESCRIPTION
This allows for the test also run with the Clang compiler.

@MaEtUgR You have added [this](https://github.com/PX4/ecl/pull/741/files#diff-59007f958bf3519ed464d95c410f5d1eL44) on the Firmware side. Do you know if this is still necessary? This caused issues with the Clang compiler.

I noticed that if the same code is compiled with Clang compiler, the change indication output differs from the one produced when compiled with GCC.

#740 