### PR TITLE
EKF: Add Emergency yaw recovery using EKF-GSF estimator

### DIFF
--- a/EKF/CMakeLists.txt
+++ b/EKF/CMakeLists.txt
@@ -49,6 +49,7 @@ add_library(ecl_EKF
 	gps_yaw_fusion.cpp
 	range_finder_checks.cpp
 	imu_down_sampler.cpp
+	EKFGSF_yaw_estimator.cpp
 )
 
 add_dependencies(ecl_EKF prebuild_targets)

--- a/EKF/EKFGSF_yaw_estimator.cpp
+++ b/EKF/EKFGSF_yaw_estimator.cpp
@@ -838,7 +838,8 @@ Matrix3f Ekf::updateRotMatEKFGSF(Matrix3f &R, Vector3f &g)
 	for (uint8_t r = 0; r < 3; r++) {
 		rowLengthSq = ret(r,0) * ret(r,0) + ret(r,1) * ret(r,1) + ret(r,2) * ret(r,2);
 		if (rowLengthSq > FLT_EPSILON) {
-			const float rowLengthInv = 1.0f / sqrtf(rowLengthSq);
+			// Use linear approximation for inverse sqrt taking advantage of the row length being close to 1.0
+			const float rowLengthInv = 1.5f - 0.5f * rowLengthSq;
 			ret(r,0) *= rowLengthInv;
 			ret(r,1) *= rowLengthInv;
 			ret(r,2) *= rowLengthInv;

--- a/EKF/EKFGSF_yaw_estimator.cpp
+++ b/EKF/EKFGSF_yaw_estimator.cpp
@@ -744,9 +744,7 @@ bool Ekf::resetYawToEKFGSF()
 
 }
 
-// request the EKF reset the yaw to the estimate from the internal EKF-GSF filter
-// argument should be incremented only when a new reset is required
-void Ekf::request_ekfgsf_yaw_reset(uint8_t counter)
+void Ekf::requestEmergencyNavReset(uint8_t counter)
 {
 	if (counter > _yaw_extreset_counter) {
 		_yaw_extreset_counter = counter;

--- a/EKF/EKFGSF_yaw_estimator.cpp
+++ b/EKF/EKFGSF_yaw_estimator.cpp
@@ -1,0 +1,792 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2019 Paul Riseborough
+ *
+ ****************************************************************************/
+
+/*
+ * @file EKFGSF_yaw_estimator.cpp
+ * Definition of functions used to provide a backup estimate of yaw angle
+ * that doesn't use a magnetometer.
+ * Uses a bank of 3-state EKF's organised as a Guassian sum filter
+ * where states are velocity N,E (m/s) and yaw angle (rad)
+ *
+ * @author Paul Riseborough <p_riseborough@live.com.au>
+ */
+
+#include "ekf.h"
+#include <ecl.h>
+#include <mathlib/mathlib.h>
+#include <cstdlib>
+
+void Ekf::quatPredictEKFGSF(const uint8_t model_index)
+{
+	// generate attitude solution using simple complementary filter for the selected model
+
+	// Accelerometer correction
+	// Project 'k' unit vector of earth frame to body frame
+	// Vector3f k = quaterion.conjugate_inversed(Vector3f(0.0f, 0.0f, 1.0f));
+	// Optimized version with dropped zeros
+	const Vector3f k(
+		2.0f * (_ahrs_ekf_gsf[model_index].quat(1) * _ahrs_ekf_gsf[model_index].quat(3) - _ahrs_ekf_gsf[model_index].quat(0) * _ahrs_ekf_gsf[model_index].quat(2)),
+		2.0f * (_ahrs_ekf_gsf[model_index].quat(2) * _ahrs_ekf_gsf[model_index].quat(3) + _ahrs_ekf_gsf[model_index].quat(0) * _ahrs_ekf_gsf[model_index].quat(1)),
+		(_ahrs_ekf_gsf[model_index].quat(0) * _ahrs_ekf_gsf[model_index].quat(0) - _ahrs_ekf_gsf[model_index].quat(1) * _ahrs_ekf_gsf[model_index].quat(1) - _ahrs_ekf_gsf[model_index].quat(2) * _ahrs_ekf_gsf[model_index].quat(2) + _ahrs_ekf_gsf[model_index].quat(3) * _ahrs_ekf_gsf[model_index].quat(3))
+	);
+
+	// Perform angular rate correction using accel data and reduce correction as accel magnitude moves away from 1 g (reduces drift when vehicle picked up and moved).
+	// During fixed wing flight, compensate for centripetal acceleration assuming coordinated turns and X axis forward
+	Vector3f correction = {};
+	Vector3f accel = _ahrs_accel;
+	if (_ahrs_accel_norm > 0.5f * CONSTANTS_ONE_G && (_ahrs_accel_norm < 1.5f * CONSTANTS_ONE_G || _ahrs_turn_comp_enabled)) {
+		if (_ahrs_turn_comp_enabled) {
+			// turn rate is component of gyro rate about vertical (down) axis
+			const float turn_rate = _ahrs_ekf_gsf[model_index].R(2,0) * _ang_rate_delayed_raw(0)
+					  + _ahrs_ekf_gsf[model_index].R(2,1) * _ang_rate_delayed_raw(1)
+					  + _ahrs_ekf_gsf[model_index].R(2,2) * _ang_rate_delayed_raw(2);
+
+			// use measured airspeed to calculate centripetal acceleration if available
+			float centripetal_accel;
+			if (_imu_sample_delayed.time_us - _airspeed_sample_delayed.time_us < 1000000) {
+				centripetal_accel = _airspeed_sample_delayed.true_airspeed * turn_rate;
+			} else {
+				centripetal_accel = _params.EKFGSF_tas_default * turn_rate;
+			}
+
+			// project Y body axis onto horizontal and multiply by centripetal acceleration to give estimated
+			// centripetal acceleration vector in earth frame due to coordinated turn
+			Vector3f centripetal_accel_vec_ef = {_ahrs_ekf_gsf[model_index].R(0,1), _ahrs_ekf_gsf[model_index].R(1,1), 0.0f};
+			if (_ahrs_ekf_gsf[model_index].R(2,2) > 0.0f) {
+				// vehicle is upright
+				centripetal_accel_vec_ef *= centripetal_accel;
+			} else {
+				// vehicle is inverted
+				centripetal_accel_vec_ef *= - centripetal_accel;
+			}
+
+			// rotate into body frame
+			Vector3f centripetal_accel_vec_bf = _ahrs_ekf_gsf[model_index].R.transpose() * centripetal_accel_vec_ef;
+
+			// correct measured accel for centripetal acceleration
+			accel -= centripetal_accel_vec_bf;
+		}
+
+		correction = (k % accel) * _ahrs_accel_fusion_gain / _ahrs_accel_norm;
+
+	}
+
+	// Gyro bias estimation
+	const float gyro_bias_limit = 0.05f;
+	const float spinRate = _ang_rate_delayed_raw.length();
+	if (spinRate < 0.175f) {
+		_ahrs_ekf_gsf[model_index].gyro_bias -= correction * (_params.EKFGSF_gyro_bias_gain * _imu_sample_delayed.delta_ang_dt);
+
+		for (int i = 0; i < 3; i++) {
+			_ahrs_ekf_gsf[model_index].gyro_bias(i) = math::constrain(_ahrs_ekf_gsf[model_index].gyro_bias(i), -gyro_bias_limit, gyro_bias_limit);
+		}
+	}
+
+	const Vector3f rates = _ang_rate_delayed_raw - _ahrs_ekf_gsf[model_index].gyro_bias;
+
+	// Feed forward gyro
+	correction += rates;
+
+	// Apply correction to state
+	_ahrs_ekf_gsf[model_index].quat += _ahrs_ekf_gsf[model_index].quat.derivative1(correction) * _imu_sample_delayed.delta_ang_dt;
+
+	// Normalize quaternion
+	_ahrs_ekf_gsf[model_index].quat.normalize();
+
+	// uodate body to earth frame rotation matrix
+	_ahrs_ekf_gsf[model_index].R = Dcmf(_ahrs_ekf_gsf[model_index].quat);
+
+}
+
+void Ekf::alignQuatEKFGSF()
+{
+	// Rotation matrix is constructed directly from acceleration measurement and will be the same for
+	// all models so only need to calculate it once. Assumptions are:
+	// 1) Yaw angle is zero - yaw is aligned later for each model when velocity fusion commences.
+	// 2) The vehicle is not accelerating so all of the measured acceleration is due to gravity.
+
+	// Calculate earth frame Down axis unit vector rotated into body frame
+	Vector3f down_in_bf = -_imu_sample_delayed.delta_vel;
+	down_in_bf.normalize();
+
+	// Calculate earth frame North axis unit vector rotated into body frame, orthogonal to 'down_in_bf'
+	// * operator is overloaded to provide a dot product
+	const Vector3f i_vec_bf(1.0f,0.0f,0.0f);
+	Vector3f north_in_bf = i_vec_bf - down_in_bf * (i_vec_bf * down_in_bf);
+	north_in_bf.normalize();
+
+	// Calculate earth frame East axis unit vector rotated into body frame, orthogonal to 'down_in_bf' and 'north_in_bf'
+	// % operator is overloaded to provide a cross product
+	const Vector3f east_in_bf = down_in_bf % north_in_bf;
+
+	// Each column in a rotation matrix from earth frame to body frame represents the projection of the
+	// corresponding earth frame unit vector rotated into the body frame, eg 'north_in_bf' would be the first column.
+	// We need the rotation matrix from body frame to earth frame so the earth frame unit vectors rotated into body
+	// frame are copied into corresponding rows instead.
+	Dcmf R;
+	R.setRow(0, north_in_bf);
+	R.setRow(1, east_in_bf);
+	R.setRow(2, down_in_bf);
+
+	// Convert to quaternion
+	for (uint8_t model_index = 0; model_index < N_MODELS_EKFGSF; model_index++) {
+		_ahrs_ekf_gsf[model_index].quat = R;
+		_ahrs_ekf_gsf[model_index].quat.normalize();
+		_ahrs_ekf_gsf[model_index].quat_initialised = true;
+	}
+}
+
+void Ekf::alignQuatYawEKFGSF()
+{
+	// Align yaw angle for each model
+	for (uint8_t model_index = 0; model_index < N_MODELS_EKFGSF; model_index++) {
+		if (fabsf(_ahrs_ekf_gsf[model_index].R(2, 0)) < fabsf(_ahrs_ekf_gsf[model_index].R(2, 1))) {
+			// get the roll, pitch, yaw estimates from the rotation matrix using a  321 Tait-Bryan rotation sequence
+			Eulerf euler_init(_ahrs_ekf_gsf[model_index].quat);
+
+			// set the yaw angle
+			euler_init(2) = wrap_pi(_ekf_gsf[model_index].X[2]);
+
+			// update the quaternions and rotation matrix
+			_ahrs_ekf_gsf[model_index].quat = Quatf(euler_init);
+			_ahrs_ekf_gsf[model_index].R = Dcmf(_ahrs_ekf_gsf[model_index].quat);
+
+		} else {
+			// Calculate the 312 Tait-Bryan rotation sequence that rotates from earth to body frame
+			Vector3f rot312;
+			rot312(0) = wrap_pi(_ekf_gsf[model_index].X[2]); // first rotation (yaw) taken from EKF model state
+			rot312(1) = asinf(_ahrs_ekf_gsf[model_index].R(2, 1)); // second rotation (roll)
+			rot312(2) = atan2f(-_ahrs_ekf_gsf[model_index].R(2, 0), _ahrs_ekf_gsf[model_index].R(2, 2));  // third rotation (pitch)
+
+			// Calculate the body to earth frame rotation matrix
+			_ahrs_ekf_gsf[model_index].R = taitBryan312ToRotMat(rot312);
+
+			// update the quaternion
+			_ahrs_ekf_gsf[model_index].quat = Quatf(_ahrs_ekf_gsf[model_index].R);
+			_ahrs_ekf_gsf[model_index].quat.normalize();
+		}
+		_ahrs_ekf_gsf[model_index].quat_initialised = true;
+	}
+}
+
+// predict states and covariance for specified model index
+void Ekf::statePredictEKFGSF(const uint8_t model_index)
+{
+	// generate an attitude reference using IMU data
+	quatPredictEKFGSF(model_index);
+
+	// we don't start running the EKF part of the algorithm until there are regular velocity observations
+	if (!_ekf_gsf_vel_fuse_started) {
+		return;
+	}
+
+	// Calculate the yaw state using a projection onto the horizontal that avoids gimbal lock
+	if (fabsf(_ahrs_ekf_gsf[model_index].R(2, 0)) < fabsf(_ahrs_ekf_gsf[model_index].R(2, 1))) {
+		// use 321 Tait-Bryan rotation to define yaw state
+		_ekf_gsf[model_index].X[2] = atan2(_ahrs_ekf_gsf[model_index].R(1, 0), _ahrs_ekf_gsf[model_index].R(0, 0));
+		_ekf_gsf[model_index].use_312 = false;
+	} else {
+		// use 312 Tait-Bryan rotation to define yaw state
+		_ekf_gsf[model_index].X[2] = atan2(-_ahrs_ekf_gsf[model_index].R(0, 1), _ahrs_ekf_gsf[model_index].R(1, 1)); // first rotation (yaw)
+		_ekf_gsf[model_index].use_312 = true;
+	}
+
+	// calculate delta velocity in a horizontal front-right frame
+	const Vector3f del_vel_NED = _ahrs_ekf_gsf[model_index].R * _imu_sample_delayed.delta_vel;
+	const float dvx =   del_vel_NED(0) * cosf(_ekf_gsf[model_index].X[2]) + del_vel_NED(1) * sinf(_ekf_gsf[model_index].X[2]);
+	const float dvy = - del_vel_NED(0) * sinf(_ekf_gsf[model_index].X[2]) + del_vel_NED(1) * cosf(_ekf_gsf[model_index].X[2]);
+
+	// sum delta velocities in earth frame:
+	_ekf_gsf[model_index].X[0] += del_vel_NED(0);
+	_ekf_gsf[model_index].X[1] += del_vel_NED(1);
+
+	// predict covariance - autocode from https://github.com/priseborough/3_state_filter/blob/flightLogReplay-wip/calcPupdate.txt
+
+	// Local short variable name copies required for readability
+	// Compiler might be smart enough to optimise these out
+	const float P00 = _ekf_gsf[model_index].P[0][0];
+	const float P01 = _ekf_gsf[model_index].P[0][1];
+	const float P02 = _ekf_gsf[model_index].P[0][2];
+	const float P10 = _ekf_gsf[model_index].P[1][0];
+	const float P11 = _ekf_gsf[model_index].P[1][1];
+	const float P12 = _ekf_gsf[model_index].P[1][2];
+	const float P20 = _ekf_gsf[model_index].P[2][0];
+	const float P21 = _ekf_gsf[model_index].P[2][1];
+	const float P22 = _ekf_gsf[model_index].P[2][2];
+
+	// Use fixed values for delta velocity and delta angle process noise variances
+	const float dvxVar = sq(_params.EKFGSF_accel_noise * _imu_sample_delayed.delta_vel_dt); // variance of forward delta velocity - (m/s)^2
+	const float dvyVar = dvxVar; // variance of right delta velocity - (m/s)^2
+	const float dazVar = sq(_params.EKFGSF_gyro_noise * _imu_sample_delayed.delta_ang_dt); // variance of yaw delta angle - rad^2
+
+	const float t2 = sinf(_ekf_gsf[model_index].X[2]);
+	const float t3 = cosf(_ekf_gsf[model_index].X[2]);
+	const float t4 = dvy*t3;
+	const float t5 = dvx*t2;
+	const float t6 = t4+t5;
+	const float t8 = P22*t6;
+	const float t7 = P02-t8;
+	const float t9 = dvx*t3;
+	const float t11 = dvy*t2;
+	const float t10 = t9-t11;
+	const float t12 = dvxVar*t2*t3;
+	const float t13 = t2*t2;
+	const float t14 = t3*t3;
+	const float t15 = P22*t10;
+	const float t16 = P12+t15;
+
+	const float min_var = 1e-6f;
+	_ekf_gsf[model_index].P[0][0] = fmaxf(P00-P20*t6+dvxVar*t14+dvyVar*t13-t6*t7 , min_var);
+	_ekf_gsf[model_index].P[0][1] = P01+t12-P21*t6+t7*t10-dvyVar*t2*t3;
+	_ekf_gsf[model_index].P[0][2] = t7;
+	_ekf_gsf[model_index].P[1][0] = P10+t12+P20*t10-t6*t16-dvyVar*t2*t3;
+	_ekf_gsf[model_index].P[1][1] = fmaxf(P11+P21*t10+dvxVar*t13+dvyVar*t14+t10*t16 , min_var);
+	_ekf_gsf[model_index].P[1][2] = t16;
+	_ekf_gsf[model_index].P[2][0] = P20-t8;
+	_ekf_gsf[model_index].P[2][1] = P21+t15;
+	_ekf_gsf[model_index].P[2][2] = fmaxf(P22+dazVar , min_var);
+
+	// force symmetry
+	makeCovSymEKFGSF(model_index);
+}
+
+// Update EKF states and covariance for specified model index using velocity measurement
+void Ekf::stateUpdateEKFGSF(const uint8_t model_index)
+{
+	// set observation variance from accuracy estimate supplied by GPS and apply a sanity check minimum
+	const float velObsVar = sq(fmaxf(_gps_sample_delayed.sacc, _params.gps_vel_noise));
+
+	// calculate velocity observation innovations
+	_ekf_gsf[model_index].innov[0] = _ekf_gsf[model_index].X[0] - _gps_sample_delayed.vel(0);
+	_ekf_gsf[model_index].innov[1] = _ekf_gsf[model_index].X[1] - _gps_sample_delayed.vel(1);
+
+	// copy covariance matrix to temporary variables
+	const float P00 = _ekf_gsf[model_index].P[0][0];
+	const float P01 = _ekf_gsf[model_index].P[0][1];
+	const float P02 = _ekf_gsf[model_index].P[0][2];
+	const float P10 = _ekf_gsf[model_index].P[1][0];
+	const float P11 = _ekf_gsf[model_index].P[1][1];
+	const float P12 = _ekf_gsf[model_index].P[1][2];
+	const float P20 = _ekf_gsf[model_index].P[2][0];
+	const float P21 = _ekf_gsf[model_index].P[2][1];
+	const float P22 = _ekf_gsf[model_index].P[2][2];
+
+	// calculate innovation variance
+	_ekf_gsf[model_index].S[0][0] = P00 + velObsVar;
+	_ekf_gsf[model_index].S[1][1] = P11 + velObsVar;
+	_ekf_gsf[model_index].S[0][1] = P01;
+	_ekf_gsf[model_index].S[1][0] = P10;
+
+	// Perform a chi-square innovation consistency test and calculate a compression scale factor that limits the magnitude of innovations to 5-sigma
+	float S_det_inv = (_ekf_gsf[model_index].S[0][0]*_ekf_gsf[model_index].S[1][1] - _ekf_gsf[model_index].S[0][1]*_ekf_gsf[model_index].S[1][0]);
+	float innov_comp_scale_factor = 1.0f;
+	if (fabsf(S_det_inv) > 1E-6f) {
+		// Calculate elements for innovation covariance inverse matrix assuming symmetry
+		S_det_inv = 1.0f / S_det_inv;
+		const float S_inv_NN = _ekf_gsf[model_index].S[1][1] * S_det_inv;
+		const float S_inv_EE = _ekf_gsf[model_index].S[0][0] * S_det_inv;
+		const float S_inv_NE = _ekf_gsf[model_index].S[0][1] * S_det_inv;
+
+		// The following expression was derived symbolically from test ratio = transpose(innovation) * inverse(innovation variance) * innovation = [1x2] * [2,2] * [2,1] = [1,1]
+		const float test_ratio = _ekf_gsf[model_index].innov[0]*(_ekf_gsf[model_index].innov[0]*S_inv_NN + _ekf_gsf[model_index].innov[1]*S_inv_NE) + _ekf_gsf[model_index].innov[1]*(_ekf_gsf[model_index].innov[0]*S_inv_NE + _ekf_gsf[model_index].innov[1]*S_inv_EE);
+
+		// If the test ratio is greater than 25 (5 Sigma) then reduce the length of the innovation vector to clip it at 5-Sigma
+		// This protects from large measurement spikes
+		if (test_ratio > 25.0f) {
+			innov_comp_scale_factor = sqrtf(25.0f / test_ratio);
+		}
+	} else {
+		// skip this fusion step because calculation is badly conditioned
+		return;
+	}
+
+	// calculate Kalman gain K  and covariance matrix P
+	// autocode from https://github.com/priseborough/3_state_filter/blob/flightLogReplay-wip/calcK.txt
+	// and https://github.com/priseborough/3_state_filter/blob/flightLogReplay-wip/calcPmat.txt
+	const float t2 = P00*velObsVar;
+ 	const float t3 = P11*velObsVar;
+	const float t4 = velObsVar*velObsVar;
+	const float t5 = P00*P11;
+	const float t9 = P01*P10;
+	const float t6 = t2+t3+t4+t5-t9;
+	float t7;
+	if (fabsf(t6) > 1e-6f) {
+		t7 = 1.0f/t6;
+	} else {
+		// skip this fusion step
+		return;
+	}
+	const float t8 = P11+velObsVar;
+	const float t10 = P00+velObsVar;
+	float K[3][2];
+
+ 	K[0][0] = -P01*P10*t7+P00*t7*t8;
+	K[0][1] = -P00*P01*t7+P01*t7*t10;
+	K[1][0] = -P10*P11*t7+P10*t7*t8;
+	K[1][1] = -P01*P10*t7+P11*t7*t10;
+	K[2][0] = -P10*P21*t7+P20*t7*t8;
+	K[2][1] = -P01*P20*t7+P21*t7*t10;
+
+	const float t11 = P00*P01*t7;
+	const float t15 = P01*t7*t10;
+	const float t12 = t11-t15;
+	const float t13 = P01*P10*t7;
+	const float t16 = P00*t7*t8;
+	const float t14 = t13-t16;
+	const float t17 = t8*t12;
+	const float t18 = P01*t14;
+	const float t19 = t17+t18;
+	const float t20 = t10*t14;
+	const float t21 = P10*t12;
+	const float t22 = t20+t21;
+	const float t27 = P11*t7*t10;
+	const float t23 = t13-t27;
+	const float t24 = P10*P11*t7;
+	const float t26 = P10*t7*t8;
+	const float t25 = t24-t26;
+	const float t28 = t8*t23;
+	const float t29 = P01*t25;
+	const float t30 = t28+t29;
+	const float t31 = t10*t25;
+	const float t32 = P10*t23;
+	const float t33 = t31+t32;
+	const float t34 = P01*P20*t7;
+	const float t38 = P21*t7*t10;
+	const float t35 = t34-t38;
+	const float t36 = P10*P21*t7;
+	const float t39 = P20*t7*t8;
+	const float t37 = t36-t39;
+	const float t40 = t8*t35;
+	const float t41 = P01*t37;
+	const float t42 = t40+t41;
+	const float t43 = t10*t37;
+	const float t44 = P10*t35;
+	const float t45 = t43+t44;
+
+	const float min_var = 1e-6f;
+	_ekf_gsf[model_index].P[0][0] = fmaxf(P00-t12*t19-t14*t22 , min_var);
+	_ekf_gsf[model_index].P[0][1] = P01-t19*t23-t22*t25;
+	_ekf_gsf[model_index].P[0][2] = P02-t19*t35-t22*t37;
+	_ekf_gsf[model_index].P[1][0] = P10-t12*t30-t14*t33;
+	_ekf_gsf[model_index].P[1][1] = fmaxf(P11-t23*t30-t25*t33 , min_var);
+	_ekf_gsf[model_index].P[1][2] = P12-t30*t35-t33*t37;
+	_ekf_gsf[model_index].P[2][0] = P20-t12*t42-t14*t45;
+	_ekf_gsf[model_index].P[2][1] = P21-t23*t42-t25*t45;
+	_ekf_gsf[model_index].P[2][2] = fmaxf(P22-t35*t42-t37*t45 , min_var);
+
+	// force symmetry
+	makeCovSymEKFGSF(model_index);
+
+	for (uint8_t obs_index = 0; obs_index < 2; obs_index++) {
+		// apply the state corrections including the compression scale factor
+		for (unsigned row = 0; row < 3; row++) {
+			_ekf_gsf[model_index].X[row] -= K[row][obs_index] * _ekf_gsf[model_index].innov[obs_index] * innov_comp_scale_factor;
+		}
+	}
+
+	// Apply yaw correction to AHRS quaternion sing the same rotation sequence as was used by the prediction step
+	// TODO - This is an  expensive process due to the number of trig operations so a method of doing it more efficiently,
+	// eg storing rotation matrix from the state prediction that doesn't include the yaw rotation should be investigated.
+	// This matrix could then be multiplied with the yaw rotation to obtain the updated R matrix from which the updated
+	// quaternion is calculated
+	if (_ekf_gsf[model_index].use_312) {
+		// Calculate the 312 Tait-Bryan rotation sequence that rotates from earth to body frame
+		// We use a 312 sequence as an alternate when there is more pitch tilt than roll tilt
+		// to avoid gimbal lock
+		Vector3f rot312;
+		rot312(0) = _ekf_gsf[model_index].X[2]; // first rotation is about Z and is taken from 3-state EKF
+		rot312(1) = asinf(_ahrs_ekf_gsf[model_index].R(2, 1)); // second rotation is about X and is taken from AHRS
+		rot312(2) = atan2f(-_ahrs_ekf_gsf[model_index].R(2, 0), _ahrs_ekf_gsf[model_index].R(2, 2));  // third rotation is about Y and is taken from AHRS
+
+		// Calculate the body to earth frame rotation matrix
+		const Dcmf R = taitBryan312ToRotMat(rot312);
+
+		// update the quaternion used by the AHRS prediction algorithm
+		_ahrs_ekf_gsf[model_index].quat = Quatf(R);
+
+	} else {
+		// using a 321 Tait-Bryan rotation to define yaw state
+		// take roll pitch yaw from AHRS prediction
+		Eulerf euler321(_ahrs_ekf_gsf[model_index].R);
+
+		// replace the yaw angle using the EKF state estimate
+		euler321(2) = _ekf_gsf[model_index].X[2];
+
+		// update the quaternion used by the AHRS prediction algorithm
+		_ahrs_ekf_gsf[model_index].quat = Quatf(euler321);
+
+	}
+}
+
+void Ekf::initialiseEKFGSF()
+{
+	memset(&_ekf_gsf, 0, sizeof(_ekf_gsf));
+	const float yaw_increment = 2.0f * M_PI_F / (float)N_MODELS_EKFGSF;
+	for (uint8_t model_index = 0; model_index < N_MODELS_EKFGSF; model_index++) {
+		// evenly space initial yaw estimates in the region between +-Pi
+		_ekf_gsf[model_index].X[2] = -M_PI_F + (0.5f * yaw_increment) + ((float)model_index * yaw_increment);
+
+		// All filter models start with the same weight
+		_ekf_gsf[model_index].W = 1.0f / (float)N_MODELS_EKFGSF;
+
+		// Assume velocity within 0.5 m/s of zero at alignment
+		if (_control_status.flags.gps) {
+			_ekf_gsf[model_index].X[0] = _gps_sample_delayed.vel(0);
+			_ekf_gsf[model_index].X[1] = _gps_sample_delayed.vel(1);
+			_ekf_gsf[model_index].P[0][0] = sq(_gps_sample_delayed.sacc);
+			_ekf_gsf[model_index].P[1][1] = _ekf_gsf[model_index].P[0][0];
+		} else {
+			_ekf_gsf[model_index].P[0][0] = sq(0.5f);
+			_ekf_gsf[model_index].P[1][1] = sq(0.5f);
+		}
+
+		// use half yaw interval for yaw uncertainty
+		_ekf_gsf[model_index].P[2][2] = sq(0.5f * yaw_increment);
+	}
+}
+
+void Ekf::runEKFGSF()
+{
+	// Iniitialise states first time
+	_ahrs_accel = _imu_sample_delayed.delta_vel / fmaxf(_imu_sample_delayed.delta_vel_dt, FILTER_UPDATE_PERIOD_S / 4);
+	if (!_ahrs_ekf_gsf_tilt_aligned) {
+		// check for excessive acceleration.
+		const float accel_norm_sq = _ahrs_accel.norm_squared();
+		const float upper_accel_limit = CONSTANTS_ONE_G * 1.1f;
+		const float lower_accel_limit = CONSTANTS_ONE_G * 0.9f;
+		const bool ok_to_align = ((accel_norm_sq > lower_accel_limit * lower_accel_limit &&
+			  accel_norm_sq < upper_accel_limit * upper_accel_limit));
+		if (ok_to_align) {
+			initialiseEKFGSF();
+			alignQuatEKFGSF();
+			_ahrs_ekf_gsf_tilt_aligned = true;
+		}
+		return;
+	}
+
+	// calculate common values used by the AHRS prediction models
+	_ahrs_accel_norm = _ahrs_accel.norm();
+	_ahrs_turn_comp_enabled = _control_status.flags.fixed_wing && _params.EKFGSF_tas_default > FLT_EPSILON;
+	if (_ahrs_accel_norm > CONSTANTS_ONE_G) {
+		if (_ahrs_turn_comp_enabled && _ahrs_accel_norm <= 2.0f * CONSTANTS_ONE_G) {
+			_ahrs_accel_fusion_gain = _params.EKFGSF_tilt_gain * sq(1.0f - (_ahrs_accel_norm - CONSTANTS_ONE_G)/CONSTANTS_ONE_G);
+		} else if (_ahrs_accel_norm <= 1.5f * CONSTANTS_ONE_G) {
+			_ahrs_accel_fusion_gain = _params.EKFGSF_tilt_gain * sq(1.0f - 2.0f * (_ahrs_accel_norm - CONSTANTS_ONE_G)/CONSTANTS_ONE_G);
+		}
+	} else if (_ahrs_accel_norm > 0.5f * CONSTANTS_ONE_G) {
+		_ahrs_accel_fusion_gain = _params.EKFGSF_tilt_gain * sq(1.0f + 2.0f * (_ahrs_accel_norm - CONSTANTS_ONE_G)/CONSTANTS_ONE_G);
+	}
+
+	// AHRS prediction cycle for each model
+	// This always runs
+	for (uint8_t model_index = 0; model_index < N_MODELS_EKFGSF; model_index ++) {
+		statePredictEKFGSF(model_index);
+	}
+
+	// The 3-state EKF models only run when flying to avoid corrupted estimates due to operator handling and GPS interference
+	if (_control_status.flags.gps && _gps_data_ready && _control_status.flags.in_air) {
+		if (!_ekf_gsf_vel_fuse_started) {
+			for (uint8_t model_index = 0; model_index < N_MODELS_EKFGSF; model_index ++) {
+				// use the first measurement to set the velocities and corresponding covariances
+				_ekf_gsf[model_index].X[0] = _gps_sample_delayed.vel(0);
+				_ekf_gsf[model_index].X[1] = _gps_sample_delayed.vel(1);
+				_ekf_gsf[model_index].P[0][0] = sq(_gps_sample_delayed.sacc);
+				_ekf_gsf[model_index].P[1][1] = _ekf_gsf[model_index].P[0][0];
+				alignQuatYawEKFGSF();
+			}
+			_ekf_gsf_vel_fuse_started = true;
+		} else {
+			float total_w = 0.0f;
+			float newWeight[N_MODELS_EKFGSF];
+			for (uint8_t model_index = 0; model_index < N_MODELS_EKFGSF; model_index ++) {
+				// subsequent measurements are fused as direct state observations
+				stateUpdateEKFGSF(model_index);
+
+				// calculate weighting for each model assuming a normal distribution
+				newWeight[model_index]= fmaxf(gaussianDensityEKFGSF(model_index) * _ekf_gsf[model_index].W, 0.0f);
+				total_w += newWeight[model_index];
+			}
+
+			// normalise the weighting function
+			if (_ekf_gsf_vel_fuse_started && total_w > 0.0f) {
+				float total_w_inv = 1.0f / total_w;
+				for (uint8_t model_index = 0; model_index < N_MODELS_EKFGSF; model_index ++) {
+					_ekf_gsf[model_index].W  = newWeight[model_index] * total_w_inv;
+				}
+			}
+
+			// enforce a minimum weighting value
+			float correction_sum = 0.0f; // amount the sum of weights has been increased by application of the limit
+			bool change_mask[N_MODELS_EKFGSF] = {}; // true when the weighting for that model has been increased
+			float unmodified_weights_sum = 0.0f; // sum of unmodified weights
+			for (uint8_t model_index = 0; model_index < N_MODELS_EKFGSF; model_index ++) {
+				if (_ekf_gsf[model_index].W < _params.EKFGSF_weight_min) {
+					correction_sum += _params.EKFGSF_weight_min - _ekf_gsf[model_index].W;
+					_ekf_gsf[model_index].W = _params.EKFGSF_weight_min;
+					change_mask[model_index] = true;
+				} else {
+					unmodified_weights_sum += _ekf_gsf[model_index].W;
+				}
+			}
+
+			// rescale the unmodified weights to make the total sum unity
+			const float scale_factor = (unmodified_weights_sum - correction_sum - _params.EKFGSF_weight_min) / (unmodified_weights_sum - _params.EKFGSF_weight_min);
+			for (uint8_t model_index = 0; model_index < N_MODELS_EKFGSF; model_index ++) {
+				if (!change_mask[model_index]) {
+					_ekf_gsf[model_index].W = _params.EKFGSF_weight_min + scale_factor * (_ekf_gsf[model_index].W - _params.EKFGSF_weight_min);
+				}
+			}
+		}
+	} else if (_ekf_gsf_vel_fuse_started && !_control_status.flags.in_air) {
+		// reset EKF states and wait to fly again
+		initialiseEKFGSF();
+		_ekf_gsf_vel_fuse_started = false;
+	}
+
+	// calculate a composite state vector as a weighted average of the states for each model
+	memset(&X_GSF, 0, sizeof(X_GSF));
+	for (uint8_t model_index = 0; model_index < N_MODELS_EKFGSF; model_index ++) {
+		for (uint8_t state_index = 0; state_index < 3; state_index++) {
+			X_GSF[state_index] += _ekf_gsf[model_index].X[state_index] * _ekf_gsf[model_index].W;
+		}
+	}
+	/*
+	// calculate a composite covariance matrix from a weighted average of the covariance for each model
+	// models with larger innovations are weighted less
+	memset(&P_GSF, 0, sizeof(P_GSF));
+	for (uint8_t model_index = 0; model_index < N_MODELS_EKFGSF; model_index ++) {
+		float Xdelta[3];
+		for (uint8_t row = 0; row < 3; row++) {
+			Xdelta[row] = _ekf_gsf[model_index].X[row] - X_GSF[row];
+		}
+		for (uint8_t row = 0; row < 3; row++) {
+			for (uint8_t col = 0; col < 3; col++) {
+				P_GSF[row][col] +=  _ekf_gsf[model_index].W * (_ekf_gsf[model_index].P[row][col] + Xdelta[row] * Xdelta[col]);
+			}
+		}
+	}
+	*/
+}
+
+float Ekf::gaussianDensityEKFGSF(const uint8_t model_index) const
+{
+	const float t2 = _ekf_gsf[model_index].S[0][0] * _ekf_gsf[model_index].S[1][1];
+	const float t5 = _ekf_gsf[model_index].S[0][1] * _ekf_gsf[model_index].S[1][0];
+	const float t3 = t2 - t5; // determinant
+	float t4; // determinant inverse
+	if (fabsf(t3) > 1e-6f) {
+		t4 = 1.0f/t3;
+	} else {
+		t4 = 1.0f/t2;
+	}
+
+	// inv(S)
+	float invMat[2][2];
+	invMat[0][0] =   t4 * _ekf_gsf[model_index].S[1][1];
+	invMat[1][1] =   t4 * _ekf_gsf[model_index].S[0][0];
+	invMat[0][1] = - t4 * _ekf_gsf[model_index].S[0][1];
+	invMat[1][0] = - t4 * _ekf_gsf[model_index].S[1][0];
+
+ 	// inv(S) * innovation
+	float tempVec[2];
+	tempVec[0] = invMat[0][0] * _ekf_gsf[model_index].innov[0] + invMat[0][1] * _ekf_gsf[model_index].innov[1];
+	tempVec[1] = invMat[1][0] * _ekf_gsf[model_index].innov[0] + invMat[1][1] * _ekf_gsf[model_index].innov[1];
+
+	// transpose(innovation) * inv(S) * innovation
+	float normDist = tempVec[0] * _ekf_gsf[model_index].innov[0] + tempVec[1] * _ekf_gsf[model_index].innov[1];
+
+	normDist = expf(-0.5f * normDist);
+	normDist *= sqrtf(t4)/ M_TWOPI_F;
+	return normDist;
+}
+
+void Ekf::getDataEKFGSF(float *yaw_composite, float yaw[N_MODELS_EKFGSF], float innov_VN[N_MODELS_EKFGSF], float innov_VE[N_MODELS_EKFGSF], float weight[N_MODELS_EKFGSF])
+{
+	memcpy(yaw_composite, &X_GSF[2], sizeof(X_GSF[2]));
+	for (uint8_t model_index = 0; model_index < N_MODELS_EKFGSF; model_index++) {
+		yaw[model_index] = _ekf_gsf[model_index].X[2];
+		innov_VN[model_index] = _ekf_gsf[model_index].innov[0];
+		innov_VE[model_index] = _ekf_gsf[model_index].innov[1];
+		weight[model_index] = _ekf_gsf[model_index].W;
+	}
+}
+
+void Ekf::makeCovSymEKFGSF(const uint8_t model_index)
+{
+	float P01 = 0.5f * (_ekf_gsf[model_index].P[0][1] + _ekf_gsf[model_index].P[1][0]);
+	float P02 = 0.5f * (_ekf_gsf[model_index].P[0][2] + _ekf_gsf[model_index].P[2][0]);
+	float P12 = 0.5f * (_ekf_gsf[model_index].P[1][2] + _ekf_gsf[model_index].P[2][1]);
+	_ekf_gsf[model_index].P[0][1] = _ekf_gsf[model_index].P[1][0] = P01;
+	_ekf_gsf[model_index].P[0][2] = _ekf_gsf[model_index].P[2][0] = P02;
+	_ekf_gsf[model_index].P[1][2] = _ekf_gsf[model_index].P[2][1] = P12;
+}
+
+// Reset heading and magnetic field states
+void Ekf::resetYawToEKFGSF()
+{
+	// save a copy of the quaternion state for later use in calculating the amount of reset change
+	Quatf quat_before_reset = _state.quat_nominal;
+	Quatf quat_after_reset = _state.quat_nominal;
+
+	// update transformation matrix from body to world frame using the current estimate
+	_R_to_earth = Dcmf(_state.quat_nominal);
+
+	// calculate the initial quaternion
+	// determine if a 321 or 312 Euler sequence is best
+	if (fabsf(_R_to_earth(2, 0)) < fabsf(_R_to_earth(2, 1))) {
+		// use a 321 sequence
+
+		Eulerf euler321(_state.quat_nominal);
+		euler321(2) = X_GSF[2];
+		quat_after_reset = Quatf(euler321);
+
+	} else {
+		// Calculate the 312 Tait-Bryan rotation sequence that rotates from earth to body frame
+		// We use a 312 sequence as an alternate when there is more pitch tilt than roll tilt
+		// to avoid gimbal lock
+		Vector3f rot312;
+		rot312(0) = X_GSF[2]; // first rotation about Z is taken from EKF-GSF
+		rot312(1) = asinf(_R_to_earth(2, 1)); // second rotation about X is taken from main EKF
+		rot312(2) = atan2f(-_R_to_earth(2, 0), _R_to_earth(2, 2));  // third rotation about Y is taken from main EKF
+
+		// Calculate the body to earth frame rotation matrix
+		const Dcmf R = taitBryan312ToRotMat(rot312);
+
+		// calculate initial quaternion states for the main EKF
+		// we don't change the output attitude to avoid jumps
+		quat_after_reset = Quatf(R);
+	}
+
+	// record the time for the magnetic field alignment event
+	_flt_mag_align_start_time = _imu_sample_delayed.time_us;
+
+	// calculate the amount that the quaternion has changed by
+	Quatf q_error =  quat_after_reset * quat_before_reset.inversed();
+	q_error.normalize();
+
+	// update quaternion states
+	_state.quat_nominal = quat_after_reset;
+	uncorrelateQuatStates();
+
+	// record the state change
+	_state_reset_status.quat_change = q_error;
+
+	// update transformation matrix from body to world frame using the current estimate
+	_R_to_earth = Dcmf(_state.quat_nominal);
+
+	// reset the rotation from the EV to EKF frame of reference if it is being used
+	if ((_params.fusion_mode & MASK_ROTATE_EV) && !_control_status.flags.ev_yaw) {
+		calcExtVisRotMat();
+	}
+
+	// update the yaw angle variance using half the nominal yaw separation between models
+	increaseQuatYawErrVariance(sq(fmaxf(M_PI_F / (float)N_MODELS_EKFGSF, 1.0e-2f)));
+
+	// add the reset amount to the output observer buffered data
+	for (uint8_t i = 0; i < _output_buffer.get_length(); i++) {
+		_output_buffer[i].quat_nominal = _state_reset_status.quat_change * _output_buffer[i].quat_nominal;
+	}
+
+	// apply the change in attitude quaternion to our newest quaternion estimate
+	// which was already taken out from the output buffer
+	_output_new.quat_nominal = _state_reset_status.quat_change * _output_new.quat_nominal;
+
+	// capture the reset event
+	_state_reset_status.quat_counter++;
+
+	// reset velocity and position states to GPS - if yaw is fixed then the filter should start to operate correctly
+	resetVelocity();
+	resetPosition();
+
+	ECL_INFO_TIMESTAMPED("EKF emergency yaw reset");
+
+	// stop using the magnetometer in the main EKF otherwise it's fusion could drag the yaw around
+	// and cause another navigation failure
+	_control_status.flags.mag_fault = true;
+	ECL_WARN_TIMESTAMPED("EKF stopping magnetometer use");
+
+}
+
+// gets simple AHRS derived data which will be logged and used for algorithm development work
+// returns false when no data available
+bool Ekf::get_algo_test_data(float delAng[3],
+		float *delAngDt,
+		float delVel[3],
+		float *delVelDt,
+		float vel[3],
+		float *velErr,
+		bool *fuse_vel,
+		float quat[4])
+{
+	const bool vel_updated = _control_status.flags.gps && _gps_data_ready;
+
+	delAng[0] = _imu_sample_delayed.delta_ang(0);
+	delAng[1] = _imu_sample_delayed.delta_ang(1);
+	delAng[2] = _imu_sample_delayed.delta_ang(2);
+
+	memcpy(delAngDt, &_imu_sample_delayed.delta_vel_dt, sizeof(float));
+
+	delVel[0] = _imu_sample_delayed.delta_vel(0);
+	delVel[1] = _imu_sample_delayed.delta_vel(1);
+	delVel[2] = _imu_sample_delayed.delta_vel(2);
+
+	memcpy(delVelDt, &_imu_sample_delayed.delta_vel_dt, sizeof(float));
+
+	vel[0] = _gps_sample_delayed.vel(0);
+	vel[1] = _gps_sample_delayed.vel(1);
+	vel[2] = _gps_sample_delayed.vel(2);
+
+	memcpy(velErr, &_gps_sample_delayed.sacc, sizeof(float));
+
+	memcpy(fuse_vel, &vel_updated, sizeof(bool));
+
+	quat[0] =  _state.quat_nominal(0);
+	quat[1] =  _state.quat_nominal(1);
+	quat[2] =  _state.quat_nominal(2);
+	quat[3] =  _state.quat_nominal(3);
+
+	return _filter_initialised;
+}
+
+// request the EKF reset the yaw to the estimate from the internal EKF-GSF filter
+// argument should be incremented only when a new reset is required
+void Ekf::request_ekfgsf_yaw_reset(uint8_t counter)
+{
+	if (counter > _yaw_extreset_counter) {
+		_yaw_extreset_counter = counter;
+		_do_emergency_yaw_reset = true;
+	}
+}
+
+// converts Tait-Bryan 312 sequence of rotations from frame 1 to frame 2
+// to the corresponding rotation matrix that rotates from frame 2 to frame 1
+// rot312(0) - First rotation is a RH rotation about the Z axis (rad)
+// rot312(1) - Second rotation is a RH rotation about the X axis (rad)
+// rot312(2) - Third rotation is a RH rotation about the Y axis (rad)
+// See http://www.atacolorado.com/eulersequences.doc
+Dcmf Ekf::taitBryan312ToRotMat(Vector3f &rot312)
+{
+		// Calculate the frame2 to frame 1 rotation matrix from a 312 rotation sequence
+		const float c2 = cosf(rot312(2));
+		const float s2 = sinf(rot312(2));
+		const float s1 = sinf(rot312(1));
+		const float c1 = cosf(rot312(1));
+		const float s0 = sinf(rot312(0));
+		const float c0 = cosf(rot312(0));
+
+		Dcmf R;
+		R(0, 0) = c0 * c2 - s0 * s1 * s2;
+		R(1, 1) = c0 * c1;
+		R(2, 2) = c2 * c1;
+		R(0, 1) = -c1 * s0;
+		R(0, 2) = s2 * c0 + c2 * s1 * s0;
+		R(1, 0) = c2 * s0 + s2 * s1 * c0;
+		R(1, 2) = s0 * s2 - s1 * c0 * c2;
+		R(2, 0) = -s2 * c1;
+		R(2, 1) = s1;
+
+		return R;
+}

--- a/EKF/EKFGSF_yaw_estimator.cpp
+++ b/EKF/EKFGSF_yaw_estimator.cpp
@@ -427,10 +427,12 @@ void Ekf::stateUpdateEKFGSF(const uint8_t model_index)
 
 	} else {
 		// using a 321 Tait-Bryan rotation to define yaw state
-		// take roll pitch yaw from AHRS prediction
-		Eulerf euler321(_ahrs_ekf_gsf[model_index].R);
+		// take roll and pitch from AHRS prediction
+		Eulerf euler321;
+		euler321(0) = atan2f(_ahrs_ekf_gsf[model_index].R(2,1), _ahrs_ekf_gsf[model_index].R(2,2));
+		euler321(1) = -asinf(_ahrs_ekf_gsf[model_index].R(2,0));
 
-		// replace the yaw angle using the EKF state estimate
+		// take yaw angle from the 3-state EKF updated state estimate
 		euler321(2) = _ekf_gsf[model_index].X[2];
 
 		// update the rotation matrix used by the AHRS prediction algorithm
@@ -630,9 +632,7 @@ float Ekf::gaussianDensityEKFGSF(const uint8_t model_index) const
 	// transpose(innovation) * inv(S) * innovation
 	float normDist = tempVec[0] * _ekf_gsf[model_index].innov[0] + tempVec[1] * _ekf_gsf[model_index].innov[1];
 
-	normDist = expf(-0.5f * normDist);
-	normDist *= sqrtf(t4)/ M_TWOPI_F;
-	return normDist;
+	return M_TWOPI_INV * sqrtf(t4) * expf(-0.5f * normDist);
 }
 
 bool Ekf::getDataEKFGSF(float *yaw_composite, float *yaw_variance, float yaw[N_MODELS_EKFGSF], float innov_VN[N_MODELS_EKFGSF], float innov_VE[N_MODELS_EKFGSF], float weight[N_MODELS_EKFGSF])

--- a/EKF/EKFGSF_yaw_estimator.cpp
+++ b/EKF/EKFGSF_yaw_estimator.cpp
@@ -583,7 +583,7 @@ void Ekf::runEKFGSF()
 	// models with larger innovations are weighted less
 	_ekf_gsf_yaw_variance = 0.0f;
 	for (uint8_t model_index = 0; model_index < N_MODELS_EKFGSF; model_index ++) {
-		float yaw_delta = _ekf_gsf[model_index].X[2] - X_GSF[2];
+		float yaw_delta = wrap_pi(_ekf_gsf[model_index].X[2] - X_GSF[2]);
 		_ekf_gsf_yaw_variance += _ekf_gsf[model_index].W * (_ekf_gsf[model_index].P[2][2] + sq(yaw_delta));
 	}
 }

--- a/EKF/EKFGSF_yaw_estimator.cpp
+++ b/EKF/EKFGSF_yaw_estimator.cpp
@@ -676,7 +676,7 @@ void Ekf::resetYawToEKFGSF()
 
 	// update quaternion states
 	_state.quat_nominal = quat_after_reset;
-	uncorrelateQuatStates();
+	uncorrelateQuatFromOtherStates();
 
 	// record the state change
 	_state_reset_status.quat_change = q_error;

--- a/EKF/EKFGSF_yaw_estimator.cpp
+++ b/EKF/EKFGSF_yaw_estimator.cpp
@@ -76,8 +76,10 @@ void Ekf::quatPredictEKFGSF(const uint8_t model_index)
 	// Perform angular rate correction using accel data and reduce correction as accel magnitude moves away from 1 g (reduces drift when vehicle picked up and moved).
 	// During fixed wing flight, compensate for centripetal acceleration assuming coordinated turns and X axis forward
 	Vector3f correction = {};
-	Vector3f accel = _ahrs_accel;
-	if (_ahrs_accel_norm > 0.5f * CONSTANTS_ONE_G && (_ahrs_accel_norm < 1.5f * CONSTANTS_ONE_G || _ahrs_turn_comp_enabled)) {
+	if (_ahrs_accel_fusion_gain > 0.0f) {
+
+		Vector3f accel = _ahrs_accel;
+
 		if (_ahrs_turn_comp_enabled) {
 			// turn rate is component of gyro rate about vertical (down) axis
 			const float turn_rate = _ahrs_ekf_gsf[model_index].R(2,0) * _ang_rate_delayed_raw(0)

--- a/EKF/EKFGSF_yaw_estimator.cpp
+++ b/EKF/EKFGSF_yaw_estimator.cpp
@@ -413,13 +413,14 @@ void Ekf::stateUpdateEKFGSF(const uint8_t model_index)
 	// take advantage of sparseness in the yaw rotation matrix
 	const float cosYaw = cosf(yawDelta);
 	const float sinYaw = sinf(yawDelta);
-	Matrix3f  R = _ahrs_ekf_gsf[model_index].R;
-	_ahrs_ekf_gsf[model_index].R(0,0) = R(0,0) * cosYaw - R(1,0) * sinYaw;
-	_ahrs_ekf_gsf[model_index].R(0,1) = R(0,1) * cosYaw - R(1,1) * sinYaw;
-	_ahrs_ekf_gsf[model_index].R(0,2) = R(0,2) * cosYaw - R(1,2) * sinYaw;
-	_ahrs_ekf_gsf[model_index].R(1,0) = R(0,0) * sinYaw + R(1,0) * cosYaw;
-	_ahrs_ekf_gsf[model_index].R(1,1) = R(0,1) * sinYaw + R(1,1) * cosYaw;
-	_ahrs_ekf_gsf[model_index].R(1,2) = R(0,2) * sinYaw + R(1,2) * cosYaw;
+	float  R_prev[2][3];
+	memcpy(&R_prev, &_ahrs_ekf_gsf[model_index].R, sizeof(R_prev));
+	_ahrs_ekf_gsf[model_index].R(0,0) = R_prev[0][0] * cosYaw - R_prev[1][0] * sinYaw;
+	_ahrs_ekf_gsf[model_index].R(0,1) = R_prev[0][1] * cosYaw - R_prev[1][1] * sinYaw;
+	_ahrs_ekf_gsf[model_index].R(0,2) = R_prev[0][2] * cosYaw - R_prev[1][2] * sinYaw;
+	_ahrs_ekf_gsf[model_index].R(1,0) = R_prev[0][0] * sinYaw + R_prev[1][0] * cosYaw;
+	_ahrs_ekf_gsf[model_index].R(1,1) = R_prev[0][1] * sinYaw + R_prev[1][1] * cosYaw;
+	_ahrs_ekf_gsf[model_index].R(1,2) = R_prev[0][2] * sinYaw + R_prev[1][2] * cosYaw;
 
 }
 

--- a/EKF/EKFGSF_yaw_estimator.cpp
+++ b/EKF/EKFGSF_yaw_estimator.cpp
@@ -502,8 +502,8 @@ void Ekf::runEKFGSF()
 				_ekf_gsf[model_index].X[1] = _gps_sample_delayed.vel(1);
 				_ekf_gsf[model_index].P[0][0] = sq(_gps_sample_delayed.sacc);
 				_ekf_gsf[model_index].P[1][1] = _ekf_gsf[model_index].P[0][0];
-				alignQuatYawEKFGSF();
 			}
+			alignQuatYawEKFGSF();
 			_ekf_gsf_vel_fuse_started = true;
 		} else {
 			float total_w = 0.0f;

--- a/EKF/EKFGSF_yaw_estimator.cpp
+++ b/EKF/EKFGSF_yaw_estimator.cpp
@@ -525,7 +525,10 @@ void Ekf::runEKFGSF()
 				}
 			}
 
-			// enforce a minimum weighting value
+			// Enforce a minimum weighting value. This was added during initial development but has not been needed
+			// subsequently, so this block of code and the corresponding EKFGSF_weight_min can be removed if we get
+			// through testing without any weighting function issues.
+			if (_params.EKFGSF_weight_min > FLT_EPSILON) {
 			float correction_sum = 0.0f; // amount the sum of weights has been increased by application of the limit
 			bool change_mask[N_MODELS_EKFGSF] = {}; // true when the weighting for that model has been increased
 			float unmodified_weights_sum = 0.0f; // sum of unmodified weights
@@ -546,6 +549,7 @@ void Ekf::runEKFGSF()
 					_ekf_gsf[model_index].W = _params.EKFGSF_weight_min + scale_factor * (_ekf_gsf[model_index].W - _params.EKFGSF_weight_min);
 				}
 			}
+		}
 		}
 	} else if (_ekf_gsf_vel_fuse_started && !_control_status.flags.in_air) {
 		// reset EKF states and wait to fly again

--- a/EKF/EKFGSF_yaw_estimator.cpp
+++ b/EKF/EKFGSF_yaw_estimator.cpp
@@ -186,11 +186,11 @@ void Ekf::statePredictEKFGSF(const uint8_t model_index)
 	// Calculate the yaw state using a projection onto the horizontal that avoids gimbal lock
 	if (fabsf(_ahrs_ekf_gsf[model_index].R(2, 0)) < fabsf(_ahrs_ekf_gsf[model_index].R(2, 1))) {
 		// use 321 Tait-Bryan rotation to define yaw state
-		_ekf_gsf[model_index].X[2] = atan2(_ahrs_ekf_gsf[model_index].R(1, 0), _ahrs_ekf_gsf[model_index].R(0, 0));
+		_ekf_gsf[model_index].X[2] = atan2f(_ahrs_ekf_gsf[model_index].R(1, 0), _ahrs_ekf_gsf[model_index].R(0, 0));
 		_ekf_gsf[model_index].use_312 = false;
 	} else {
 		// use 312 Tait-Bryan rotation to define yaw state
-		_ekf_gsf[model_index].X[2] = atan2(-_ahrs_ekf_gsf[model_index].R(0, 1), _ahrs_ekf_gsf[model_index].R(1, 1)); // first rotation (yaw)
+		_ekf_gsf[model_index].X[2] = atan2f(-_ahrs_ekf_gsf[model_index].R(0, 1), _ahrs_ekf_gsf[model_index].R(1, 1)); // first rotation (yaw)
 		_ekf_gsf[model_index].use_312 = true;
 	}
 

--- a/EKF/EKFGSF_yaw_estimator.cpp
+++ b/EKF/EKFGSF_yaw_estimator.cpp
@@ -833,12 +833,12 @@ Matrix3f Ekf::updateRotMatEKFGSF(Matrix3f &R, Vector3f &g)
 	ret(2,1) += R(2,2) * g(0) - R(2,0) * g(2);
 	ret(2,2) += R(2,0) * g(1) - R(2,1) * g(0);
 
-	// Renormalise rows - Use sqrt approximation which is valid for small deviations that accumulate
+	// Renormalise rows
 	float rowLengthSq;
 	for (uint8_t r = 0; r < 3; r++) {
 		rowLengthSq = ret(r,0) * ret(r,0) + ret(r,1) * ret(r,1) + ret(r,2) * ret(r,2);
 		if (rowLengthSq > FLT_EPSILON) {
-			float rowLengthInv = 0.5f / rowLengthSq;
+			const float rowLengthInv = 1.0f / sqrtf(rowLengthSq);
 			ret(r,0) *= rowLengthInv;
 			ret(r,1) *= rowLengthInv;
 			ret(r,2) *= rowLengthInv;

--- a/EKF/common.h
+++ b/EKF/common.h
@@ -200,6 +200,8 @@ struct auxVelSample {
 // ground effect compensation
 #define GNDEFFECT_TIMEOUT	10E6	///< Maximum period of time that ground effect protection will be active after it was last turned on (uSec)
 
+#define N_MODELS_EKFGSF 8 // number of models used by EKF-GSF yaw estimator
+
 struct parameters {
 	// measurement source control
 	int32_t fusion_mode{MASK_USE_GPS};		///< bitmasked integer that selects which aiding sources will be used
@@ -354,6 +356,15 @@ struct parameters {
 	// compute synthetic magnetomter Z value if possible
 	int32_t synthesize_mag_z{0};
 	int32_t check_mag_strength{0};
+
+	// Parameters used by EKF-GSF yaw estimator
+	float EKFGSF_gyro_noise{1.0e-1f}; 	///< yaw rate noise used for covariance prediction (rad/sec)
+	float EKFGSF_accel_noise{2.0f};		///< horizontal accel noise used for covariance prediction (m/sec**2)
+	float EKFGSF_tilt_gain{0.4f};		///< gain from tilt error to gyro correction for complementary filter (1/sec)
+	float EKFGSF_gyro_bias_gain{0.04f};	///< gain applied to integral of gyro correction for complementary filter (1/sec)
+	float EKFGSF_weight_min{0.0f};		///< minimum value of an individual model weighting
+	float EKFGSF_tas_default{15.0f};	///< default airspeed value assumed during fixed wing flight if no airspeed measurement available (m/s)
+	unsigned EKFGSF_reset_delay{1000000};	///< Number of uSec of bad innovations on main filter inpost takeoff phase before yaw is reset to EKF-GSF value
 };
 
 struct stateSample {

--- a/EKF/common.h
+++ b/EKF/common.h
@@ -202,7 +202,8 @@ struct auxVelSample {
 
 #define N_MODELS_EKFGSF 8 // number of models used by EKF-GSF yaw estimator
 
-#define M_TWOPI_F 6.28318531f
+#define M_TWOPI_F   6.28318531f
+#define M_TWOPI_INV 0.159154943f
 
 struct parameters {
 	// measurement source control

--- a/EKF/common.h
+++ b/EKF/common.h
@@ -202,6 +202,8 @@ struct auxVelSample {
 
 #define N_MODELS_EKFGSF 8 // number of models used by EKF-GSF yaw estimator
 
+#define M_TWOPI_F 6.28318531f
+
 struct parameters {
 	// measurement source control
 	int32_t fusion_mode{MASK_USE_GPS};		///< bitmasked integer that selects which aiding sources will be used

--- a/EKF/common.h
+++ b/EKF/common.h
@@ -367,6 +367,7 @@ struct parameters {
 	float EKFGSF_weight_min{0.0f};		///< minimum value of an individual model weighting
 	float EKFGSF_tas_default{15.0f};	///< default airspeed value assumed during fixed wing flight if no airspeed measurement available (m/s)
 	unsigned EKFGSF_reset_delay{1000000};	///< Number of uSec of bad innovations on main filter inpost takeoff phase before yaw is reset to EKF-GSF value
+	float EKFGSF_yaw_err_max{0.2f}; 	///< Composite yaw 1-sigma uncertainty threshold used to check for convergence (rad)
 };
 
 struct stateSample {

--- a/EKF/control.cpp
+++ b/EKF/control.cpp
@@ -227,7 +227,7 @@ void Ekf::controlExternalVisionFusion()
 
 				// calculate initial quaternion states for the ekf
 				_state.quat_nominal = Quatf(euler_init);
-				uncorrelateQuatStates();
+				uncorrelateQuatFromOtherStates();
 
 				// adjust the quaternion covariances estimated yaw error
 				increaseQuatYawErrVariance(fmaxf(_ev_sample_delayed.angVar, sq(1.0e-2f)));

--- a/EKF/control.cpp
+++ b/EKF/control.cpp
@@ -670,20 +670,18 @@ void Ekf::controlGpsFusion()
 			const bool recent_takeoff = (_control_status.flags.in_air && (_imu_sample_delayed.time_us - _time_last_on_ground_us) < 30000000);
 			const bool reset_yaw_to_EKFGSF = (do_reset || _do_emergency_yaw_reset || stopped_following_gps_velocity) && recent_takeoff && ((_imu_sample_delayed.time_us - _emergency_yaw_reset_time) > 5000000);
 
-			if (reset_yaw_to_EKFGSF) {
-				// Attempt to recover using an alternative algorithm for estimating yaw
-				if (_ekf_gsf_vel_fuse_started && (_imu_sample_delayed.time_us - _emergency_yaw_reset_time) > 5000000) {
-					resetYawToEKFGSF();
+			if (reset_yaw_to_EKFGSF && (_imu_sample_delayed.time_us - _emergency_yaw_reset_time) > 5000000) {
+				if (resetYawToEKFGSF()) {
 					_emergency_yaw_reset_time = _imu_sample_delayed.time_us;
 					_do_emergency_yaw_reset = false;
+
+					// Reset the timeout counters
+					_time_last_hor_pos_fuse = _time_last_imu;
+					_time_last_delpos_fuse = _time_last_imu;
+					_time_last_hor_vel_fuse = _time_last_imu;
+					_time_last_of_fuse = _time_last_imu;
+
 				}
-
-				// Reset the timeout counters
-				_time_last_hor_pos_fuse = _time_last_imu;
-				_time_last_delpos_fuse = _time_last_imu;
-				_time_last_hor_vel_fuse = _time_last_imu;
-				_time_last_of_fuse = _time_last_imu;
-
 			} else if (do_reset) {
 				// use GPS velocity data to check and correct yaw angle if a FW vehicle
 				if (_control_status.flags.fixed_wing && _control_status.flags.in_air) {

--- a/EKF/control.cpp
+++ b/EKF/control.cpp
@@ -662,17 +662,19 @@ void Ekf::controlGpsFusion()
 			// This special case reset can also be requested externally.
 			// The minimum time interval between resets to the EKF-GSF estimate must be limited to
 			// allow the EKF-GSF time to improve its estimate if the first reset was not successful.
-			const bool stopped_following_gps_velocity = (_time_last_imu - _time_last_hor_vel_fuse) > _params.EKFGSF_reset_delay &&
+			const bool stopped_following_gps_velocity = isTimedOut(_time_last_hor_vel_fuse, _params.EKFGSF_reset_delay) &&
 							   (_time_last_hor_vel_fuse > _time_last_on_ground_us);
 			if (!_control_status.flags.in_air) {
 				_time_last_on_ground_us = _time_last_imu;
 			}
-			const bool recent_takeoff = (_control_status.flags.in_air && (_imu_sample_delayed.time_us - _time_last_on_ground_us) < 30000000);
-			const bool reset_yaw_to_EKFGSF = (do_reset || _do_emergency_yaw_reset || stopped_following_gps_velocity) && recent_takeoff && ((_imu_sample_delayed.time_us - _emergency_yaw_reset_time) > 5000000);
+			const bool recent_takeoff = _control_status.flags.in_air && !isTimedOut(_time_last_on_ground_us, 30000000);
+			const bool reset_yaw_to_EKFGSF = (do_reset || _do_emergency_yaw_reset || stopped_following_gps_velocity) &&
+								recent_takeoff &&
+								isTimedOut(_emergency_yaw_reset_time, 5000000);
 
-			if (reset_yaw_to_EKFGSF && (_imu_sample_delayed.time_us - _emergency_yaw_reset_time) > 5000000) {
+			if (reset_yaw_to_EKFGSF) {
 				if (resetYawToEKFGSF()) {
-					_emergency_yaw_reset_time = _imu_sample_delayed.time_us;
+					_emergency_yaw_reset_time = _time_last_imu;
 					_do_emergency_yaw_reset = false;
 
 					// Reset the timeout counters

--- a/EKF/control.cpp
+++ b/EKF/control.cpp
@@ -358,9 +358,8 @@ void Ekf::controlExternalVisionFusion()
 			}
 
 			// correct velocity for offset relative to IMU
-			const Vector3f ang_rate = _imu_sample_delayed.delta_ang * (1.0f / _imu_sample_delayed.delta_ang_dt);
 			const Vector3f pos_offset_body = _params.ev_pos_body - _params.imu_pos_body;
-			const Vector3f vel_offset_body = ang_rate % pos_offset_body;
+			const Vector3f vel_offset_body = _ang_rate_delayed_raw % pos_offset_body;
 			const Vector3f vel_offset_earth = _R_to_earth * vel_offset_body;
 			vel_aligned -= vel_offset_earth;
 
@@ -658,7 +657,34 @@ void Ekf::controlGpsFusion()
 			// We haven't had an absolute position fix for a longer time so need to do something
 			do_reset = do_reset || isTimedOut(_time_last_hor_pos_fuse, 2 * _params.reset_timeout_max);
 
-			if (do_reset) {
+			// A reset to the EKF-GSF estimate can be performed after a recent takeoff which will enable
+			// recovery from a bad magnetometer or field estimate.
+			// This special case reset can also be requested externally.
+			// The minimum time interval between resets to the EKF-GSF estimate must be limited to
+			// allow the EKF-GSF time to improve its estimate if the first reset was not successful.
+			const bool stopped_following_gps_velocity = (_time_last_imu - _time_last_hor_vel_fuse) > _params.EKFGSF_reset_delay &&
+							   (_time_last_hor_vel_fuse > _time_last_on_ground_us);
+			if (!_control_status.flags.in_air) {
+				_time_last_on_ground_us = _time_last_imu;
+			}
+			const bool recent_takeoff = (_control_status.flags.in_air && (_imu_sample_delayed.time_us - _time_last_on_ground_us) < 30000000);
+			const bool reset_yaw_to_EKFGSF = (do_reset || _do_emergency_yaw_reset || stopped_following_gps_velocity) && recent_takeoff && ((_imu_sample_delayed.time_us - _emergency_yaw_reset_time) > 5000000);
+
+			if (reset_yaw_to_EKFGSF) {
+				// Attempt to recover using an alternative algorithm for estimating yaw
+				if (_ekf_gsf_vel_fuse_started && (_imu_sample_delayed.time_us - _emergency_yaw_reset_time) > 5000000) {
+					resetYawToEKFGSF();
+					_emergency_yaw_reset_time = _imu_sample_delayed.time_us;
+					_do_emergency_yaw_reset = false;
+				}
+
+				// Reset the timeout counters
+				_time_last_hor_pos_fuse = _time_last_imu;
+				_time_last_delpos_fuse = _time_last_imu;
+				_time_last_hor_vel_fuse = _time_last_imu;
+				_time_last_of_fuse = _time_last_imu;
+
+			} else if (do_reset) {
 				// use GPS velocity data to check and correct yaw angle if a FW vehicle
 				if (_control_status.flags.fixed_wing && _control_status.flags.in_air) {
 					// if flying a fixed wing aircraft, do a complete reset that includes yaw
@@ -687,9 +713,8 @@ void Ekf::controlGpsFusion()
 			Vector3f gps_pos_obs_var;
 
 			// correct velocity for offset relative to IMU
-			const Vector3f ang_rate = _imu_sample_delayed.delta_ang * (1.0f / _imu_sample_delayed.delta_ang_dt);
 			const Vector3f pos_offset_body = _params.gps_pos_body - _params.imu_pos_body;
-			const Vector3f vel_offset_body = ang_rate % pos_offset_body;
+			const Vector3f vel_offset_body = _ang_rate_delayed_raw % pos_offset_body;
 			const Vector3f vel_offset_earth = _R_to_earth * vel_offset_body;
 			_gps_sample_delayed.vel -= vel_offset_earth;
 

--- a/EKF/ekf.cpp
+++ b/EKF/ekf.cpp
@@ -83,6 +83,8 @@ void Ekf::reset()
 
 	_dt_ekf_avg = FILTER_UPDATE_PERIOD_S;
 
+	_ang_rate_delayed_raw.zero();
+
 	_fault_status.value = 0;
 	_innov_check_fail_status.value = 0;
 
@@ -119,6 +121,9 @@ bool Ekf::update()
 		runTerrainEstimator();
 
 		updated = true;
+
+		// run test code for EKF-GSF yaw estimator
+		runEKFGSF();
 	}
 
 	// the output observer always runs
@@ -287,6 +292,10 @@ void Ekf::predictState()
 	// filter and limit input between -50% and +100% of nominal value
 	input = math::constrain(input, 0.5f * FILTER_UPDATE_PERIOD_S, 2.0f * FILTER_UPDATE_PERIOD_S);
 	_dt_ekf_avg = 0.99f * _dt_ekf_avg + 0.01f * input;
+
+	// some calculations elsewhere in code require a raw angular rate vector so calculate here to avoid duplication
+	_ang_rate_delayed_raw = _imu_sample_delayed.delta_ang / fmaxf(_imu_sample_delayed.delta_ang_dt, FILTER_UPDATE_PERIOD_S / 4);
+
 }
 
 /*

--- a/EKF/ekf.h
+++ b/EKF/ekf.h
@@ -285,18 +285,8 @@ public:
 	void set_min_required_gps_health_time(uint32_t time_us) { _min_gps_health_time_us = time_us; }
 
 	// get solution data for the EKF-GSF emergency yaw esitmator
-	void getDataEKFGSF(float *yaw_composite, float yaw[N_MODELS_EKFGSF], float innov_VN[N_MODELS_EKFGSF], float innov_VE[N_MODELS_EKFGSF], float weight[N_MODELS_EKFGSF]) override;
-
-	// gets data which to be logged and used for EKF-GSF development replay
-	// returns false when no data available
-	bool get_algo_test_data(float delAng[3], // delta angle from IMU (rad)
-				float *delAngDt, // delta angle integration time (sec)
-				float delVel[3], // delta velocity from IMU (m/s)
-				float *delVelDt, // delta velocity integration time (sec)
-				float vel[3], // NED velocity measurement (m/s)
-				float *velErr, // 1-sigma velocity measurement uncertainty (m/s)
-				bool *fuse_vel, // true when velociy measurement has been updated
-				float quat[4]) override; // reference quaternion from EKF
+	// return false if estimator is not running
+	bool getDataEKFGSF(float *yaw_composite, float *yaw_variance, float yaw[N_MODELS_EKFGSF], float innov_VN[N_MODELS_EKFGSF], float innov_VE[N_MODELS_EKFGSF], float weight[N_MODELS_EKFGSF]) override;
 
 	// request the EKF reset the yaw to the estimate from the internal EKF-GSF filter
 	// argment should be incremented only when a new reset is required

--- a/EKF/ekf.h
+++ b/EKF/ekf.h
@@ -854,7 +854,6 @@ private:
 		float W = 0.0f; // weighting
 		float S[2][2]; // innovation variance
 		float innov[2]; // Velocity N,E innovation (m/s)
-		bool use_312; // true if a 312 Tait-Bryan rotation sequence should be used when converting between the AHRS quaternion and EKF yaw state
 	};
 	_ekf_gsf_struct _ekf_gsf[N_MODELS_EKFGSF];
 	float X_GSF[3] {};

--- a/EKF/ekf.h
+++ b/EKF/ekf.h
@@ -835,7 +835,7 @@ private:
 	struct _ahrs_ekf_gsf_struct{
 		Dcmf R;				///< matrix that rotates a vector from body to earth frame
 		Vector3f gyro_bias;		///< gyro bias learned and used by the quaternion calculation
-		bool quat_initialised{false};	///< true when calibrator quaternion has been aligned
+		bool aligned{false};		///< true when AHRS has been aligned
 		float accel_FR[2] {};		///< front-right acceleration vector in a horizontal plane (m/s/s)
 		float vel_NE[2] {};		///< NE velocity vector from last GPS measurement (m/s)
 		bool fuse_gps = false;		///< true when GPS should be fused on that frame
@@ -867,9 +867,9 @@ private:
 
 	void runEKFGSF();
 	void initialiseEKFGSF();
-	void quatPredictEKFGSF(const uint8_t model_index);
-	void alignQuatEKFGSF();
-	void alignQuatYawEKFGSF();
+	void ahrsPredictEKFGSF(const uint8_t model_index);
+	void ahrsAlignTiltEKFGSF();
+	void ahrsAlignYawEKFGSF();
 	void statePredictEKFGSF(const uint8_t model_index);
 	void stateUpdateEKFGSF(const uint8_t model_index);
 	float gaussianDensityEKFGSF(const uint8_t model_index) const;

--- a/EKF/ekf.h
+++ b/EKF/ekf.h
@@ -794,7 +794,7 @@ private:
 	void zeroMagCov();
 
 	// uncorrelate quaternion states from other states
-	void uncorrelateQuatStates();
+	void uncorrelateQuatFromOtherStates();
 
 	// Use Kahan summation algorithm to get the sum of "sum_previous" and "input".
 	// This function relies on the caller to be responsible for keeping a copy of

--- a/EKF/ekf.h
+++ b/EKF/ekf.h
@@ -833,8 +833,7 @@ private:
 
 	// Declarations for a EKF-GSF estimator used to provide a backup estimate of vehicle yaw
 	struct _ahrs_ekf_gsf_struct{
-		Quatf quat;			///< quaternion describing rotation from body to earth frame and calculated using only IMU data.
-		Dcmf R;				///< matrix that rotates avector from body to earth frame
+		Dcmf R;				///< matrix that rotates a vector from body to earth frame
 		Vector3f gyro_bias;		///< gyro bias learned and used by the quaternion calculation
 		bool quat_initialised{false};	///< true when calibrator quaternion has been aligned
 		float accel_FR[2] {};		///< front-right acceleration vector in a horizontal plane (m/s/s)
@@ -878,4 +877,5 @@ private:
 	bool resetYawToEKFGSF();
 	Dcmf taitBryan312ToRotMat(Vector3f &rot312);
 	void calcAccelGainEKFGSF();
+	Matrix3f updateRotMatEKFGSF(Matrix3f &R, Vector3f &g);
 };

--- a/EKF/ekf.h
+++ b/EKF/ekf.h
@@ -871,6 +871,7 @@ private:
 	uint64_t _time_last_on_ground_us{0};	///< last tine we were on the ground (uSec)
 	uint8_t _yaw_extreset_counter{0};	// number of external emergency yaw reset requests
 	bool _do_emergency_yaw_reset{false};	// true when an emergency yaw reset has been requested
+	float _ekf_gsf_yaw_variance{0.0f};	// varince of composite yaw estimate (rad^2)
 
 	void runEKFGSF();
 	void initialiseEKFGSF();
@@ -881,6 +882,6 @@ private:
 	void stateUpdateEKFGSF(const uint8_t model_index);
 	float gaussianDensityEKFGSF(const uint8_t model_index) const;
 	void makeCovSymEKFGSF(const uint8_t model_index);
-	void resetYawToEKFGSF();
+	bool resetYawToEKFGSF();
 	Dcmf taitBryan312ToRotMat(Vector3f &rot312);
 };

--- a/EKF/ekf.h
+++ b/EKF/ekf.h
@@ -288,9 +288,12 @@ public:
 	// return false if estimator is not running
 	bool getDataEKFGSF(float *yaw_composite, float *yaw_variance, float yaw[N_MODELS_EKFGSF], float innov_VN[N_MODELS_EKFGSF], float innov_VE[N_MODELS_EKFGSF], float weight[N_MODELS_EKFGSF]) override;
 
-	// request the EKF reset the yaw to the estimate from the internal EKF-GSF filter
-	// argment should be incremented only when a new reset is required
-	void request_ekfgsf_yaw_reset(uint8_t counter) override;
+	// Request the EKF reset the yaw to the estimate from the internal EKF-GSF filter
+	// and reset the velocity and position states to the GPS. This will cause the EKF
+	// to ignore the magnetomer for the remainder of flight.
+	// This should only be used as a last resort before activating a loss of navigation failsafe
+	// The counter must be incremented for each new reset request
+	void requestEmergencyNavReset(uint8_t counter) override;
 
 private:
 

--- a/EKF/ekf.h
+++ b/EKF/ekf.h
@@ -877,4 +877,5 @@ private:
 	void makeCovSymEKFGSF(const uint8_t model_index);
 	bool resetYawToEKFGSF();
 	Dcmf taitBryan312ToRotMat(Vector3f &rot312);
+	void calcAccelGainEKFGSF();
 };

--- a/EKF/estimator_interface.h
+++ b/EKF/estimator_interface.h
@@ -274,7 +274,7 @@ public:
 	int getNumberOfActiveHorizontalAidingSources() const;
 
 	// return true if the EKF is dead reckoning the position using inertial data only
-	bool inertial_dead_reckoning() {return _is_dead_reckoning;}
+	bool inertial_dead_reckoning() {return _deadreckon_time_exceeded;}
 
 	virtual bool isTerrainEstimateValid() const = 0;
 	//[[deprecated("Replaced by isTerrainEstimateValid")]]
@@ -413,6 +413,24 @@ public:
 
 	static constexpr unsigned FILTER_UPDATE_PERIOD_MS{8};	// ekf prediction period in milliseconds - this should ideally be an integer multiple of the IMU time delta
 	static constexpr float FILTER_UPDATE_PERIOD_S{FILTER_UPDATE_PERIOD_MS * 0.001f};
+
+	// request the EKF reset the yaw to the estimate from the internal EKF-GSF filter
+	// argment should be incremented only when a new reset is required
+	virtual void request_ekfgsf_yaw_reset(uint8_t counter) = 0;
+
+	// get ekf-gsf debug data
+	virtual void getDataEKFGSF(float *yaw_composite, float yaw[N_MODELS_EKFGSF], float innov_VN[N_MODELS_EKFGSF], float innov_VE[N_MODELS_EKFGSF], float weight[N_MODELS_EKFGSF]) = 0;
+
+	// gets data which will be logged and used for algorithm development work
+	// returns false when no data avialable
+	virtual bool get_algo_test_data(float delAng[3],
+				float *delAngDt,
+				float delVel[3],
+				float *delVelDt,
+				float vel[3],
+				float *velErr,
+				bool *fuse_vel,
+				float quat[4]) = 0;
 
 protected:
 

--- a/EKF/estimator_interface.h
+++ b/EKF/estimator_interface.h
@@ -274,7 +274,7 @@ public:
 	int getNumberOfActiveHorizontalAidingSources() const;
 
 	// return true if the EKF is dead reckoning the position using inertial data only
-	bool inertial_dead_reckoning() {return _deadreckon_time_exceeded;}
+	bool inertial_dead_reckoning() {return _is_dead_reckoning;}
 
 	virtual bool isTerrainEstimateValid() const = 0;
 	//[[deprecated("Replaced by isTerrainEstimateValid")]]

--- a/EKF/estimator_interface.h
+++ b/EKF/estimator_interface.h
@@ -419,18 +419,7 @@ public:
 	virtual void request_ekfgsf_yaw_reset(uint8_t counter) = 0;
 
 	// get ekf-gsf debug data
-	virtual void getDataEKFGSF(float *yaw_composite, float yaw[N_MODELS_EKFGSF], float innov_VN[N_MODELS_EKFGSF], float innov_VE[N_MODELS_EKFGSF], float weight[N_MODELS_EKFGSF]) = 0;
-
-	// gets data which will be logged and used for algorithm development work
-	// returns false when no data avialable
-	virtual bool get_algo_test_data(float delAng[3],
-				float *delAngDt,
-				float delVel[3],
-				float *delVelDt,
-				float vel[3],
-				float *velErr,
-				bool *fuse_vel,
-				float quat[4]) = 0;
+	virtual bool getDataEKFGSF(float *yaw_composite, float *yaw_variance, float yaw[N_MODELS_EKFGSF], float innov_VN[N_MODELS_EKFGSF], float innov_VE[N_MODELS_EKFGSF], float weight[N_MODELS_EKFGSF]) = 0;
 
 protected:
 

--- a/EKF/estimator_interface.h
+++ b/EKF/estimator_interface.h
@@ -416,7 +416,7 @@ public:
 
 	// request the EKF reset the yaw to the estimate from the internal EKF-GSF filter
 	// argment should be incremented only when a new reset is required
-	virtual void request_ekfgsf_yaw_reset(uint8_t counter) = 0;
+	virtual void requestEmergencyNavReset(uint8_t counter) = 0;
 
 	// get ekf-gsf debug data
 	virtual bool getDataEKFGSF(float *yaw_composite, float *yaw_variance, float yaw[N_MODELS_EKFGSF], float innov_VN[N_MODELS_EKFGSF], float innov_VE[N_MODELS_EKFGSF], float weight[N_MODELS_EKFGSF]) = 0;

--- a/EKF/gps_yaw_fusion.cpp
+++ b/EKF/gps_yaw_fusion.cpp
@@ -385,7 +385,7 @@ bool Ekf::resetGpsAntYaw()
 		if (delta_ang_error.norm() > math::radians(15.0f) || !_control_status.flags.yaw_align) {
 			// update quaternion states
 			_state.quat_nominal = quat_after_reset;
-			uncorrelateQuatStates();
+			uncorrelateQuatFromOtherStates();
 
 			// record the state change
 			_state_reset_status.quat_change = q_error;


### PR DESCRIPTION
This is functionally the same as https://github.com/PX4/ecl/pull/751 and any changes identified during review and testing of https://github.com/PX4/ecl/pull/751 will be cherry-picked into this branch.

Testing used https://github.com/priseborough/Firmware/tree/pr-yawEKFGSF PX4/Firmware version.

Flight testing of this version to follow, but here is replay output using https://logs.px4.io/plot_app?log=d1e5d8e4-5c44-4350-b355-ee3acb2503b8 where a navigation failure was induced by taking off with the declination set to an error of 100 degrees. This can be achieved by setting EKF2_MAG_DECL to a large value at least 90 degrees away from the declination at the test location and EKF2_DECL_TYPE = 0 to force the EKF to use the parameter value. 

If you do testing make sure you have a non-position control mode like altitude or manual/stabilized available.

<img width="962" alt="Screen Shot 2020-02-14 at 7 32 14 am" src="https://user-images.githubusercontent.com/3596952/74475868-5ef41100-4efc-11ea-8a67-47e6915e839a.png">

