### PR TITLE
do not zero gps altitude reference in init function

### DIFF
--- a/EKF/ekf.cpp
+++ b/EKF/ekf.cpp
@@ -184,7 +184,6 @@ bool Ekf::initialiseFilter()
 
 		// reset variables that are shared with post alignment GPS checks
 		_gps_pos_deriv_filt(2) = 0.0f;
-		_gps_alt_ref = 0.0f;
 
 		if(!initialiseTilt()){
 			return false;


### PR DESCRIPTION
- if gps checks pass before the filter initialized this will set the gps
reference altitude to zero and thus global altitude will not be correct.
I found that this was actually the case in SITL because there the gps checks pass really quickly.

Signed-off-by: RomanBapst <bapstroman@gmail.com>