### PR TITLE
WIP: added python script with ekf derivation

### DIFF
--- a/EKF/python/ekf_derivation/__init__.py
+++ b/EKF/python/ekf_derivation/__init__.py
@@ -1,0 +1,8 @@
+#!/usr/bin/env python2
+# -*- coding: utf-8 -*-
+"""
+Created on Sat Mar 14 13:02:26 2020
+
+@author: roman
+"""
+

--- a/EKF/python/ekf_derivation/code_gen.py
+++ b/EKF/python/ekf_derivation/code_gen.py
@@ -12,6 +12,9 @@ class CodeGenerator:
     def __init__(self, file_name):
         self.file_name = file_name
         self.file = open(self.file_name, 'w', buffering=0)
+
+    def print_string(self, string):
+        self.file.write("// " + string + "\n")
         
     def get_ccode(self, expression):
         return ccode(expression, type_aliases={real:float32})
@@ -20,14 +23,16 @@ class CodeGenerator:
         write_string = ""
         for item in subexpressions:
             write_string = write_string + "float " + str(item[0]) + " = " + self.get_ccode(item[1]) + ";\n"
-        
+
         write_string = write_string + "\n\n"
         self.file.write(write_string)
         
     def write_matrix(self, matrix, identifier, is_symmetric=False):
         write_string = ""
-        
-        if matrix.shape[0] == 1 or matrix.shape[1] == 1:
+
+        if matrix.shape[0] * matrix.shape[1] == 1:
+            write_string = write_string + identifier + " = " + self.get_ccode(matrix[0]) + ";\n"
+        elif matrix.shape[0] == 1 or matrix.shape[1] == 1:
             for i in range(0,len(matrix)):
                 write_string = write_string + identifier + "(" + str(i) + ") = " + self.get_ccode(matrix[i]) + ";\n"
         else:

--- a/EKF/python/ekf_derivation/code_gen.py
+++ b/EKF/python/ekf_derivation/code_gen.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python2
+# -*- coding: utf-8 -*-
+"""
+Created on Sat Mar 14 12:47:24 2020
+
+@author: roman
+"""
+from sympy import ccode
+from sympy.codegen.ast import float32, real
+
+class CodeGenerator:
+    def __init__(self, file_name):
+        self.file_name = file_name
+        self.file = open(self.file_name, 'w', buffering=0)
+        
+    def get_ccode(self, expression):
+        return ccode(expression, type_aliases={real:float32})
+        
+    def write_subexpressions(self,subexpressions):
+        write_string = ""
+        for item in subexpressions:
+            write_string = write_string + "float " + str(item[0]) + " = " + self.get_ccode(item[1]) + ";\n"
+        
+        write_string = write_string + "\n\n"
+        self.file.write(write_string)
+        
+    def write_matrix(self, matrix, identifier, is_symmetric=False):
+        write_string = ""
+        
+        if matrix.shape[0] == 1 or matrix.shape[1] == 1:
+            for i in range(0,len(matrix)):
+                write_string = write_string + identifier + "(" + str(i) + ") = " + self.get_ccode(matrix[i]) + ";\n"
+        else:
+            #write_string = "float " + identifier + "[" + str(matrix.shape[0]) + "][" + str(matrix.shape[1]) + "] = {};\n"
+            for j in range(0, matrix.shape[1]):
+                for i in range(0, matrix.shape[0]):
+                    if j >= i or not is_symmetric:
+                        write_string = write_string + identifier + "(" + str(i) + "," + str(j) + ") = " + self.get_ccode(matrix[i,j]) + ";\n"
+
+        write_string = write_string + "\n\n"
+        self.file.write(write_string)
+        
+    def close(self):
+        self.file.close()

--- a/EKF/python/ekf_derivation/main.py
+++ b/EKF/python/ekf_derivation/main.py
@@ -17,7 +17,7 @@ def quat2Rot(q):
 
 def create_cov_matrix(i, j):
     if j >= i:
-        return Symbol("P[" + str(i) + "][" + str(j) + "]", real=True)
+        return Symbol("P(" + str(i) + "," + str(j) + ")", real=True)
     else:
         return 0
     
@@ -49,10 +49,10 @@ def generate_ccode(Input):
         # write a matrix
         write_string = "float " + Input["array_identifier"] + "[" + str(Input["shape"][0]) + "][" + str(Input["shape"][1]) + "] = {};\n"
         
-        for i in range(0, Input["shape"][0]):
-            for j in range(0, Input["shape"][1]):
+        for j in range(0, Input["shape"][1]):
+            for i in range(0, Input["shape"][0]):
                 if j >= i or not Input["symetric_matrix"]:
-                    write_string = write_string + Input["array_identifier"] + "[" + str(i) + "][" + str(j) + "] = " + ccode(Input["data"][i,j]) + ";\n"
+                    write_string = write_string + Input["array_identifier"] + "(" + str(i) + "," + str(j) + ") = " + ccode(Input["data"][i,j]) + ";\n"
     elif  Input["shape"][0] == 0 and Input["shape"][1] == 0:
         for item in Input["data"]:
             write_string = write_string + "float " + str(item[0]) + " = " + ccode(item[1]) + ";\n"

--- a/EKF/python/ekf_derivation/main.py
+++ b/EKF/python/ekf_derivation/main.py
@@ -194,39 +194,39 @@ r_ver_vel = create_symbol("R_vert_vel", real=True) # vertical velocity noise var
 r_hor_pos = create_symbol("R_hor_pos", real=True) # horizontal position noise variance
 
 # inputs, integrated gyro measurements
-d_ang_x = create_symbol("d_ang_x", real=True)  # delta angle x
-d_ang_y = create_symbol("d_ang_y", real=True)  # delta angle y
-d_ang_z = create_symbol("d_ang_z", real=True)  # delta angle z
+d_ang_x = create_symbol("dax", real=True)  # delta angle x
+d_ang_y = create_symbol("day", real=True)  # delta angle y
+d_ang_z = create_symbol("daz", real=True)  # delta angle z
 
 d_ang = Matrix([d_ang_x, d_ang_y, d_ang_z])
 
 # inputs, integrated accelerometer measurements
-d_v_x = create_symbol("d_v_x", real=True)  # delta velocity x
-d_v_y = create_symbol("d_v_y", real=True)  # delta velocity y
-d_v_z = create_symbol("d_v_z", real=True)  # delta velocity z
+d_v_x = create_symbol("dvx", real=True)  # delta velocity x
+d_v_y = create_symbol("dvy", real=True)  # delta velocity y
+d_v_z = create_symbol("dvz", real=True)  # delta velocity z
 
 d_v = Matrix([d_v_x, d_v_y,d_v_z])
 
 u = Matrix([d_ang, d_v])
 
 # input noise
-d_ang_x_var = create_symbol("d_ang_x_var", real=True)
-d_ang_y_var = create_symbol("d_ang_y_var", real=True)
-d_ang_z_var = create_symbol("d_ang_z_var", real=True)
+d_ang_x_var = create_symbol("daxVar", real=True)
+d_ang_y_var = create_symbol("dayVar", real=True)
+d_ang_z_var = create_symbol("dazVar", real=True)
 
-d_v_x_var = create_symbol("d_v_x_var", real=True)
-d_v_y_var = create_symbol("d_v_y_var", real=True)
-d_v_z_var = create_symbol("d_v_z_var", real=True)
+d_v_x_var = create_symbol("dvxVar", real=True)
+d_v_y_var = create_symbol("dvyVar", real=True)
+d_v_z_var = create_symbol("dvzVar", real=True)
 
 var_u = Matrix.diag(d_ang_x_var, d_ang_y_var, d_ang_z_var, d_v_x_var, d_v_y_var, d_v_z_var)
 
 # define state vector
     
 # attitude quaternion
-qw = create_symbol("qw", real=True)  # quaternion real part
-qx = create_symbol("qx", real=True)  # quaternion x component
-qy = create_symbol("qy", real=True)  # quaternion y component
-qz = create_symbol("qz", real=True)  # quaternion z component
+qw = create_symbol("q0", real=True)  # quaternion real part
+qx = create_symbol("q1", real=True)  # quaternion x component
+qy = create_symbol("q2", real=True)  # quaternion y component
+qz = create_symbol("q3", real=True)  # quaternion z component
 
 q = Matrix([qw,qx,qy,qz])
 R_to_earth = quat2Rot(q)
@@ -248,18 +248,18 @@ pz = create_symbol("pz", real=True)  # down position
 p = Matrix([px,py,pz])
 
 # delta angle bias
-d_ang_bx = create_symbol("d_ang_bx", real=True)  # delta angle bias x
-d_ang_by = create_symbol("d_ang_by", real=True)  # delta angle bias y
-d_ang_bz = create_symbol("d_ang_bz", real=True)  # delta angle bias z
+d_ang_bx = create_symbol("dax_b", real=True)  # delta angle bias x
+d_ang_by = create_symbol("day_b", real=True)  # delta angle bias y
+d_ang_bz = create_symbol("daz_b", real=True)  # delta angle bias z
 
 d_ang_b = Matrix([d_ang_bx, d_ang_by, d_ang_bz])
 d_ang_true = d_ang - d_ang_b
 
 
 # delta velocity bias
-d_vel_bx = create_symbol("d_vel_bx", real=True)  # delta velocity bias x
-d_vel_by = create_symbol("d_vel_by", real=True)  # delta velocity bias y
-d_vel_bz = create_symbol("d_vel_bz", real=True)  # delta velocity bias z
+d_vel_bx = create_symbol("dvx_b", real=True)  # delta velocity bias x
+d_vel_by = create_symbol("dvy_b", real=True)  # delta velocity bias y
+d_vel_bz = create_symbol("dvz_b", real=True)  # delta velocity bias z
 
 d_vel_b = Matrix([d_vel_bx, d_vel_by, d_vel_bz])
 
@@ -344,9 +344,9 @@ code_gen_data = {
 
 generate_ccode(code_gen_data)
 
-set_values_for_cov_update({"save_location" : "./generated_python.cpp"})
+#set_values_for_cov_update({"save_location" : "./generated_python.cpp"})
 
-set_values_for_cov_update_matlab({"save_location" : "./generated_matlab.cpp"})
+#set_values_for_cov_update_matlab({"save_location" : "./generated_matlab.cpp"})
 
 
 # magnetometer fusion

--- a/EKF/python/ekf_derivation/main.py
+++ b/EKF/python/ekf_derivation/main.py
@@ -1,0 +1,293 @@
+from sympy import *
+
+# q: quaternion describing rotation from frame 1 to frame 2
+# returns a rotation matrix derived form q which describes the same
+# rotation
+def quat2Rot(q):
+    q0 = q[0]
+    q1 = q[1]
+    q2 = q[2]
+    q3 = q[3]
+
+    Rot = Matrix([[q0**2 + q1**2 - q2**2 - q3**2, 2*(q1*q2 - q0*q3), 2*(q1*q3 + q0*q2)],
+                  [2*(q1*q2 + q0*q3), q0**2 - q1**2 + q2**2 - q3**2, 2*(q2*q3 - q0*q1)],
+                   [2*(q1*q3-q0*q2), 2*(q2*q3 + q0*q1), q0**2 - q1**2 - q2**2 + q3**2]])
+
+    return Rot
+
+def create_cov_matrix(i, j):
+    if j >= i:
+        return Symbol("P_" + str(i) + "_" + str(j) + "", real=True)
+    else:
+        return 0
+    
+def quat_mult(p,q):
+    r = Matrix([p[0] * q[0] - p[1] * q[1] - p[2] * q[2] - p[3] * q[3],
+                p[0] * q[1] + p[1] * q[0] + p[2] * q[3] - p[3] * q[2],
+                p[0] * q[2] - p[1] * q[3] + p[2] * q[0] + p[3] * q[1],
+                p[0] * q[3] + p[1] * q[2] - p[2] * q[1] + p[3] * q[0]])
+    
+    return r
+
+def create_symmetric_cov_matrix():
+    # define a symbolic covariance matrix
+    P = Matrix(24,24,create_cov_matrix)
+
+    for index in range(24):
+        for j in range(24):
+            if index > j:
+                P[index,j] = P[j,index]
+
+    return P
+
+dt = Symbol("dt", real=True)  # dt
+g = Symbol("g", real=True) # gravity constant
+
+r_mag = Symbol("R_mag", real=True)  # magnetometer measurement noise variance
+r_baro = Symbol("R_baro", real=True)    # barometer noise variance
+r_hor_vel = Symbol("R_hor_vel", real=True) # horizontal velocity noise variance
+r_ver_vel = Symbol("R_vert_vel", real=True) # vertical velocity noise variance
+r_hor_pos = Symbol("R_hor_pos", real=True) # horizontal position noise variance
+
+# inputs, integrated gyro measurements
+d_ang_x = Symbol("d_ang_x", real=True)  # delta angle x
+d_ang_y = Symbol("d_ang_y", real=True)  # delta angle y
+d_ang_z = Symbol("d_ang_z", real=True)  # delta angle z
+
+d_ang = Matrix([d_ang_x, d_ang_y, d_ang_z])
+
+# inputs, integrated accelerometer measurements
+d_v_x = Symbol("d_v_x", real=True)  # delta velocity x
+d_v_y = Symbol("d_v_y", real=True)  # delta velocity y
+d_v_z = Symbol("d_v_z", real=True)  # delta velocity z
+
+d_v = Matrix([d_v_x, d_v_y,d_v_z])
+
+u = Matrix([d_ang, d_v])
+
+# input noise
+d_ang_x_var = Symbol("d_ang_x_var", real=True)
+d_ang_y_var = Symbol("d_ang_y_var", real=True)
+d_ang_z_var = Symbol("d_ang_z_var", real=True)
+
+d_v_x_var = Symbol("d_v_x_var", real=True)
+d_v_y_var = Symbol("d_v_y_var", real=True)
+d_v_z_var = Symbol("d_v_z_var", real=True)
+
+var_u = Matrix.diag(d_ang_x_var, d_ang_y_var, d_ang_z_var, d_v_x_var, d_v_y_var, d_v_z_var)
+
+# define state vector
+    
+# attitude quaternion
+qw = Symbol("qw", real=True)  # quaternion real part
+qx = Symbol("qx", real=True)  # quaternion x component
+qy = Symbol("qy", real=True)  # quaternion y component
+qz = Symbol("qz", real=True)  # quaternion z component
+
+q = Matrix([qw,qx,qy,qz])
+R_to_earth = quat2Rot(q)
+R_to_body = R_to_earth.T
+
+
+# velocity in NED local frame
+vx = Symbol("vx", real=True)  # north velocity
+vy = Symbol("vy", real=True)  # east velocity
+vz = Symbol("vz", real=True)  # down velocity
+
+v = Matrix([vx,vy,vz])
+
+# position in NED local frame
+px = Symbol("px", real=True)  # north position
+py = Symbol("py", real=True)  # east position
+pz = Symbol("pz", real=True)  # down position
+
+p = Matrix([px,py,pz])
+
+# delta angle bias
+d_ang_bx = Symbol("d_ang_bx", real=True)  # delta angle bias x
+d_ang_by = Symbol("d_ang_by", real=True)  # delta angle bias y
+d_ang_bz = Symbol("d_ang_bz", real=True)  # delta angle bias z
+
+d_ang_b = Matrix([d_ang_bx, d_ang_by, d_ang_bz])
+d_ang_true = d_ang - d_ang_b
+
+
+# delta velocity bias
+d_vel_bx = Symbol("d_vel_bx", real=True)  # delta velocity bias x
+d_vel_by = Symbol("d_vel_by", real=True)  # delta velocity bias y
+d_vel_bz = Symbol("d_vel_bz", real=True)  # delta velocity bias z
+
+d_vel_b = Matrix([d_vel_bx, d_vel_by, d_vel_bz])
+
+d_vel_true = d_v - d_vel_b
+
+# earth magnetic field vector
+ix = Symbol("ix", real=True)  # earth magnetic field x component
+iy = Symbol("iy", real=True)  # earth magnetic field y component
+iz = Symbol("iz", real=True)  # earth magnetic field z component
+
+i = Matrix([ix,iy,iz])
+
+# magnetometer bias in body frame
+ibx = Symbol("ibx", real=True)  # earth magnetic field bias in body x
+iby = Symbol("iby", real=True)  # earth magnetic field bias in body y
+ibz = Symbol("ibz", real=True)  # earth magnetic field bias in body z
+
+ib = Matrix([ibx,iby,ibz])
+
+# wind in local NE frame
+wx = Symbol("wx", real=True)  # wind in north direction
+wy = Symbol("wy", real=True)  # wind in east direction
+
+w = Matrix([wx,wy])
+
+# state vector at arbitrary time t
+state = Matrix([q,v,p,d_ang_b,d_vel_b,i,ib,w])
+
+# define state propagation
+q_new = quat_mult(q, Matrix([1, 0.5 * d_ang_true[0],  0.5 * d_ang_true[1],  0.5 * d_ang_true[2]]))
+
+v_new = v + R_to_earth * d_vel_true + Matrix([0,0,g]) * dt
+
+p_new = p + v * dt
+
+d_ang_b_new = d_ang_b
+d_vel_b_new = d_vel_b
+i_new = i
+ib_new = ib
+w_new = w
+
+# predicted state vector at time t + dt
+state_new = Matrix([q_new, v_new, p_new, d_ang_b_new, d_vel_b_new, i_new, ib_new, w_new])
+
+# state transition matrix
+A = state_new.jacobian(state)
+
+# B
+G = state_new.jacobian(u)
+
+P = create_symmetric_cov_matrix()
+
+# propagate covariance matrix
+P_new = A * P * A.T + G * var_u * G.T
+
+for index in range(24):
+    for j in range(24):
+        if index > j:
+            P_new[index,j] = 0
+
+
+P_new_simple = cse(P_new, symbols("PS0:400"), optimizations='basic')
+
+
+# magnetometer fusion
+m_mag = R_to_body * i + ib
+
+H_x_mag = Matrix([m_mag[0]]).jacobian(state)
+H_y_mag = Matrix([m_mag[1]]).jacobian(state)
+H_z_mag = Matrix([m_mag[2]]).jacobian(state)
+
+K_x_mag = P * H_x_mag.T / (H_x_mag * P * H_x_mag.T + Matrix([r_mag]))
+K_y_mag = P * H_y_mag.T / (H_y_mag * P * H_y_mag.T + Matrix([r_mag]))
+K_z_mag = P * H_z_mag.T / (H_z_mag * P * H_z_mag.T + Matrix([r_mag]))
+
+K_simple_x = cse(K_x_mag, symbols('KS0:200'))
+K_simple_y = cse(K_y_mag, symbols('KS0:200'))
+K_simple_z = cse(K_z_mag, symbols('KS0:200'))
+
+# velocity fusion
+m_v = v
+H_v = m_v.jacobian(state)
+K_v_x = P * H_v[0,:].T / (H_v[0,:] * P * H_v[0,:].T + Matrix([r_hor_vel]))
+K_v_y = P * H_v[1,:].T / (H_v[1,:] * P * H_v[1,:].T + Matrix([r_hor_vel]))
+K_v_z = P * H_v[2,:].T / (H_v[2,:] * P * H_v[2,:].T + Matrix([r_ver_vel]))
+
+# position fusion
+m_p = p
+H_p = m_p.jacobian(state)
+
+K_p_x = P * H_p[0,:].T / (H_p[0,:] * P * H_p[0,:].T + Matrix([r_hor_pos]))
+K_p_y = P * H_p[1,:].T / (H_p[1,:] * P * H_p[1,:].T + Matrix([r_hor_pos]))
+K_p_z = P * H_p[2,:].T / (H_p[2,:] * P * H_p[2,:].T + Matrix([r_baro]))
+
+#a= P_new.subs([(d_ang_x, 0.1), (d_ang_y, 0.2), (d_ang_z, 0.3), (d_ang_bx, 0.1), (d_ang_by, 0.2), (d_ang_bz, 0.3), (qw, 1), (qx, 0.3), (qy, 0.4), (qz, 0.5), (dt, 0.01), (d_v_x, 0.1), (d_v_y, 0.2), (d_v_z, 0.3), (d_vel_bx, 0.1), (d_vel_by, 0.2), (d_vel_bz, 0.3), (d_ang_x_var, 0.1), (d_ang_y_var, 0.2), (d_ang_z_var, 0.3), (d_v_x_var, 0.1), (d_v_y_var, 0.2), (d_v_z_var, 0.3)])
+#
+#
+#for index in range(24):
+#    for j in range(24):
+#        a = a.subs([(P[index,j], 0.1)])
+#       
+#        
+#sum_P = 0
+#for index in range(24):
+#    for j in range(24):
+#        sum_P = sum_P + a[index,j]
+#        
+#for index in range(24):
+#    sum_P = 0
+#    for j in range(24):
+#        sum_P = sum_P + a[index,j]
+#    
+#    print("sum %s %s") % (str(index), str(sum_P))
+#        
+#s = 0
+#for index in range(24):
+#        print(a[4,index])  
+#        
+## counter number of operations
+#mult = 0
+#sumations = 0
+#
+#for item in P_new_simple[0]:
+#    expression_string = str(item)
+#    
+#    for index,char in enumerate(expression_string):
+#        if char == "+" or char == "-":
+#            sumations = sumations + 1
+#            
+#        if char == "*":
+#            if index > 0 and expression_string[index-1] != "*":
+#                if index < len(expression_string) -1 and expression_string[index+1] != "*":
+#                    mult = mult +1
+#       
+#    
+#for item in P_new_simple[1][0]:
+#    expression_string = str(item)
+#    
+#    for index,char in enumerate(expression_string):
+#        if char == "+" or char == "-":
+#            sumations = sumations + 1
+#            
+#        if char == "*":
+#            if index > 0 and expression_string[index-1] != "*":
+#                if index < len(expression_string) -1 and expression_string[index+1] != "*":
+#                    mult = mult +1
+#
+#
+#f = open("./test.cpp", "r")
+#
+#sum_matlab = 0
+#mult_matlab = 0
+#
+#started = False
+#
+#for line in f.readlines():
+#    if "begin" in line:
+#        started = True
+#        
+#    if "end" in line:
+#         break
+#        
+#    if started:
+#        for index,char in enumerate(line):
+#            if char == "+" or char == "-":
+#                sum_matlab = sum_matlab + 1
+#        
+#            if char == "*":
+#                if index > 0 and line[index-1] != "*":
+#                    if index < len(line) -1 and line[index+1] != "*":
+#                        mult_matlab = mult_matlab +1
+#
+#
+#f.close()
+

--- a/EKF/python/ekf_derivation/main.py
+++ b/EKF/python/ekf_derivation/main.py
@@ -1,4 +1,5 @@
 from sympy import *
+from code_gen import *
 
 # q: quaternion describing rotation from frame 1 to frame 2
 # returns a rotation matrix derived form q which describes the same
@@ -40,149 +41,11 @@ def create_symmetric_cov_matrix():
 
     return P
 
-def generate_ccode(Input):
-    f_output = open(Input["save_location"], "a+")
-    
-    write_string = ""
-    
-    if Input["shape"][0] > 0 and Input["shape"][1] > 0:
-        # write a matrix
-        write_string = "float " + Input["array_identifier"] + "[" + str(Input["shape"][0]) + "][" + str(Input["shape"][1]) + "] = {};\n"
-        
-        for j in range(0, Input["shape"][1]):
-            for i in range(0, Input["shape"][0]):
-                if j >= i or not Input["symetric_matrix"]:
-                    write_string = write_string + Input["array_identifier"] + "(" + str(i) + "," + str(j) + ") = " + ccode(Input["data"][i,j]) + ";\n"
-    elif  Input["shape"][0] == 0 and Input["shape"][1] == 0:
-        for item in Input["data"]:
-            write_string = write_string + "float " + str(item[0]) + " = " + ccode(item[1]) + ";\n"
-    
-    f_output.write(write_string)
-    f_output.close()
-            
-
 def create_symbol(name, real=True):
     symbol_name_list.append(name)
     return Symbol(name, real=True)
 
-def set_values_for_cov_update(Input):
-    f_output = open(Input["save_location"], "a+")
-    
-    for index,item in enumerate(symbol_name_list):
-        write_string = "float " + item + " = " + str(symbol_value_list[item]) + ";\n"
-        f_output.write(write_string)
-    
-    f_output.close()
-    
-def set_values_for_cov_update_matlab(Input):
-    f_output = open(Input["save_location"], "a+")
-    
-    for item in symbol_values_matlab.keys():
-        write_string = "float " + item + " = " + str(symbol_values_matlab[item]) + ";\n"
-        f_output.write(write_string)
-    
-    f_output.close()
-    
-def set_symbol_values():
-    symbol_value_list = {
-           "dt" : 0.01,
-           "g"  : 9.81,
-           "R_mag" : 0.01,
-           "R_baro": 4.0,
-           "R_hor_vel" : 0.1**2,
-           "R_vert_vel" : 0.2**2,
-           "R_hor_pos" : 0.5**2,
-           "d_ang_x" : 0.1,
-           "d_ang_y" : 0.1,
-           "d_ang_z": 0.1,
-           "d_v_x"  : 0.1,
-           "d_v_y"  : 0.1,
-           "d_v_z"  :0.2,
-           "d_ang_x_var" : 0.01**2,
-           "d_ang_y_var" : 0.01**2,
-           "d_ang_z_var" : 0.01**2,
-           "d_v_x_var"  : 0.1**2,
-           "d_v_y_var"  : 0.1**2,
-           "d_v_z_var"  : 0.1**2,
-           "qw"     : 1,
-           "qx"     : 0,
-           "qy"     : 0,
-           "qz"     : 0,
-           "vx"     : 0.1,
-           "vy"     : 0.2,
-           "vz"     : 0.3,
-           "px"     : 0,
-           "py"     : 0,
-           "pz"     : 0,
-           "d_ang_bx" : 0.001,
-           "d_ang_by" : 0.002,
-           "d_ang_bz" : 0.003,
-           "d_vel_bx" : 0.001,
-           "d_vel_by" : 0.002,
-           "d_vel_bz" : 0.003,
-           "ix" : 0.2,
-           "iy" : 0,
-           "iz" : 0.5,
-           "ibx" : 0.01,
-           "iby" : 0.02,
-           "ibz" : 0.03,
-           "wx" : -1,
-           "wy" : 2
-            }
-    return symbol_value_list
-
-def set_symbol_values_matlab():
-    symbol_value_list = {
-           "dt" : 0.01,
-           "g"  : 9.81,
-           "R_mag" : 0.01,
-           "R_baro": 4.0,
-           "R_hor_vel" : 0.1**2,
-           "R_vert_vel" : 0.2**2,
-           "R_hor_pos" : 0.5**2,
-           "dax" : 0.1,
-           "day" : 0.1,
-           "daz": 0.1,
-           "dvx"  : 0.1,
-           "dvy"  : 0.1,
-           "dvz"  :0.2,
-           "daxVar" : 0.01**2,
-           "dayVar" : 0.01**2,
-           "dazVar" : 0.01**2,
-           "dvxVar"  : 0.1**2,
-           "dvyVar"  : 0.1**2,
-           "dvzVar"  : 0.1**2,
-           "q0"     : 1,
-           "q1"     : 0,
-           "q2"     : 0,
-           "q3"     : 0,
-           "vx"     : 0.1,
-           "vy"     : 0.2,
-           "vz"     : 0.3,
-           "px"     : 0,
-           "py"     : 0,
-           "pz"     : 0,
-           "dax_b" : 0.001,
-           "day_b" : 0.002,
-           "daz_b" : 0.003,
-           "dvx_b" : 0.001,
-           "dvy_b" : 0.002,
-           "dvz_b" : 0.003,
-           "ix" : 0.2,
-           "iy" : 0,
-           "iz" : 0.5,
-           "ibx" : 0.01,
-           "iby" : 0.02,
-           "ibz" : 0.03,
-           "wx" : -1,
-           "wy" : 2
-            }
-    return symbol_value_list
-        
-
 symbol_name_list = []
-symbol_value_list = set_symbol_values()
-symbol_values_matlab = set_symbol_values_matlab()
 
 dt = create_symbol("dt", real=True)  # dt
 g = create_symbol("g", real=True) # gravity constant
@@ -322,34 +185,14 @@ for index in range(24):
 
 
 P_new_simple = cse(P_new, symbols("PS0:400"), optimizations='basic')
-Psimple = Matrix(P_new_simple[1])
 
+cov_code_generator = CodeGenerator("./covariance_generated.cpp")
+cov_code_generator.write_subexpressions(P_new_simple[0])
+cov_code_generator.write_matrix(Matrix(P_new_simple[1]), "nextP", True)
 
-code_gen_data = {
-     "data" : P_new_simple[0],
-     "shape" : (0,0),
-     "save_location" : "./generated_python.cpp"
-     }
+cov_code_generator.close()
 
-generate_ccode(code_gen_data)
-
-            
-code_gen_data = {
-     "data" : Psimple,
-     "shape" : (24,24),
-     "array_identifier" : "nextP",
-     "symetric_matrix" : True,
-     "save_location" : "./generated_python.cpp"
-     }
-
-generate_ccode(code_gen_data)
-
-#set_values_for_cov_update({"save_location" : "./generated_python.cpp"})
-
-#set_values_for_cov_update_matlab({"save_location" : "./generated_matlab.cpp"})
-
-
-# magnetometer fusion
+# 3D magnetometer fusion
 m_mag = R_to_body * i + ib
 
 H_x_mag = Matrix([m_mag[0]]).jacobian(state)
@@ -360,9 +203,22 @@ K_x_mag = P * H_x_mag.T / (H_x_mag * P * H_x_mag.T + Matrix([r_mag]))
 K_y_mag = P * H_y_mag.T / (H_y_mag * P * H_y_mag.T + Matrix([r_mag]))
 K_z_mag = P * H_z_mag.T / (H_z_mag * P * H_z_mag.T + Matrix([r_mag]))
 
-K_simple_x = cse(K_x_mag, symbols('KS0:200'))
-K_simple_y = cse(K_y_mag, symbols('KS0:200'))
-K_simple_z = cse(K_z_mag, symbols('KS0:200'))
+K_simple_x = cse(K_x_mag, symbols('KSX0:200'))
+K_simple_y = cse(K_y_mag, symbols('KSY0:200'))
+K_simple_z = cse(K_z_mag, symbols('KSZ0:200'))
+
+mag_code_generator = CodeGenerator("./3Dmag_generated.cpp")
+
+mag_code_generator.write_subexpressions(K_simple_x[0])
+mag_code_generator.write_matrix(Matrix(K_simple_x[1]), "Kx")
+
+mag_code_generator.write_subexpressions(K_simple_y[0])
+mag_code_generator.write_matrix(Matrix(K_simple_y[1]), "Ky")
+
+mag_code_generator.write_subexpressions(K_simple_z[0])
+mag_code_generator.write_matrix(Matrix(K_simple_z[1]), "Kz")
+
+mag_code_generator.close()
 
 # velocity fusion
 m_v = v
@@ -370,6 +226,23 @@ H_v = m_v.jacobian(state)
 K_v_x = P * H_v[0,:].T / (H_v[0,:] * P * H_v[0,:].T + Matrix([r_hor_vel]))
 K_v_y = P * H_v[1,:].T / (H_v[1,:] * P * H_v[1,:].T + Matrix([r_hor_vel]))
 K_v_z = P * H_v[2,:].T / (H_v[2,:] * P * H_v[2,:].T + Matrix([r_ver_vel]))
+
+K_v_x_simple = cse(K_v_x, symbols('KSX0:200'))
+K_v_y_simple = cse(K_v_y, symbols('KSY0:200'))
+K_v_z_simple = cse(K_v_z, symbols('KSZ0:200'))
+
+vel_code_generator = CodeGenerator("velocity_generated.cpp")
+vel_code_generator.write_subexpressions(K_v_x_simple[0])
+vel_code_generator.write_matrix(Matrix(K_v_x_simple[1]), "Kvx")
+
+vel_code_generator.write_subexpressions(K_v_y_simple[0])
+vel_code_generator.write_matrix(Matrix(K_v_y_simple[1]), "Kvy")
+
+vel_code_generator.write_subexpressions(K_v_z_simple[0])
+vel_code_generator.write_matrix(Matrix(K_v_z_simple[1]), "Kvz")
+
+vel_code_generator.close()
+
 
 # position fusion
 m_p = p
@@ -379,84 +252,22 @@ K_p_x = P * H_p[0,:].T / (H_p[0,:] * P * H_p[0,:].T + Matrix([r_hor_pos]))
 K_p_y = P * H_p[1,:].T / (H_p[1,:] * P * H_p[1,:].T + Matrix([r_hor_pos]))
 K_p_z = P * H_p[2,:].T / (H_p[2,:] * P * H_p[2,:].T + Matrix([r_baro]))
 
-a= P_new.subs([(d_ang_x, 0.1), (d_ang_y, 0.2), (d_ang_z, 0.3), (d_ang_bx, 0.1), (d_ang_by, 0.2), (d_ang_bz, 0.3), (qw, 1), (qx, 0.3), (qy, 0.4), (qz, 0.5), (dt, 0.01), (d_v_x, 0.1), (d_v_y, 0.2), (d_v_z, 0.3), (d_vel_bx, 0.1), (d_vel_by, 0.2), (d_vel_bz, 0.3), (d_ang_x_var, 0.1), (d_ang_y_var, 0.2), (d_ang_z_var, 0.3), (d_v_x_var, 0.1), (d_v_y_var, 0.2), (d_v_z_var, 0.3)])
+K_p_x_simple = cse(K_p_x, symbols('KSX0:200'))
+K_p_y_simple = cse(K_p_y, symbols('KSY0:200'))
+K_p_z_simple = cse(K_p_z, symbols('KSZ0:200'))
+
+pos_code_generator = CodeGenerator("./position_generated.cpp")
+
+pos_code_generator.write_subexpressions(K_p_x_simple[0])
+pos_code_generator.write_matrix(Matrix(K_p_x_simple[1]), "Kpx")
+
+pos_code_generator.write_subexpressions(K_p_y_simple[0])
+pos_code_generator.write_matrix(Matrix(K_p_y_simple[1]), "Kpy")
+
+pos_code_generator.write_subexpressions(K_p_z_simple[0])
+pos_code_generator.write_matrix(Matrix(K_p_z_simple[1]), "Kpz")
+
+pos_code_generator.close()
 
 
-for index in range(24):
-    for j in range(24):
-        a = a.subs([(P[index,j], 0.1)])
-       
-        
-sum_P = 0
-for index in range(24):
-    for j in range(24):
-        sum_P = sum_P + a[index,j]
-        
-for index in range(24):
-    sum_P = 0
-    for j in range(24):
-        sum_P = sum_P + a[index,j]
-    
-    print("sum %s %s") % (str(index), str(sum_P))
-        
-s = 0
-for index in range(24):
-        print(a[4,index])  
-        
-# counter number of operations
-mult = 0
-sumations = 0
-
-for item in P_new_simple[0]:
-    expression_string = str(item)
-    
-    for index,char in enumerate(expression_string):
-        if char == "+" or char == "-":
-            sumations = sumations + 1
-            
-        if char == "*":
-            if index > 0 and expression_string[index-1] != "*":
-                if index < len(expression_string) -1 and expression_string[index+1] != "*":
-                    mult = mult +1
-       
-    
-for item in P_new_simple[1][0]:
-    expression_string = str(item)
-    
-    for index,char in enumerate(expression_string):
-        if char == "+" or char == "-":
-            sumations = sumations + 1
-            
-        if char == "*":
-            if index > 0 and expression_string[index-1] != "*":
-                if index < len(expression_string) -1 and expression_string[index+1] != "*":
-                    mult = mult +1
-
-
-f = open("./test.cpp", "r")
-
-sum_matlab = 0
-mult_matlab = 0
-
-started = False
-
-for line in f.readlines():
-    if "begin" in line:
-        started = True
-        
-    if "end" in line:
-         break
-        
-    if started:
-        for index,char in enumerate(line):
-            if char == "+" or char == "-":
-                sum_matlab = sum_matlab + 1
-        
-            if char == "*":
-                if index > 0 and line[index-1] != "*":
-                    if index < len(line) -1 and line[index+1] != "*":
-                        mult_matlab = mult_matlab +1
-
-
-f.close()
 


### PR DESCRIPTION
### Motivation
Some time ago I decided to implement the 24 state EKF filter equations in python for the following reasons:

- I do not have a Matlab license anymore
- I wanted to be able to derive the equations quickly and not wait for 3 hours every time I change something
- I wanted to use this in combination with an editor which allows me to interact with the equations once they were generated

### What's the state of this
So far I have implemented:

- definition of states and state propagation
- derivation of covariance matrix prediction and simplification (most interesting one)
- derivation of 3D mag fusion
- derivation of vel/pos fusion

I used simpy's [cse](https://docs.sympy.org/latest/modules/rewriting.html#common-subexpression-detection-and-collection) for doing common subexpression detection.
My initial observation with this comparing to the brute force algorithm implemented in Matlab is:

- it's very fast, simplifying the covariance matrix update takes between 10 and 20 seconds
- it produces more intermediate variables than the matlab version
- it produces code with less mathematical operations (+, -, *)

### Verification of the equations
In order to test the correctness of the equations I numerically evaluated the predicted covariance matrix using random numbers. I then summed each row of the covariance matrix and compared the values between the two derivations (c++ code generated by matlab and the python code).
The values look exactly the same as seen in the figure below.
So I'm currently assuming that the derivation is mathematically correct and there are no big mistakes in the code anymore. This was just some initial experiment though, this needs to be done properly moving forward.
![image](https://user-images.githubusercontent.com/7610489/75423521-efe0d880-594f-11ea-8b97-ba89ecaf7879.png)

Update:
Compared the executing time of the covariance matrix update between this derivation here and the one from matlab. I ran both versions for 10000 times in a loop side by side and evaluated the performance using calgrind. The resulting graph can be seen below:
![image](https://user-images.githubusercontent.com/7610489/75807382-59b91200-5d96-11ea-9159-3be5b0686943.png)

I also noticed some slight differences in the numerical result of the predicted covariance matrix between the two derivations. The figure below shows two matrices:
1) The difference between the predicted matrices, e.g. `P_next_matlab - P_next_python` multiplied by a factor of 1e6 in order to make the error more visible.
2) The second matrix shows the same error but relative  to `P_next - P` in percent. In other words, "how big are those differences in magnitude compared to the delta you add to `P` in order to arrive at `P_next` "
I wanted to figure out if the small differences seen in 1) are negligible, and it seems like they are.
However, it would still be nice to figure out where those differences come from.
![image](https://user-images.githubusercontent.com/7610489/75807990-6b4ee980-5d97-11ea-8468-5f4b0521987c.png)

**Update**
Converted all floats to double in both derivations and the errors are gone!



### Editor
I was using [spyder](https://www.spyder-ide.org/) which allows you to interact with the script.

fixes https://github.com/PX4/ecl/issues/667