### PR TITLE
Interface style improvement

### DIFF
--- a/EKF/airspeed_fusion.cpp
+++ b/EKF/airspeed_fusion.cpp
@@ -225,16 +225,14 @@ void Ekf::fuseAirspeed()
 	}
 }
 
-void Ekf::get_wind_velocity(float *wind)
+Vector2f Ekf::getWindVelocity() const
 {
-	wind[0] = _state.wind_vel(0);
-	wind[1] = _state.wind_vel(1);
+	return _state.wind_vel;
 }
 
-void Ekf::get_wind_velocity_var(float *wind_var)
+Vector2f Ekf::getWindVelocityVariance() const
 {
-	wind_var[0] = P(22,22);
-	wind_var[1] = P(23,23);
+	return P.slice<2, 2>(22,22).diag();
 }
 
 void Ekf::get_true_airspeed(float *tas)
@@ -248,8 +246,7 @@ void Ekf::get_true_airspeed(float *tas)
 */
 void Ekf::resetWindStates()
 {
-	// get euler yaw angle
-	Eulerf euler321(_state.quat_nominal);
+	const Eulerf euler321(_state.quat_nominal);
 	const float euler_yaw = euler321(2);
 
 	if (_tas_data_ready && (_imu_sample_delayed.time_us - _airspeed_sample_delayed.time_us < (uint64_t)5e5)) {

--- a/EKF/covariance.cpp
+++ b/EKF/covariance.cpp
@@ -101,15 +101,14 @@ void Ekf::initialiseCovariance()
 
 }
 
-void Ekf::get_pos_var(Vector3f &pos_var)
+Vector3f Ekf::getPositionVariance() const
 {
-	pos_var = P.slice<3,3>(7,7).diag();
+	return P.slice<3,3>(7,7).diag();
 }
 
-void Ekf::get_vel_var(Vector3f &vel_var)
+Vector3f Ekf::getVelocityVariance() const
 {
-	vel_var = P.slice<3,3>(4,4).diag();
-
+	return P.slice<3,3>(4,4).diag();
 }
 
 void Ekf::predictCovariance()

--- a/EKF/ekf.h
+++ b/EKF/ekf.h
@@ -62,77 +62,77 @@ public:
 	// should be called every time new data is pushed into the filter
 	bool update() override;
 
-	void getGpsVelPosInnov(float hvel[2], float &vvel, float hpos[2], float &vpos) override;
+	void getGpsVelPosInnov(float hvel[2], float &vvel, float hpos[2], float &vpos) const override;
 
-	void getGpsVelPosInnovVar(float hvel[2], float &vvel, float hpos[2], float &vpos) override;
+	void getGpsVelPosInnovVar(float hvel[2], float &vvel, float hpos[2], float &vpos) const override;
 
-	void getGpsVelPosInnovRatio(float &hvel, float &vvel, float &hpos, float &vpos) override;
+	void getGpsVelPosInnovRatio(float &hvel, float &vvel, float &hpos, float &vpos) const override;
 
-	void getEvVelPosInnov(float hvel[2], float &vvel, float hpos[2], float &vpos) override;
+	void getEvVelPosInnov(float hvel[2], float &vvel, float hpos[2], float &vpos) const override;
 
-	void getEvVelPosInnovVar(float hvel[2], float &vvel, float hpos[2], float &vpos) override;
+	void getEvVelPosInnovVar(float hvel[2], float &vvel, float hpos[2], float &vpos) const override;
 
-	void getEvVelPosInnovRatio(float &hvel, float &vvel, float &hpos, float &vpos) override;
+	void getEvVelPosInnovRatio(float &hvel, float &vvel, float &hpos, float &vpos) const override;
 
-	void getBaroHgtInnov(float &baro_hgt_innov) override;
+	void getBaroHgtInnov(float &baro_hgt_innov) const override;
 
-	void getBaroHgtInnovVar(float &baro_hgt_innov_var) override;
+	void getBaroHgtInnovVar(float &baro_hgt_innov_var) const override;
 
-	void getBaroHgtInnovRatio(float &baro_hgt_innov_ratio) override;
+	void getBaroHgtInnovRatio(float &baro_hgt_innov_ratio) const override;
 
-	void getRngHgtInnov(float &rng_hgt_innov) override;
+	void getRngHgtInnov(float &rng_hgt_innov) const override;
 
-	void getRngHgtInnovVar(float &rng_hgt_innov_var) override;
+	void getRngHgtInnovVar(float &rng_hgt_innov_var) const override;
 
-	void getRngHgtInnovRatio(float &rng_hgt_innov_ratio) override;
+	void getRngHgtInnovRatio(float &rng_hgt_innov_ratio) const override;
 
-	void getAuxVelInnov(float aux_vel_innov[2]) override;
+	void getAuxVelInnov(float aux_vel_innov[2]) const override;
 
-	void getAuxVelInnovVar(float aux_vel_innov[2]) override;
+	void getAuxVelInnovVar(float aux_vel_innov[2]) const override;
 
-	void getAuxVelInnovRatio(float &aux_vel_innov_ratio) override;
+	void getAuxVelInnovRatio(float &aux_vel_innov_ratio) const override;
 
-	void getFlowInnov(float flow_innov[2]) override;
+	void getFlowInnov(float flow_innov[2]) const override;
 
-	void getFlowInnovVar(float flow_innov_var[2]) override;
+	void getFlowInnovVar(float flow_innov_var[2]) const override;
 
-	void getFlowInnovRatio(float &flow_innov_ratio) override;
+	void getFlowInnovRatio(float &flow_innov_ratio) const override;
 
-	void getHeadingInnov(float &heading_innov) override;
+	void getHeadingInnov(float &heading_innov) const override;
 
-	void getHeadingInnovVar(float &heading_innov_var) override;
+	void getHeadingInnovVar(float &heading_innov_var) const override;
 
-	void getHeadingInnovRatio(float &heading_innov_ratio) override;
+	void getHeadingInnovRatio(float &heading_innov_ratio) const override;
 
-	void getMagInnov(float mag_innov[3]) override;
+	void getMagInnov(float mag_innov[3]) const override;
 
-	void getMagInnovVar(float mag_innov_var[3]) override;
+	void getMagInnovVar(float mag_innov_var[3]) const override;
 
-	void getMagInnovRatio(float &mag_innov_ratio) override;
+	void getMagInnovRatio(float &mag_innov_ratio) const override;
 
-	void getDragInnov(float drag_innov[2]) override;
+	void getDragInnov(float drag_innov[2]) const override;
 
-	void getDragInnovVar(float drag_innov_var[2]) override;
+	void getDragInnovVar(float drag_innov_var[2]) const override;
 
-	void getDragInnovRatio(float drag_innov_ratio[2]) override;
+	void getDragInnovRatio(float drag_innov_ratio[2]) const override;
 
-	void getAirspeedInnov(float &airspeed_innov) override;
+	void getAirspeedInnov(float &airspeed_innov) const override;
 
-	void getAirspeedInnovVar(float &airspeed_innov_var) override;
+	void getAirspeedInnovVar(float &airspeed_innov_var) const override;
 
-	void getAirspeedInnovRatio(float &airspeed_innov_ratio) override;
+	void getAirspeedInnovRatio(float &airspeed_innov_ratio) const override;
 
-	void getBetaInnov(float &beta_innov) override;
+	void getBetaInnov(float &beta_innov) const override;
 
-	void getBetaInnovVar(float &beta_innov_var) override;
+	void getBetaInnovVar(float &beta_innov_var) const override;
 
-	void getBetaInnovRatio(float &beta_innov_ratio) override;
+	void getBetaInnovRatio(float &beta_innov_ratio) const override;
 
-	void getHaglInnov(float &hagl_innov) override;
+	void getHaglInnov(float &hagl_innov) const override;
 
-	void getHaglInnovVar(float &hagl_innov_var) override;
+	void getHaglInnovVar(float &hagl_innov_var) const override;
 
-	void getHaglInnovRatio(float &hagl_innov_ratio) override;
+	void getHaglInnovRatio(float &hagl_innov_ratio) const override;
 
 	// get the state vector at the delayed time horizon
 	void get_state_delayed(float *state) override;

--- a/EKF/ekf.h
+++ b/EKF/ekf.h
@@ -135,13 +135,13 @@ public:
 	void getHaglInnovRatio(float &hagl_innov_ratio) const override;
 
 	// get the state vector at the delayed time horizon
-	void get_state_delayed(float *state) override;
+	matrix::Vector<float, 24> getStateAtFusionHorizonAsVector() const override;
 
 	// get the wind velocity in m/s
-	void get_wind_velocity(float *wind) override;
+	Vector2f getWindVelocity() const override;
 
 	// get the wind velocity var
-	void get_wind_velocity_var(float *wind_var) override;
+	Vector2f getWindVelocityVariance() const override;
 
 	// get the true airspeed in m/s
 	void get_true_airspeed(float *tas) override;
@@ -187,13 +187,13 @@ public:
 	*/
 	bool reset_imu_bias() override;
 
-	void get_vel_var(Vector3f &vel_var) override;
+	Vector3f getVelocityVariance() const override;
 
-	void get_pos_var(Vector3f &pos_var) override;
+	Vector3f getPositionVariance() const override;
 
 	// return an array containing the output predictor angular, velocity and position tracking
 	// error magnitudes (rad), (m/sec), (m)
-	void get_output_tracking_error(float error[3]) override;
+	Vector3f getOutputTrackingError() const override;
 
 	/*
 	Returns  following IMU vibration metrics in the following array locations
@@ -201,7 +201,7 @@ public:
 	1 : Gyro high frequency vibe = filtered length of (delta_angle - prev_delta_angle)
 	2 : Accel high frequency vibe = filtered length of (delta_velocity - prev_delta_velocity)
 	*/
-	void get_imu_vibe_metrics(float vibe[3]) override;
+	Vector3f getImuVibrationMetrics() const override;
 
 	/*
 	First argument returns GPS drift  metrics in the following array locations
@@ -224,16 +224,16 @@ public:
 	void updateTerrainValidity();
 
 	// get the estimated terrain vertical position relative to the NED origin
-	void getTerrainVertPos(float *ret) override;
+	float getTerrainVertPos() const override;
 
 	// get the terrain variance
 	float get_terrain_var() const { return _terrain_var; }
 
-	// get the accelerometer bias in m/s/s
-	void get_accel_bias(float bias[3]) override;
+	// get the accelerometer bias in m/s**2
+	Vector3f getAccelBias() const override;
 
 	// get the gyroscope bias in rad/s
-	void get_gyro_bias(float bias[3]) override;
+	Vector3f getGyroBias() const override;
 
 	// get GPS check status
 	void get_gps_check_status(uint16_t *val) override;
@@ -276,7 +276,7 @@ public:
 	void get_ekf_soln_status(uint16_t *status) override;
 
 	// return the quaternion defining the rotation from the External Vision to the EKF reference frame
-	void get_ev2ekf_quaternion(float *quat) override;
+	matrix::Quatf getVisionAlignmentQuaternion() const override;
 
 	// use the latest IMU data at the current time horizon.
 	Quatf calculate_quaternion() const;
@@ -441,7 +441,7 @@ private:
 	Vector3f _delta_angle_corr;	///< delta angle correction vector (rad)
 	Vector3f _vel_err_integ;	///< integral of velocity tracking error (m)
 	Vector3f _pos_err_integ;	///< integral of position tracking error (m.s)
-	float _output_tracking_error[3] {}; ///< contains the magnitude of the angle, velocity and position track errors (rad, m/s, m)
+	Vector3f _output_tracking_error; ///< contains the magnitude of the angle, velocity and position track errors (rad, m/s, m)
 
 	// variables used for the GPS quality checks
 	Vector3f _gps_pos_deriv_filt;	///< GPS NED position derivative (m/sec)

--- a/EKF/ekf_helper.cpp
+++ b/EKF/ekf_helper.cpp
@@ -661,7 +661,7 @@ Vector3f Ekf::calcEarthRateNED(float lat_rad) const
 			-CONSTANTS_EARTH_SPIN_RATE * sinf(lat_rad));
 }
 
-void Ekf::getGpsVelPosInnov(float hvel[2], float &vvel, float hpos[2],  float &vpos)
+void Ekf::getGpsVelPosInnov(float hvel[2], float &vvel, float hpos[2],  float &vpos) const
 {
 	hvel[0] = _gps_vel_innov(0);
 	hvel[1] = _gps_vel_innov(1);
@@ -671,7 +671,7 @@ void Ekf::getGpsVelPosInnov(float hvel[2], float &vvel, float hpos[2],  float &v
 	vpos    = _gps_pos_innov(2);
 }
 
-void Ekf::getGpsVelPosInnovVar(float hvel[2], float &vvel, float hpos[2], float &vpos)
+void Ekf::getGpsVelPosInnovVar(float hvel[2], float &vvel, float hpos[2], float &vpos)  const
 {
 	hvel[0] = _gps_vel_innov_var(0);
 	hvel[1] = _gps_vel_innov_var(1);
@@ -681,7 +681,7 @@ void Ekf::getGpsVelPosInnovVar(float hvel[2], float &vvel, float hpos[2], float 
 	vpos    = _gps_pos_innov_var(2);
 }
 
-void Ekf::getGpsVelPosInnovRatio(float &hvel, float &vvel, float &hpos, float &vpos)
+void Ekf::getGpsVelPosInnovRatio(float &hvel, float &vvel, float &hpos, float &vpos) const
 {
 	hvel = _gps_vel_test_ratio(0);
 	vvel = _gps_vel_test_ratio(1);
@@ -689,7 +689,7 @@ void Ekf::getGpsVelPosInnovRatio(float &hvel, float &vvel, float &hpos, float &v
 	vpos = _gps_pos_test_ratio(1);
 }
 
-void Ekf::getEvVelPosInnov(float hvel[2], float &vvel, float hpos[2], float &vpos)
+void Ekf::getEvVelPosInnov(float hvel[2], float &vvel, float hpos[2], float &vpos) const
 {
 	hvel[0] = _ev_vel_innov(0);
 	hvel[1] = _ev_vel_innov(1);
@@ -699,7 +699,7 @@ void Ekf::getEvVelPosInnov(float hvel[2], float &vvel, float hpos[2], float &vpo
 	vpos    = _ev_pos_innov(2);
 }
 
-void Ekf::getEvVelPosInnovVar(float hvel[2], float &vvel, float hpos[2], float &vpos)
+void Ekf::getEvVelPosInnovVar(float hvel[2], float &vvel, float hpos[2], float &vpos) const
 {
 	hvel[0] = _ev_vel_innov_var(0);
 	hvel[1] = _ev_vel_innov_var(1);
@@ -709,7 +709,7 @@ void Ekf::getEvVelPosInnovVar(float hvel[2], float &vvel, float hpos[2], float &
 	vpos    = _ev_pos_innov_var(2);
 }
 
-void Ekf::getEvVelPosInnovRatio(float &hvel, float &vvel, float &hpos, float &vpos)
+void Ekf::getEvVelPosInnovRatio(float &hvel, float &vvel, float &hpos, float &vpos) const
 {
 	hvel = _ev_vel_test_ratio(0);
 	vvel = _ev_vel_test_ratio(1);
@@ -717,154 +717,154 @@ void Ekf::getEvVelPosInnovRatio(float &hvel, float &vvel, float &hpos, float &vp
 	vpos = _ev_pos_test_ratio(1);
 }
 
-void Ekf::getBaroHgtInnov(float &baro_hgt_innov)
+void Ekf::getBaroHgtInnov(float &baro_hgt_innov) const
 {
 	baro_hgt_innov = _baro_hgt_innov(2);
 }
 
-void Ekf::getBaroHgtInnovVar(float &baro_hgt_innov_var)
+void Ekf::getBaroHgtInnovVar(float &baro_hgt_innov_var) const
 {
 	baro_hgt_innov_var = _baro_hgt_innov_var(2);
 }
 
-void Ekf::getBaroHgtInnovRatio(float &baro_hgt_innov_ratio)
+void Ekf::getBaroHgtInnovRatio(float &baro_hgt_innov_ratio) const
 {
 	baro_hgt_innov_ratio = _baro_hgt_test_ratio(1);
 }
 
-void Ekf::getRngHgtInnov(float &rng_hgt_innov)
+void Ekf::getRngHgtInnov(float &rng_hgt_innov) const
 {
 	rng_hgt_innov = _rng_hgt_innov(2);
 }
 
-void Ekf::getRngHgtInnovVar(float &rng_hgt_innov_var)
+void Ekf::getRngHgtInnovVar(float &rng_hgt_innov_var) const
 {
 	rng_hgt_innov_var = _rng_hgt_innov_var(2);
 }
 
-void Ekf::getRngHgtInnovRatio(float &rng_hgt_innov_ratio)
+void Ekf::getRngHgtInnovRatio(float &rng_hgt_innov_ratio) const
 {
 	rng_hgt_innov_ratio = _rng_hgt_test_ratio(1);
 }
 
-void Ekf::getAuxVelInnov(float aux_vel_innov[2])
+void Ekf::getAuxVelInnov(float aux_vel_innov[2]) const
 {
 	aux_vel_innov[0] = _aux_vel_innov(0);
 	aux_vel_innov[1] = _aux_vel_innov(1);
 }
 
-void Ekf::getAuxVelInnovVar(float aux_vel_innov_var[2])
+void Ekf::getAuxVelInnovVar(float aux_vel_innov_var[2]) const
 {
 	aux_vel_innov_var[0] = _aux_vel_innov_var(0);
 	aux_vel_innov_var[1] = _aux_vel_innov_var(1);
 }
 
-void Ekf::getAuxVelInnovRatio(float &aux_vel_innov_ratio)
+void Ekf::getAuxVelInnovRatio(float &aux_vel_innov_ratio) const
 {
 	aux_vel_innov_ratio = _aux_vel_test_ratio(0);
 }
 
-void Ekf::getFlowInnov(float flow_innov[2])
+void Ekf::getFlowInnov(float flow_innov[2]) const
 {
 	memcpy(flow_innov, _flow_innov, sizeof(_flow_innov));
 }
 
-void Ekf::getFlowInnovVar(float flow_innov_var[2])
+void Ekf::getFlowInnovVar(float flow_innov_var[2]) const
 {
 	memcpy(flow_innov_var, _flow_innov_var, sizeof(_flow_innov_var));
 }
 
-void Ekf::getFlowInnovRatio(float &flow_innov_ratio)
+void Ekf::getFlowInnovRatio(float &flow_innov_ratio) const
 {
 	flow_innov_ratio = _optflow_test_ratio;
 }
 
-void Ekf::getHeadingInnov(float &heading_innov)
+void Ekf::getHeadingInnov(float &heading_innov) const
 {
 	heading_innov = _heading_innov;
 }
 
-void Ekf::getHeadingInnovVar(float &heading_innov_var)
+void Ekf::getHeadingInnovVar(float &heading_innov_var) const
 {
 	heading_innov_var = _heading_innov_var;
 }
 
-void Ekf::getHeadingInnovRatio(float &heading_innov_ratio)
+void Ekf::getHeadingInnovRatio(float &heading_innov_ratio) const
 {
 	heading_innov_ratio = _yaw_test_ratio;
 }
 
-void Ekf::getMagInnov(float mag_innov[3])
+void Ekf::getMagInnov(float mag_innov[3]) const
 {
 	memcpy(mag_innov, _mag_innov, sizeof(_mag_innov));
 }
 
-void Ekf::getMagInnovVar(float mag_innov_var[3])
+void Ekf::getMagInnovVar(float mag_innov_var[3]) const
 {
 	memcpy(mag_innov_var, _mag_innov_var, sizeof(_mag_innov_var));
 }
 
-void Ekf::getMagInnovRatio(float &mag_innov_ratio)
+void Ekf::getMagInnovRatio(float &mag_innov_ratio) const
 {
 	mag_innov_ratio = math::max(math::max(_mag_test_ratio[0], _mag_test_ratio[1]), _mag_test_ratio[2]);
 }
 
-void Ekf::getDragInnov(float drag_innov[2])
+void Ekf::getDragInnov(float drag_innov[2]) const
 {
 	memcpy(drag_innov, _drag_innov, sizeof(_drag_innov));
 }
 
-void Ekf::getDragInnovVar(float drag_innov_var[2])
+void Ekf::getDragInnovVar(float drag_innov_var[2]) const
 {
 	memcpy(drag_innov_var, _drag_innov_var, sizeof(_drag_innov_var));
 }
 
-void Ekf::getDragInnovRatio(float drag_innov_ratio[2])
+void Ekf::getDragInnovRatio(float drag_innov_ratio[2]) const
 {
 	memcpy(drag_innov_ratio, &_drag_test_ratio, sizeof(_drag_test_ratio));
 }
 
-void Ekf::getAirspeedInnov(float &airspeed_innov)
+void Ekf::getAirspeedInnov(float &airspeed_innov) const
 {
 	airspeed_innov = _airspeed_innov;
 }
 
-void Ekf::getAirspeedInnovVar(float &airspeed_innov_var)
+void Ekf::getAirspeedInnovVar(float &airspeed_innov_var) const
 {
 	airspeed_innov_var = _airspeed_innov_var;
 }
 
-void Ekf::getAirspeedInnovRatio(float &airspeed_innov_ratio)
+void Ekf::getAirspeedInnovRatio(float &airspeed_innov_ratio) const
 {
 	airspeed_innov_ratio = _tas_test_ratio;
 }
 
-void Ekf::getBetaInnov(float &beta_innov)
+void Ekf::getBetaInnov(float &beta_innov) const
 {
 	beta_innov = _beta_innov;
 }
 
-void Ekf::getBetaInnovVar(float &beta_innov_var)
+void Ekf::getBetaInnovVar(float &beta_innov_var) const
 {
 	beta_innov_var = _beta_innov_var;
 }
 
-void Ekf::getBetaInnovRatio(float &beta_innov_ratio)
+void Ekf::getBetaInnovRatio(float &beta_innov_ratio) const
 {
 	beta_innov_ratio = _beta_test_ratio;
 }
 
-void Ekf::getHaglInnov(float &hagl_innov)
+void Ekf::getHaglInnov(float &hagl_innov) const
 {
 	hagl_innov = _hagl_innov;
 }
 
-void Ekf::getHaglInnovVar(float &hagl_innov_var)
+void Ekf::getHaglInnovVar(float &hagl_innov_var) const
 {
 	hagl_innov_var = _hagl_innov_var;
 }
 
-void Ekf::getHaglInnovRatio(float &hagl_innov_ratio)
+void Ekf::getHaglInnovRatio(float &hagl_innov_ratio) const
 {
 	hagl_innov_ratio = _hagl_test_ratio;
 }

--- a/EKF/ekf_helper.cpp
+++ b/EKF/ekf_helper.cpp
@@ -876,59 +876,51 @@ void Ekf::get_gps_check_status(uint16_t *val)
 }
 
 // get the state vector at the delayed time horizon
-void Ekf::get_state_delayed(float *state)
+matrix::Vector<float, 24> Ekf::getStateAtFusionHorizonAsVector() const
 {
+	matrix::Vector<float, 24> state;
 	for (int i = 0; i < 4; i++) {
-		state[i] = _state.quat_nominal(i);
+		state(i) = _state.quat_nominal(i);
 	}
 
 	for (int i = 0; i < 3; i++) {
-		state[i + 4] = _state.vel(i);
+		state(i + 4) = _state.vel(i);
 	}
 
 	for (int i = 0; i < 3; i++) {
-		state[i + 7] = _state.pos(i);
+		state(i + 7) = _state.pos(i);
 	}
 
 	for (int i = 0; i < 3; i++) {
-		state[i + 10] = _state.delta_ang_bias(i);
+		state(i + 10) = _state.delta_ang_bias(i);
 	}
 
 	for (int i = 0; i < 3; i++) {
-		state[i + 13] = _state.delta_vel_bias(i);
+		state(i + 13) = _state.delta_vel_bias(i);
 	}
 
 	for (int i = 0; i < 3; i++) {
-		state[i + 16] = _state.mag_I(i);
+		state(i + 16) = _state.mag_I(i);
 	}
 
 	for (int i = 0; i < 3; i++) {
-		state[i + 19] = _state.mag_B(i);
+		state(i + 19) = _state.mag_B(i);
 	}
 
 	for (int i = 0; i < 2; i++) {
-		state[i + 22] = _state.wind_vel(i);
+		state(i + 22) = _state.wind_vel(i);
 	}
+	return state;
 }
 
-// get the accelerometer bias
-void Ekf::get_accel_bias(float bias[3])
+Vector3f Ekf::getAccelBias() const
 {
-	float temp[3];
-	temp[0] = _state.delta_vel_bias(0) / _dt_ekf_avg;
-	temp[1] = _state.delta_vel_bias(1) / _dt_ekf_avg;
-	temp[2] = _state.delta_vel_bias(2) / _dt_ekf_avg;
-	memcpy(bias, temp, 3 * sizeof(float));
+	return _state.delta_vel_bias / _dt_ekf_avg;
 }
 
-// get the gyroscope bias in rad/s
-void Ekf::get_gyro_bias(float bias[3])
+Vector3f Ekf::getGyroBias() const
 {
-	float temp[3];
-	temp[0] = _state.delta_ang_bias(0) / _dt_ekf_avg;
-	temp[1] = _state.delta_ang_bias(1) / _dt_ekf_avg;
-	temp[2] = _state.delta_ang_bias(2) / _dt_ekf_avg;
-	memcpy(bias, temp, 3 * sizeof(float));
+	return _state.delta_ang_bias / _dt_ekf_avg;
 }
 
 // get the position and height of the ekf origin in WGS-84 coordinates and time the origin was set
@@ -941,11 +933,11 @@ bool Ekf::get_ekf_origin(uint64_t *origin_time, map_projection_reference_s *orig
 	return _NED_origin_initialised;
 }
 
-// return an array containing the output predictor angular, velocity and position tracking
+// return a vector containing the output predictor angular, velocity and position tracking
 // error magnitudes (rad), (m/s), (m)
-void Ekf::get_output_tracking_error(float error[3])
+Vector3f Ekf::getOutputTrackingError() const
 {
-	memcpy(error, _output_tracking_error, 3 * sizeof(float));
+	return _output_tracking_error;
 }
 
 /*
@@ -954,9 +946,9 @@ Returns  following IMU vibration metrics in the following array locations
 1 : Gyro high frequency vibe = filtered length of (delta_angle - prev_delta_angle)
 2 : Accel high frequency vibe = filtered length of (delta_velocity - prev_delta_velocity)
 */
-void Ekf::get_imu_vibe_metrics(float vibe[3])
+Vector3f Ekf::getImuVibrationMetrics() const
 {
-	memcpy(vibe, _vibe_metrics, 3 * sizeof(float));
+	return _vibe_metrics;
 }
 
 /*
@@ -1503,13 +1495,9 @@ void Ekf::calcExtVisRotMat()
 }
 
 // return the quaternions for the rotation from External Vision system reference frame to the EKF reference frame
-void Ekf::get_ev2ekf_quaternion(float *quat)
+matrix::Quatf Ekf::getVisionAlignmentQuaternion() const
 {
-	const Quatf quat_ev2ekf(_R_ev_to_ekf);
-
-	for (unsigned i = 0; i < 4; i++) {
-		quat[i] = quat_ev2ekf(i);
-	}
+	return Quatf(_R_ev_to_ekf);
 }
 
 // Increase the yaw error variance of the quaternions

--- a/EKF/estimator_interface.cpp
+++ b/EKF/estimator_interface.cpp
@@ -91,25 +91,25 @@ void EstimatorInterface::computeVibrationMetric()
 {
 	// calculate a metric which indicates the amount of coning vibration
 	Vector3f temp = _newest_high_rate_imu_sample.delta_ang % _delta_ang_prev;
-	_vibe_metrics[0] = 0.99f * _vibe_metrics[0] + 0.01f * temp.norm();
+	_vibe_metrics(0) = 0.99f * _vibe_metrics(0) + 0.01f * temp.norm();
 
 	// calculate a metric which indicates the amount of high frequency gyro vibration
 	temp = _newest_high_rate_imu_sample.delta_ang - _delta_ang_prev;
 	_delta_ang_prev = _newest_high_rate_imu_sample.delta_ang;
-	_vibe_metrics[1] = 0.99f * _vibe_metrics[1] + 0.01f * temp.norm();
+	_vibe_metrics(1) = 0.99f * _vibe_metrics(1) + 0.01f * temp.norm();
 
 	// calculate a metric which indicates the amount of high frequency accelerometer vibration
 	temp = _newest_high_rate_imu_sample.delta_vel - _delta_vel_prev;
 	_delta_vel_prev = _newest_high_rate_imu_sample.delta_vel;
-	_vibe_metrics[2] = 0.99f * _vibe_metrics[2] + 0.01f * temp.norm();
+	_vibe_metrics(2) = 0.99f * _vibe_metrics(2) + 0.01f * temp.norm();
 }
 
 bool EstimatorInterface::checkIfVehicleAtRest(float dt)
 {
 	// detect if the vehicle is not moving when on ground
 	if (!_control_status.flags.in_air) {
-		if ((_vibe_metrics[1] * 4.0E4f > _params.is_moving_scaler)
-				|| (_vibe_metrics[2] * 2.1E2f > _params.is_moving_scaler)
+		if ((_vibe_metrics(1) * 4.0E4f > _params.is_moving_scaler)
+				|| (_vibe_metrics(2) * 2.1E2f > _params.is_moving_scaler)
 				|| ((_newest_high_rate_imu_sample.delta_ang.norm() / dt) > 0.05f * _params.is_moving_scaler)) {
 
 			_time_last_move_detect_us = _newest_high_rate_imu_sample.time_us;

--- a/EKF/estimator_interface.h
+++ b/EKF/estimator_interface.h
@@ -68,54 +68,53 @@ public:
 
 	virtual bool update() = 0;
 
-	virtual void getGpsVelPosInnov(float hvel[2], float &vvel, float hpos[2], float &vpos) = 0;
-	virtual void getGpsVelPosInnovVar(float hvel[2], float &vvel, float hpos[2], float &vpos) = 0;
-	virtual void getGpsVelPosInnovRatio(float &hvel, float &vvel, float &hpos, float &vpos) = 0;
+	virtual void getGpsVelPosInnov(float hvel[2], float &vvel, float hpos[2], float &vpos) const = 0;
+	virtual void getGpsVelPosInnovVar(float hvel[2], float &vvel, float hpos[2], float &vpos) const = 0;
+	virtual void getGpsVelPosInnovRatio(float &hvel, float &vvel, float &hpos, float &vpos) const = 0;
 
-	virtual void getEvVelPosInnov(float hvel[2], float &vvel, float hpos[2], float &vpos) = 0;
-	virtual void getEvVelPosInnovVar(float hvel[2], float &vvel, float hpos[2], float &vpos) = 0;
-	virtual void getEvVelPosInnovRatio(float &hvel, float &vvel, float &hpos, float &vpos) = 0;
+	virtual void getEvVelPosInnov(float hvel[2], float &vvel, float hpos[2], float &vpos) const = 0;
+	virtual void getEvVelPosInnovVar(float hvel[2], float &vvel, float hpos[2], float &vpos) const = 0;
+	virtual void getEvVelPosInnovRatio(float &hvel, float &vvel, float &hpos, float &vpos) const = 0;
 
-	virtual void getBaroHgtInnov(float &baro_hgt_innov) = 0;
-	virtual void getBaroHgtInnovVar(float &baro_hgt_innov_var) = 0;
-	virtual void getBaroHgtInnovRatio(float &baro_hgt_innov_ratio) = 0;
+	virtual void getBaroHgtInnov(float &baro_hgt_innov) const = 0;
+	virtual void getBaroHgtInnovVar(float &baro_hgt_innov_var) const = 0;
+	virtual void getBaroHgtInnovRatio(float &baro_hgt_innov_ratio) const = 0;
 
-	virtual void getRngHgtInnov(float &rng_hgt_innov) = 0;
-	virtual void getRngHgtInnovVar(float &rng_hgt_innov_var) = 0;
-	virtual void getRngHgtInnovRatio(float &rng_hgt_innov_ratio) = 0;
+	virtual void getRngHgtInnov(float &rng_hgt_innov) const = 0;
+	virtual void getRngHgtInnovVar(float &rng_hgt_innov_var) const = 0;
+	virtual void getRngHgtInnovRatio(float &rng_hgt_innov_ratio) const = 0;
 
-	virtual void getAuxVelInnov(float aux_vel_innov[2]) = 0;
-	virtual void getAuxVelInnovVar(float aux_vel_innov[2]) = 0;
-	virtual void getAuxVelInnovRatio(float &aux_vel_innov_ratio) = 0;
+	virtual void getAuxVelInnov(float aux_vel_innov[2]) const = 0;
+	virtual void getAuxVelInnovVar(float aux_vel_innov[2]) const = 0;
+	virtual void getAuxVelInnovRatio(float &aux_vel_innov_ratio) const = 0;
 
-	virtual void getFlowInnov(float flow_innov[2]) = 0;
-	virtual void getFlowInnovVar(float flow_innov_var[2]) = 0;
-	virtual void getFlowInnovRatio(float &flow_innov_ratio) = 0;
+	virtual void getFlowInnov(float flow_innov[2]) const = 0;
+	virtual void getFlowInnovVar(float flow_innov_var[2]) const = 0;
+	virtual void getFlowInnovRatio(float &flow_innov_ratio) const = 0;
 
-	virtual void getHeadingInnov(float &heading_innov) = 0;
-	virtual void getHeadingInnovVar(float &heading_innov_var) = 0;
-	virtual void getHeadingInnovRatio(float &heading_innov_ratio) = 0;
+	virtual void getHeadingInnov(float &heading_innov) const = 0;
+	virtual void getHeadingInnovVar(float &heading_innov_var) const = 0;
+	virtual void getHeadingInnovRatio(float &heading_innov_ratio) const = 0;
 
-	virtual void getMagInnov(float mag_innov[3]) = 0;
-	virtual void getMagInnovVar(float mag_innov_var[3]) = 0;
-	virtual void getMagInnovRatio(float &mag_innov_ratio) = 0;
+	virtual void getMagInnov(float mag_innov[3]) const = 0;
+	virtual void getMagInnovVar(float mag_innov_var[3]) const = 0;
+	virtual void getMagInnovRatio(float &mag_innov_ratio) const = 0;
 
-	virtual void getDragInnov(float drag_innov[2]) = 0;
-	virtual void getDragInnovVar(float drag_innov_var[2]) = 0;
-	virtual void getDragInnovRatio(float drag_innov_ratio[2]) = 0;
+	virtual void getDragInnov(float drag_innov[2]) const = 0;
+	virtual void getDragInnovVar(float drag_innov_var[2]) const = 0;
+	virtual void getDragInnovRatio(float drag_innov_ratio[2]) const = 0;
 
-	virtual void getAirspeedInnov(float &airspeed_innov) = 0;
-	virtual void getAirspeedInnovVar(float &get_airspeed_innov_var) = 0;
-	virtual void getAirspeedInnovRatio(float &airspeed_innov_ratio) = 0;
+	virtual void getAirspeedInnov(float &airspeed_innov) const = 0;
+	virtual void getAirspeedInnovVar(float &get_airspeed_innov_var) const = 0;
+	virtual void getAirspeedInnovRatio(float &airspeed_innov_ratio) const = 0;
 
-	virtual void getBetaInnov(float &beta_innov) = 0;
-	virtual void getBetaInnovVar(float &get_beta_innov_var) = 0;
-	virtual void getBetaInnovRatio(float &beta_innov_ratio) = 0;
+	virtual void getBetaInnov(float &beta_innov) const = 0;
+	virtual void getBetaInnovVar(float &get_beta_innov_var) const = 0;
+	virtual void getBetaInnovRatio(float &beta_innov_ratio) const = 0;
 
-	virtual void getHaglInnov(float &hagl_innov) = 0;
-	virtual void getHaglInnovVar(float &hagl_innov_var) = 0;
-	virtual void getHaglInnovRatio(float &hagl_innov_ratio) = 0;
-
+	virtual void getHaglInnov(float &hagl_innov) const = 0;
+	virtual void getHaglInnovVar(float &hagl_innov_var) const = 0;
+	virtual void getHaglInnovRatio(float &hagl_innov_ratio) const = 0;
 
 	virtual void get_state_delayed(float *state) = 0;
 

--- a/EKF/terrain_estimator.cpp
+++ b/EKF/terrain_estimator.cpp
@@ -302,7 +302,7 @@ void Ekf::updateTerrainValidity()
 }
 
 // get the estimated vertical position of the terrain relative to the NED origin
-void Ekf::getTerrainVertPos(float *ret)
+float Ekf::getTerrainVertPos() const
 {
-	memcpy(ret, &_terrain_vpos, sizeof(float));
+	return _terrain_vpos;
 }

--- a/test/sensor_simulator/ekf_logger.cpp
+++ b/test/sensor_simulator/ekf_logger.cpp
@@ -58,7 +58,7 @@ void EkfLogger::writeState()
 		_file << time;
 		if(_state_logging_enabled)
 		{
-			matrix::Vector<float, 24> state = _ekf_wrapper.getState();
+			matrix::Vector<float, 24> state = _ekf->getStateAtFusionHorizonAsVector();
 			for(int i = 0; i < 24; i++)
 			{
 				_file << "," << state(i);

--- a/test/sensor_simulator/ekf_wrapper.cpp
+++ b/test/sensor_simulator/ekf_wrapper.cpp
@@ -160,74 +160,12 @@ bool EkfWrapper::isWindVelocityEstimated() const
 	return control_status.flags.wind;
 }
 
-Vector3f EkfWrapper::getPosition() const
-{
-	float temp[3];
-	_ekf->get_position(temp);
-	return Vector3f(temp);
-}
-Vector3f EkfWrapper::getVelocity() const
-{
-	float temp[3];
-	_ekf->get_velocity(temp);
-	return Vector3f(temp);
-}
-Vector3f EkfWrapper::getAccelBias() const
-{
-	float temp[3];
-	_ekf->get_accel_bias(temp);
-	return Vector3f(temp);
-}
-
-Vector3f EkfWrapper::getGyroBias() const
-{
-	float temp[3];
-	_ekf->get_gyro_bias(temp);
-	return Vector3f(temp);
-}
-
-Quatf EkfWrapper::getQuaternion() const
-{
-	return _ekf->get_quaternion();
-}
-
 Eulerf EkfWrapper::getEulerAngles() const
 {
-	return Eulerf(getQuaternion());
-}
-
-matrix::Vector<float, 24> EkfWrapper::getState() const
-{
-	float state[24];
-	_ekf->get_state_delayed(state);
-	return matrix::Vector<float, 24>{state};
+	return Eulerf(_ekf->getQuaternion());
 }
 
 matrix::Vector<float, 4> EkfWrapper::getQuaternionVariance() const
 {
 	return matrix::Vector<float, 4>(_ekf->orientation_covariances().diag());
-}
-
-Vector3f EkfWrapper::getPositionVariance() const
-{
-	return Vector3f(_ekf->position_covariances().diag());
-}
-
-Vector3f EkfWrapper::getVelocityVariance() const
-{
-	return Vector3f(_ekf->velocity_covariances().diag());
-}
-
-Vector2f EkfWrapper::getWindVelocity() const
-{
-	float temp[2];
-	_ekf->get_wind_velocity(temp);
-	return Vector2f(temp);
-}
-
-Quatf EkfWrapper::getVisionAlignmentQuaternion() const
-{
-	float temp[4];
-	_ekf->get_ev2ekf_quaternion(temp);
-	return Quatf(temp);
 }

--- a/test/sensor_simulator/ekf_wrapper.h
+++ b/test/sensor_simulator/ekf_wrapper.h
@@ -85,19 +85,8 @@ public:
 
 	bool isWindVelocityEstimated() const;
 
-	Vector3f getPosition() const;
-	Vector3f getVelocity() const;
-	Vector3f getAccelBias() const;
-	Vector3f getGyroBias() const;
-	Quatf getQuaternion() const;
 	Eulerf getEulerAngles() const;
-	matrix::Vector<float, 24> getState() const;
 	matrix::Vector<float, 4> getQuaternionVariance() const;
-	Vector3f getPositionVariance() const;
-	Vector3f getVelocityVariance() const;
-	Vector2f getWindVelocity() const;
-
-	Quatf getVisionAlignmentQuaternion() const;
 
 private:
 	std::shared_ptr<Ekf> _ekf;

--- a/test/test_EKF_airspeed.cpp
+++ b/test/test_EKF_airspeed.cpp
@@ -88,9 +88,9 @@ TEST_F(EkfAirspeedTest, testWindVelocityEstimation)
 
 	EXPECT_TRUE(_ekf_wrapper.isWindVelocityEstimated());
 
-	const Vector3f vel = _ekf_wrapper.getVelocity();
-	const Vector2f vel_wind_earth = _ekf_wrapper.getWindVelocity();
-	const float height_before_pressure_correction = _ekf_wrapper.getPosition()(2);
+	const Vector3f vel = _ekf->getVelocity();
+	const Vector2f vel_wind_earth = _ekf->getWindVelocity();
+	const float height_before_pressure_correction = _ekf->getPosition()(2);
 
 	const Dcmf R_to_earth_sim(_quat_sim);
 	EXPECT_TRUE(matrix::isEqual(vel, simulated_velocity_earth));
@@ -108,7 +108,7 @@ TEST_F(EkfAirspeedTest, testWindVelocityEstimation)
 
 	_sensor_simulator.runSeconds(20);
 
-	const float height_after_pressure_correction = _ekf_wrapper.getPosition()(2);
+	const float height_after_pressure_correction = _ekf->getPosition()(2);
 	// height increase means that state z decrease due to z axis pointing down
 	const float expected_height_after_pressure_correction = height_before_pressure_correction -
 								expected_height_difference;

--- a/test/test_EKF_basics.cpp
+++ b/test/test_EKF_basics.cpp
@@ -113,11 +113,11 @@ TEST_F(EkfBasicsTest, convergesToZero)
 	// GIVEN: initialized EKF with default IMU, baro and mag input
 	_sensor_simulator.runSeconds(4);
 
-	Vector3f pos = _ekf_wrapper.getPosition();
-	Vector3f vel = _ekf_wrapper.getVelocity();
-	Vector3f accel_bias = _ekf_wrapper.getAccelBias();
-	Vector3f gyro_bias = _ekf_wrapper.getGyroBias();
-	Vector3f ref{0.0f, 0.0f, 0.0f};
+	const Vector3f pos = _ekf->getPosition();
+	const Vector3f vel = _ekf->getVelocity();
+	const Vector3f accel_bias = _ekf->getAccelBias();
+	const Vector3f gyro_bias = _ekf->getGyroBias();
+	const Vector3f ref{0.0f, 0.0f, 0.0f};
 
 	// THEN: EKF should stay or converge to zero
 	EXPECT_TRUE(matrix::isEqual(pos, ref, 0.001f));
@@ -168,17 +168,17 @@ TEST_F(EkfBasicsTest, accleBiasEstimation)
 {
 	// GIVEN: initialized EKF with default IMU, baro and mag input for 3s
 	// WHEN: Added more sensor measurements with accel bias and gps measurements
-	Vector3f accel_bias_sim = {0.0f,0.0f,0.1f};
+	const Vector3f accel_bias_sim = {0.0f,0.0f,0.1f};
 
 	_sensor_simulator.startGps();
 	_sensor_simulator.setImuBias(accel_bias_sim, Vector3f{0.0f,0.0f,0.0f});
 	_sensor_simulator.runSeconds(10);
 
-	Vector3f pos = _ekf_wrapper.getPosition();
-	Vector3f vel = _ekf_wrapper.getVelocity();
-	Vector3f accel_bias = _ekf_wrapper.getAccelBias();
-	Vector3f gyro_bias = _ekf_wrapper.getGyroBias();
-	Vector3f zero{0.0f, 0.0f, 0.0f};
+	const Vector3f pos = _ekf->getPosition();
+	const Vector3f vel = _ekf->getVelocity();
+	const Vector3f accel_bias = _ekf->getAccelBias();
+	const Vector3f gyro_bias = _ekf->getGyroBias();
+	const Vector3f zero{0.0f, 0.0f, 0.0f};
 
 	// THEN: EKF should stay or converge to zero
 	EXPECT_TRUE(matrix::isEqual(pos, zero, 0.01f));

--- a/test/test_EKF_externalVision.cpp
+++ b/test/test_EKF_externalVision.cpp
@@ -103,7 +103,7 @@ TEST_F(EkfExternalVisionTest, checkVisionFusionLogic)
 
 TEST_F(EkfExternalVisionTest, visionVarianceCheck)
 {
-	const Vector3f velVar_init = _ekf_wrapper.getVelocityVariance();
+	const Vector3f velVar_init = _ekf->getVelocityVariance();
 	EXPECT_NEAR(velVar_init(0), velVar_init(1), 0.0001);
 
 	_sensor_simulator._vio.setVelocityVariance(Vector3f{2.0f,0.01f,0.01f});
@@ -111,7 +111,7 @@ TEST_F(EkfExternalVisionTest, visionVarianceCheck)
 	_sensor_simulator.startExternalVision();
 	_sensor_simulator.runSeconds(4);
 
-	const Vector3f velVar_new = _ekf_wrapper.getVelocityVariance();
+	const Vector3f velVar_new = _ekf->getVelocityVariance();
 	EXPECT_TRUE(velVar_new(0) > velVar_new(1));
 }
 
@@ -131,17 +131,17 @@ TEST_F(EkfExternalVisionTest, visionAlignment)
 	_ekf_wrapper.enableExternalVisionVelocityFusion();
 	_sensor_simulator.startExternalVision();
 
-	const Vector3f velVar_init = _ekf_wrapper.getVelocityVariance();
+	const Vector3f velVar_init = _ekf->getVelocityVariance();
 	EXPECT_NEAR(velVar_init(0), velVar_init(1), 0.0001);
 
 	_sensor_simulator.runSeconds(4);
 
 	// THEN: velocity uncertainty in y should be bigger
-	const Vector3f velVar_new = _ekf_wrapper.getVelocityVariance();
+	const Vector3f velVar_new = _ekf->getVelocityVariance();
 	EXPECT_TRUE(velVar_new(1) > velVar_new(0));
 
 	// THEN: the frame offset should be estimated correctly
-	Quatf estimatedExternalVisionFrameOffset = _ekf_wrapper.getVisionAlignmentQuaternion();
+	Quatf estimatedExternalVisionFrameOffset = _ekf->getVisionAlignmentQuaternion();
 	EXPECT_TRUE(matrix::isEqual(externalVisionFrameOffset.canonical(),
 				    estimatedExternalVisionFrameOffset.canonical()));
 }

--- a/test/test_EKF_fusionLogic.cpp
+++ b/test/test_EKF_fusionLogic.cpp
@@ -136,25 +136,25 @@ TEST_F(EkfFusionLogicTest, rejectGpsSignalJump)
 	EXPECT_TRUE(_ekf_wrapper.isIntendingGpsFusion());
 
 	// WHEN: Having a big horizontal position Gps jump coming from the Gps Receiver
-	Vector3f pos_old = _ekf_wrapper.getPosition();
-	Vector3f vel_old = _ekf_wrapper.getVelocity();
-	Vector3f accel_bias_old = _ekf_wrapper.getAccelBias();
+	const Vector3f pos_old = _ekf->getPosition();
+	const Vector3f vel_old = _ekf->getVelocity();
+	const Vector3f accel_bias_old = _ekf->getAccelBias();
 	_sensor_simulator._gps.stepHorizontalPositionByMeters(Vector2f{10.0f, 0.0f});
 	_sensor_simulator.runSeconds(2);
 
 	// THEN: The estimate should not change much in the short run
 	//       and GPS fusion should be stopped after a while.
-	Vector3f pos_new = _ekf_wrapper.getPosition();
-	Vector3f vel_new = _ekf_wrapper.getVelocity();
-	Vector3f accel_bias_new = _ekf_wrapper.getAccelBias();
+	Vector3f pos_new = _ekf->getPosition();
+	Vector3f vel_new = _ekf->getVelocity();
+	Vector3f accel_bias_new = _ekf->getAccelBias();
 	EXPECT_TRUE(matrix::isEqual(pos_new, pos_old, 0.01f));
 	EXPECT_TRUE(matrix::isEqual(vel_new, vel_old, 0.01f));
 	EXPECT_TRUE(matrix::isEqual(accel_bias_new, accel_bias_old, 0.01f));
 
 	_sensor_simulator.runSeconds(10);
-	pos_new = _ekf_wrapper.getPosition();
-	vel_new = _ekf_wrapper.getVelocity();
-	accel_bias_new = _ekf_wrapper.getAccelBias();
+	pos_new = _ekf->getPosition();
+	vel_new = _ekf->getVelocity();
+	accel_bias_new = _ekf->getAccelBias();
 	EXPECT_TRUE(matrix::isEqual(pos_new, pos_old, 0.01f));
 	EXPECT_TRUE(matrix::isEqual(vel_new, vel_old, 0.01f));
 	EXPECT_TRUE(matrix::isEqual(accel_bias_new, accel_bias_old, 0.01f));

--- a/test/test_EKF_initialization.cpp
+++ b/test/test_EKF_initialization.cpp
@@ -64,7 +64,7 @@ class EkfInitializationTest : public ::testing::Test {
 
 	void initializedOrienationIsMatchingGroundTruth(Quatf true_quaternion)
 	{
-		Quatf quat_est = _ekf_wrapper.getQuaternion();
+		const Quatf quat_est = _ekf->getQuaternion();
 		EXPECT_TRUE(matrix::isEqual(quat_est, true_quaternion));
 	}
 
@@ -86,8 +86,8 @@ class EkfInitializationTest : public ::testing::Test {
 
 	void velocityAndPositionCloseToZero()
 	{
-		Vector3f pos = _ekf_wrapper.getPosition();
-		Vector3f vel = _ekf_wrapper.getVelocity();
+		const Vector3f pos = _ekf->getPosition();
+		const Vector3f vel = _ekf->getVelocity();
 
 		EXPECT_TRUE(matrix::isEqual(pos, Vector3f{}, 0.001f));
 		EXPECT_TRUE(matrix::isEqual(vel, Vector3f{}, 0.001f));
@@ -95,8 +95,8 @@ class EkfInitializationTest : public ::testing::Test {
 
 	void velocityAndPositionVarianceBigEnoughAfterOrientationInitialization()
 	{
-		Vector3f pos_var = _ekf_wrapper.getPositionVariance();
-		Vector3f vel_var = _ekf_wrapper.getVelocityVariance();
+		const Vector3f pos_var = _ekf->getPositionVariance();
+		const Vector3f vel_var = _ekf->getVelocityVariance();
 
 		const float pos_variance_limit = 0.2f;
 		EXPECT_TRUE(pos_var(0) > pos_variance_limit) << "pos_var(1)" << pos_var(0);


### PR DESCRIPTION
This PR contains several non-functional improvements regarding style:
- Replace some private float arrays with matrix::Vectors
- Change interface functions to output by return-by-value
- Add const modifier to getters
- Enforce camelCase in changed functions

The flash size is decreasing by roughly 250 Bytes for v4/v5 targets, but for v2 the flash is overflowing by a tiny bit.
During profiling a SITL mission flight, no significant performance difference has been detected.

This is changing the interface. It could be an option to keep the old interface and mark it as deprecated.

Firmware PR: https://github.com/PX4/Firmware/pull/14162

Testing:
- No functional change indicated
- FixedWind [Log](https://review.px4.io/plot_app?log=862caccc-2651-4703-bd9b-65e6406f6d52)
- Multicopter [Log](https://review.px4.io/plot_app?log=288e6bf6-9e3e-48b9-956d-d14a8cb700fd)
- Log fields touched by the interface changes show reasonable data.

TODO:
- [x] Profiling
- [x] Check log files 