### PR TITLE
EKF: dont check gps_check_fail_status is velocity reset

### DIFF
--- a/EKF/ekf_helper.cpp
+++ b/EKF/ekf_helper.cpp
@@ -45,7 +45,7 @@
 #include <mathlib/mathlib.h>
 #include <cstdlib>
 
-// Reset the velocity states. If we have a recent and valid
+// Reset the velocity states. If we have a recent
 // gps measurement then use for velocity initialisation
 bool Ekf::resetVelocity()
 {
@@ -53,7 +53,7 @@ bool Ekf::resetVelocity()
 	Vector3f vel_before_reset = _state.vel;
 
 	// reset EKF states
-	if (_control_status.flags.gps && _gps_check_fail_status.value==0) {
+	if (_control_status.flags.gps) {
 		ECL_INFO_TIMESTAMPED("reset velocity to GPS");
 		// this reset is only called if we have new gps data at the fusion time horizon
 		_state.vel = _gps_sample_delayed.vel;

--- a/EKF/ekf_helper.cpp
+++ b/EKF/ekf_helper.cpp
@@ -45,7 +45,7 @@
 #include <mathlib/mathlib.h>
 #include <cstdlib>
 
-// Reset the velocity states. If we have a recent
+// Reset the velocity states. If we have a recent and valid
 // gps measurement then use for velocity initialisation
 bool Ekf::resetVelocity()
 {
@@ -53,7 +53,7 @@ bool Ekf::resetVelocity()
 	Vector3f vel_before_reset = _state.vel;
 
 	// reset EKF states
-	if (_control_status.flags.gps) {
+	if (_control_status.flags.gps && isTimedOut(_last_gps_fail_us, (uint64_t)_min_gps_health_time_us)) {
 		ECL_INFO_TIMESTAMPED("reset velocity to GPS");
 		// this reset is only called if we have new gps data at the fusion time horizon
 		_state.vel = _gps_sample_delayed.vel;


### PR DESCRIPTION
This PR removes a bug that was introduced [here](https://github.com/PX4/ecl/commit/4511b9ff5e0a75c6eb4912b813a62f23ea2cd707) 

In a velocity reset we only used the GPS measurement if `_gps_check_fail_status.value` was equal to zero. The value of this flag is independent of `EKF2_GPS_CHECK` so checks can fail even if they are not configured to have any effect. E.g. on PX4 v1.10.1 the check will always fail if the vehicle is using two GPS modules since the gdop field is set to infinity. (On master gdop is replaced by pdop which is set correctly since https://github.com/PX4/Firmware/pull/13515/files)

My interpretation is that the GPS checks configured to run by `EKF2_GPS_CHECK` and defined by the corresponding threshold parameters are *preflight* checks and should have no influence other than that.