### PR TITLE
ekf: clean uncorrelateQuatStates function

### DIFF
--- a/EKF/control.cpp
+++ b/EKF/control.cpp
@@ -227,7 +227,7 @@ void Ekf::controlExternalVisionFusion()
 
 				// calculate initial quaternion states for the ekf
 				_state.quat_nominal = Quatf(euler_init);
-				uncorrelateQuatStates();
+				uncorrelateQuatFromOtherStates();
 
 				// adjust the quaternion covariances estimated yaw error
 				increaseQuatYawErrVariance(fmaxf(_ev_sample_delayed.angVar, sq(1.0e-2f)));

--- a/EKF/ekf.h
+++ b/EKF/ekf.h
@@ -774,7 +774,7 @@ private:
 	void zeroMagCov();
 
 	// uncorrelate quaternion states from other states
-	void uncorrelateQuatStates();
+	void uncorrelateQuatFromOtherStates();
 
 	// Use Kahan summation algorithm to get the sum of "sum_previous" and "input".
 	// This function relies on the caller to be responsible for keeping a copy of

--- a/EKF/gps_yaw_fusion.cpp
+++ b/EKF/gps_yaw_fusion.cpp
@@ -385,7 +385,7 @@ bool Ekf::resetGpsAntYaw()
 		if (delta_ang_error.norm() > math::radians(15.0f) || !_control_status.flags.yaw_align) {
 			// update quaternion states
 			_state.quat_nominal = quat_after_reset;
-			uncorrelateQuatStates();
+			uncorrelateQuatFromOtherStates();
 
 			// record the state change
 			_state_reset_status.quat_change = q_error;


### PR DESCRIPTION
As the name can be ambiguous, it gets renamed "uncorrelateQuatFromOtherStates".

Also replace the loops storing the values and reapplying them by simply
zeroing two slices (this also saves 130B of flash).