### PR TITLE
Small height reset cleanup

### DIFF
--- a/EKF/control.cpp
+++ b/EKF/control.cpp
@@ -811,8 +811,6 @@ void Ekf::controlHeightSensorTimeouts()
 				ECL_WARN_TIMESTAMPED("baro hgt timeout - reset to GPS");
 
 			} else if (!_baro_hgt_faulty) {
-				setControlBaroHeight();
-
 				request_height_reset = true;
 				ECL_WARN_TIMESTAMPED("baro hgt timeout - reset to baro");
 			}
@@ -839,8 +837,6 @@ void Ekf::controlHeightSensorTimeouts()
 				ECL_WARN_TIMESTAMPED("gps hgt timeout - reset to baro");
 
 			} else if (!_gps_hgt_intermittent) {
-				setControlGPSHeight();
-
 				request_height_reset = true;
 				ECL_WARN_TIMESTAMPED("gps hgt timeout - reset to GPS");
 			}
@@ -848,8 +844,6 @@ void Ekf::controlHeightSensorTimeouts()
 		} else if (_control_status.flags.rng_hgt) {
 
 			if (_rng_hgt_valid) {
-				setControlRangeHeight();
-
 				request_height_reset = true;
 				ECL_WARN_TIMESTAMPED("rng hgt timeout - reset to rng hgt");
 
@@ -866,8 +860,6 @@ void Ekf::controlHeightSensorTimeouts()
 			const bool ev_data_available = isRecent(ev_init.time_us, 2 * EV_MAX_INTERVAL);
 
 			if (ev_data_available) {
-				setControlEVHeight();
-
 				request_height_reset = true;
 				ECL_WARN_TIMESTAMPED("ev hgt timeout - reset to ev hgt");
 
@@ -884,7 +876,6 @@ void Ekf::controlHeightSensorTimeouts()
 			resetHeight();
 			// Reset the timout timer
 			_time_last_hgt_fuse = _time_last_imu;
-
 		}
 	}
 }

--- a/EKF/ekf.h
+++ b/EKF/ekf.h
@@ -714,6 +714,8 @@ private:
 	// control for height sensor timeouts, sensor changes and state resets
 	void controlHeightSensorTimeouts();
 
+	void checkVerticalAccelerationHealth();
+
 	// control for combined height fusion mode (implemented for switching between baro and range height)
 	void controlHeightFusion();
 

--- a/EKF/ekf_helper.cpp
+++ b/EKF/ekf_helper.cpp
@@ -227,20 +227,19 @@ void Ekf::resetHeight()
 
 	// reset the vertical position
 	if (_control_status.flags.rng_hgt) {
+		float new_pos_down = _hgt_sensor_offset - _range_sample_delayed.rng * _R_rng_to_earth_2_2;
 
-			float new_pos_down = _hgt_sensor_offset - _range_sample_delayed.rng * _R_rng_to_earth_2_2;
+		// update the state and associated variance
+		_state.pos(2) = new_pos_down;
 
-			// update the state and associated variance
-			_state.pos(2) = new_pos_down;
+		// the state variance is the same as the observation
+		P.uncorrelateCovarianceSetVariance<1>(9, sq(_params.range_noise));
 
-			// the state variance is the same as the observation
-			P.uncorrelateCovarianceSetVariance<1>(9, sq(_params.range_noise));
+		vert_pos_reset = true;
 
-			vert_pos_reset = true;
-
-			// reset the baro offset which is subtracted from the baro reading if we need to use it as a backup
-			const baroSample &baro_newest = _baro_buffer.get_newest();
-			_baro_hgt_offset = baro_newest.hgt + _state.pos(2);
+		// reset the baro offset which is subtracted from the baro reading if we need to use it as a backup
+		const baroSample &baro_newest = _baro_buffer.get_newest();
+		_baro_hgt_offset = baro_newest.hgt + _state.pos(2);
 
 	} else if (_control_status.flags.baro_hgt) {
 		// initialize vertical position with newest baro measurement

--- a/EKF/ekf_helper.cpp
+++ b/EKF/ekf_helper.cpp
@@ -246,7 +246,7 @@ void Ekf::resetHeight()
 		// initialize vertical position with newest baro measurement
 		const baroSample &baro_newest = _baro_buffer.get_newest();
 
-		if (isRecent(baro_newest.time_us, 2 * BARO_MAX_INTERVAL)) {
+		if (!_baro_hgt_faulty) {
 			_state.pos(2) = _hgt_sensor_offset - baro_newest.hgt + _baro_hgt_offset;
 
 			// the state variance is the same as the observation
@@ -260,7 +260,7 @@ void Ekf::resetHeight()
 
 	} else if (_control_status.flags.gps_hgt) {
 		// initialize vertical position and velocity with newest gps measurement
-		if (isRecent(gps_newest.time_us, 2 * GPS_MAX_INTERVAL)) {
+		if (!_gps_hgt_intermittent) {
 			_state.pos(2) = _hgt_sensor_offset - gps_newest.hgt + _gps_alt_ref;
 
 			// the state variance is the same as the observation
@@ -296,7 +296,7 @@ void Ekf::resetHeight()
 	}
 
 	// reset the vertical velocity state
-	if (_control_status.flags.gps && isRecent(gps_newest.time_us, 2 * GPS_MAX_INTERVAL)) {
+	if (_control_status.flags.gps && !_gps_hgt_intermittent) {
 		// If we are using GPS, then use it to reset the vertical velocity
 		_state.vel(2) = gps_newest.vel(2);
 


### PR DESCRIPTION
Summary:
- replace all the `isRecent(gps_newest.time_us, 2 * GPS_MAX_INTERVAL)` by `!_gps_hgt_intermittent`, because it is already computed here: https://github.com/PX4/ecl/blob/93be6ea49a22b08a4bc42010a7c537640eae09fc/EKF/control.cpp#L91-L92
replace all the `isRecent(baro_init.time_us, 2 * BARO_MAX_INTERVAL)` by `!_baro_hgt_faulty`, because it is already computed here: https://github.com/PX4/ecl/blob/93be6ea49a22b08a4bc42010a7c537640eae09fc/EKF/control.cpp#L88-L89
- remove the useless setControl...Height() when the fusion mode is alredy active: 
e.g.:
```c++
if(_control_status.flags.baro_hgt) {
   ...
   setControlBaroHeight();
   ...
}
```
- extract the check of vertical velocity divergence due to accelerometer clipping to `checkVerticalAccelerationHealth()`

**Note** : it should be easy to review commit-by-commit