### PR TITLE
EKF: Don't allow alignment if vehicle is moving excessively

### DIFF
--- a/EKF/ekf.h
+++ b/EKF/ekf.h
@@ -445,12 +445,15 @@ private:
 	uint64_t _last_gps_origin_time_us{0};	///< time the origin was last set (uSec)
 	float _gps_alt_ref{0.0f};		///< WGS-84 height (m)
 
-	// Variables used to initialise the filter states
+	// Variables used by the initial filter alignment
 	bool _is_first_imu_sample{true};
 	uint32_t _baro_counter{0};		///< number of baro samples read during initialisation
 	uint32_t _mag_counter{0};		///< number of magnetometer samples read during initialisation
-	AlphaFilterVector3f _mag_lpf;		///< filtered magnetometer measurement for instant reset(Gauss)
-	AlphaFilterVector3f _accel_lpf;		///< filtered accelerometer measurement for instant reset(Gauss)
+	AlphaFilterVector3f _accel_lpf;		///< filtered accelerometer measurement used to align tilt (m/s/s)
+	AlphaFilterVector3f _gyro_lpf;		///< filtered gyro measurement used for alignment excessive movement check (rad/sec)
+
+	// Variables used to perform in flight resets and switch between height sources
+	AlphaFilterVector3f _mag_lpf;		///< filtered magnetometer measurement for instant reset (Gauss)
 	float _hgt_sensor_offset{0.0f};		///< set as necessary if desired to maintain the same height after a height reset (m)
 	float _baro_hgt_offset{0.0f};		///< baro height reading at the local NED origin (m)
 


### PR DESCRIPTION
Should fix https://github.com/PX4/ecl/issues/744

The code was missing sanity checking of the accel vector length and angular motion.

Has been tested on replay and passes checks. The accel and gyro thresholds should be able to be met on a moving platform such as a boat, but there will be some delay as it waits for the conditions to be met. Ground testing with movement is required to verify that the thresholds are appropriate. We can adjust on replay. 