### PR TITLE
ekf: fix angle wrapping in realignYawGPS

### DIFF
--- a/EKF/ekf_helper.cpp
+++ b/EKF/ekf_helper.cpp
@@ -406,7 +406,7 @@ bool Ekf::realignYawGPS()
 		const float ekfCOG = atan2f(_state.vel(1), _state.vel(0));
 
 		// Check the EKF and GPS course over ground for consistency
-		const float courseYawError = gpsCOG - ekfCOG;
+		const float courseYawError = wrap_pi(gpsCOG - ekfCOG);
 
 		// If the angles disagree and horizontal GPS velocity innovations are large or no previous yaw alignment, we declare the magnetic yaw as bad
 		const bool badYawErr = fabsf(courseYawError) > 0.5f;


### PR DESCRIPTION
To obtain the correct difference between two angles, we need to wrap
the result between -pi and pi. Otherwise, the difference between two
angles close to 180 degrees but with opposite signs will produce a large
error.

For example if a = -179 and b = 179, b - a = 258 instead of -2 degrees