### PR TITLE
[RFC] EKF filter update period with IMU samples (parameterized)

### DIFF
--- a/EKF/common.h
+++ b/EKF/common.h
@@ -201,6 +201,9 @@ struct auxVelSample {
 #define GNDEFFECT_TIMEOUT	10E6	///< Maximum period of time that ground effect protection will be active after it was last turned on (uSec)
 
 struct parameters {
+
+	int32_t filter_update_imu_samples{2};
+
 	// measurement source control
 	int32_t fusion_mode{MASK_USE_GPS};		///< bitmasked integer that selects which aiding sources will be used
 	int32_t vdist_sensor_type{VDIST_SENSOR_BARO};	///< selects the primary source for height data

--- a/EKF/control.cpp
+++ b/EKF/control.cpp
@@ -602,7 +602,7 @@ void Ekf::controlGpsFusion()
 					if (_mag_inhibit_yaw_reset_req) {
 						_mag_inhibit_yaw_reset_req = false;
 						// Zero the yaw bias covariance and set the variance to the initial alignment uncertainty
-						P.uncorrelateCovarianceSetVariance<1>(12, sq(_params.switch_on_gyro_bias * FILTER_UPDATE_PERIOD_S));
+						P.uncorrelateCovarianceSetVariance<1>(12, sq(_params.switch_on_gyro_bias * _dt_ekf_avg));
 					}
 				}
 

--- a/EKF/covariance.cpp
+++ b/EKF/covariance.cpp
@@ -55,7 +55,7 @@ void Ekf::initialiseCovariance()
 	_delta_angle_bias_var_accum.setZero();
 	_delta_vel_bias_var_accum.setZero();
 
-	const float dt = FILTER_UPDATE_PERIOD_S;
+	const float dt = _dt_ekf_avg;
 
 	// define the initial angle uncertainty as variances for a rotation vector
 	Vector3f rot_vec_var;
@@ -147,7 +147,7 @@ void Ekf::predictCovariance()
 	const float dvy_b = _state.delta_vel_bias(1);
 	const float dvz_b = _state.delta_vel_bias(2);
 
-	const float dt = math::constrain(_imu_sample_delayed.delta_ang_dt, 0.5f * FILTER_UPDATE_PERIOD_S, 2.0f * FILTER_UPDATE_PERIOD_S);
+	const float dt = math::constrain(_imu_sample_delayed.delta_ang_dt, 0.5f * _dt_ekf_avg, 2.0f * _dt_ekf_avg);
 	const float dt_inv = 1.0f / dt;
 
 	// convert rate of change of rate gyro bias (rad/s**2) as specified by the parameter to an expected change in delta angle (rad) since the last update

--- a/EKF/ekf.cpp
+++ b/EKF/ekf.cpp
@@ -81,7 +81,7 @@ void Ekf::reset()
 	_control_status.value = 0;
 	_control_status_prev.value = 0;
 
-	_dt_ekf_avg = FILTER_UPDATE_PERIOD_S;
+	_dt_ekf_avg = _params.filter_update_imu_samples * 0.004f; // TODO: use real data?
 
 	_fault_status.value = 0;
 	_innov_check_fail_status.value = 0;
@@ -282,11 +282,10 @@ void Ekf::predictState()
 	constrainStates();
 
 	// calculate an average filter update time
-	float input = 0.5f * (_imu_sample_delayed.delta_vel_dt + _imu_sample_delayed.delta_ang_dt);
+	const float input = 0.5f * (_imu_sample_delayed.delta_vel_dt + _imu_sample_delayed.delta_ang_dt);
 
-	// filter and limit input between -50% and +100% of nominal value
-	input = math::constrain(input, 0.5f * FILTER_UPDATE_PERIOD_S, 2.0f * FILTER_UPDATE_PERIOD_S);
-	_dt_ekf_avg = 0.99f * _dt_ekf_avg + 0.01f * input;
+	// filter and limit input between 2-20 ms
+	_dt_ekf_avg = 0.99f * _dt_ekf_avg + 0.01f * math::constrain(input, 0.002f, 0.02f);
 }
 
 /*

--- a/EKF/ekf.h
+++ b/EKF/ekf.h
@@ -301,9 +301,6 @@ private:
 		Quatf quat_change;	///< quaternion delta due to last reset - multiply pre-reset quaternion by this to get post-reset quaternion
 	} _state_reset_status{};	///< reset event monitoring structure containing velocity, position, height and yaw reset information
 
-	float _dt_ekf_avg{FILTER_UPDATE_PERIOD_S}; ///< average update rate of the ekf
-	float _dt_update{0.01f}; ///< delta time since last ekf update. This time can be used for filters which run at the same rate as the Ekf::update() function. (sec)
-
 	stateSample _state{};		///< state struct of the ekf running at the delayed time horizon
 
 	bool _filter_initialised{false};	///< true when the EKF sttes and covariances been initialised
@@ -341,7 +338,6 @@ private:
 	uint64_t _time_last_fake_pos{0};	///< last time we faked position measurements to constrain tilt errors during operation without external aiding (uSec)
 
 	Vector2f _last_known_posNE;		///< last known local NE position vector (m)
-	float _imu_collection_time_adj{0.0f};	///< the amount of time the IMU collection needs to be advanced to meet the target set by FILTER_UPDATE_PERIOD_MS (sec)
 
 	uint64_t _time_acc_bias_check{0};	///< last time the  accel bias check passed (uSec)
 	uint64_t _delta_time_baro_us{0};	///< delta time between two consecutive delayed baro samples from the buffer (uSec)

--- a/EKF/ekf_helper.cpp
+++ b/EKF/ekf_helper.cpp
@@ -1270,8 +1270,8 @@ bool Ekf::reset_imu_bias()
 
 	// Zero the corresponding covariances and set
 	// variances to the values use for initial alignment
-	P.uncorrelateCovarianceSetVariance<3>(10, sq(_params.switch_on_gyro_bias * FILTER_UPDATE_PERIOD_S));
-	P.uncorrelateCovarianceSetVariance<3>(13, sq(_params.switch_on_accel_bias * FILTER_UPDATE_PERIOD_S));
+	P.uncorrelateCovarianceSetVariance<3>(10, sq(_params.switch_on_gyro_bias * _dt_ekf_avg));
+	P.uncorrelateCovarianceSetVariance<3>(13, sq(_params.switch_on_accel_bias * _dt_ekf_avg));
 	_last_imu_bias_cov_reset_us = _imu_sample_delayed.time_us;
 
 	// Set previous frame values
@@ -1370,8 +1370,8 @@ void Ekf::fuse(float *K, float innovation)
 
 void Ekf::uncorrelateQuatFromOtherStates()
 {
-	P.slice<_k_num_states - 4, 4>(4, 0) = 0.f;	
-	P.slice<4, _k_num_states - 4>(0, 4) = 0.f;	
+	P.slice<_k_num_states - 4, 4>(4, 0) = 0.f;
+	P.slice<4, _k_num_states - 4>(0, 4) = 0.f;
 }
 
 bool Ekf::global_position_is_valid()

--- a/EKF/estimator_interface.cpp
+++ b/EKF/estimator_interface.cpp
@@ -156,7 +156,7 @@ void EstimatorInterface::setMagData(const magSample &mag_sample)
 		// Use the time in the middle of the downsampling interval for the sample
 		mag_sample_new.time_us = 1000 * (_mag_timestamp_sum / _mag_sample_count);
 		mag_sample_new.time_us -= _params.mag_delay_ms * 1000;
-		mag_sample_new.time_us -= FILTER_UPDATE_PERIOD_MS * 1000 / 2;
+		mag_sample_new.time_us -= _dt_ekf_avg * 5e5f; // filter update period (us) divided by 2
 
 		mag_sample_new.mag = _mag_data_sum / _mag_sample_count;
 
@@ -195,7 +195,7 @@ void EstimatorInterface::setGpsData(const gps_message &gps)
 		gpsSample gps_sample_new;
 
 		gps_sample_new.time_us = gps.time_usec - _params.gps_delay_ms * 1000;
-		gps_sample_new.time_us -= FILTER_UPDATE_PERIOD_MS * 1000 / 2;
+		gps_sample_new.time_us -= _dt_ekf_avg * 5e5f; // filter update period (us) divided by 2
 
 		gps_sample_new.vel = gps.vel_ned;
 
@@ -265,7 +265,7 @@ void EstimatorInterface::setBaroData(const baroSample &baro_sample)
 		// Use the time in the middle of the downsampling interval for the sample
 		baro_sample_new.time_us = 1000 * (_baro_timestamp_sum / _baro_sample_count);
 		baro_sample_new.time_us -= _params.baro_delay_ms * 1000;
-		baro_sample_new.time_us -= FILTER_UPDATE_PERIOD_MS * 1000 / 2;
+		baro_sample_new.time_us -= _dt_ekf_avg * 5e5f; // filter update period (us) divided by 2
 
 		_baro_buffer.push(baro_sample_new);
 
@@ -299,7 +299,7 @@ void EstimatorInterface::setAirspeedData(const airspeedSample &airspeed_sample)
 		airspeedSample airspeed_sample_new = airspeed_sample;
 
 		airspeed_sample_new.time_us -= _params.airspeed_delay_ms * 1000;
-		airspeed_sample_new.time_us -= FILTER_UPDATE_PERIOD_MS * 1000 / 2;
+		airspeed_sample_new.time_us -= _dt_ekf_avg * 5e5f; // filter update period (us) divided by 2
 
 		_airspeed_buffer.push(airspeed_sample_new);
 	}
@@ -328,7 +328,7 @@ void EstimatorInterface::setRangeData(const rangeSample& range_sample)
 
 		rangeSample range_sample_new = range_sample;
 		range_sample_new.time_us -= _params.range_delay_ms * 1000;
-		range_sample_new.time_us -= FILTER_UPDATE_PERIOD_MS * 1000 / 2;
+		range_sample_new.time_us -= _dt_ekf_avg * 5e5f; // filter update period (us) divided by 2
 
 		_range_buffer.push(range_sample_new);
 	}
@@ -386,7 +386,7 @@ void EstimatorInterface::setOpticalFlowData(const flowSample& flow)
 			flowSample optflow_sample_new = flow;
 
 			optflow_sample_new.time_us -= _params.flow_delay_ms * 1000;
-			optflow_sample_new.time_us -= FILTER_UPDATE_PERIOD_MS * 1000 / 2;
+			optflow_sample_new.time_us -= _dt_ekf_avg * 5e5f; // filter update period (us) divided by 2
 
 			optflow_sample_new.dt = delta_time;
 
@@ -420,7 +420,7 @@ void EstimatorInterface::setExtVisionData(const extVisionSample& evdata)
 		extVisionSample ev_sample_new = evdata;
 		// calculate the system time-stamp for the mid point of the integration period
 		ev_sample_new.time_us -= _params.ev_delay_ms * 1000;
-		ev_sample_new.time_us -= FILTER_UPDATE_PERIOD_MS * 1000 / 2;
+		ev_sample_new.time_us -= _dt_ekf_avg * 5e5f; // filter update period (us) divided by 2
 
 		_ext_vision_buffer.push(ev_sample_new);
 	}
@@ -450,7 +450,7 @@ void EstimatorInterface::setAuxVelData(const auxVelSample& auxvel_sample)
 		auxVelSample auxvel_sample_new = auxvel_sample;
 
 		auxvel_sample_new.time_us -= _params.auxvel_delay_ms * 1000;
-		auxvel_sample_new.time_us -= FILTER_UPDATE_PERIOD_MS * 1000 / 2;
+		auxvel_sample_new.time_us -= _dt_ekf_avg * 5e5f; // filter update period (us) divided by 2
 
 		_auxvel_buffer.push(auxvel_sample_new);
 	}
@@ -519,7 +519,7 @@ bool EstimatorInterface::initialise_interface(uint64_t timestamp)
 								 math::max(_params.airspeed_delay_ms, _params.baro_delay_ms))))))));
 
 	// calculate the IMU buffer length required to accomodate the maximum delay with some allowance for jitter
-	_imu_buffer_length = (max_time_delay_ms / FILTER_UPDATE_PERIOD_MS) + 1;
+	_imu_buffer_length = (max_time_delay_ms / (_dt_ekf_avg * 1000)) + 1;
 
 	// set the observation buffer length to handle the minimum time of arrival between observations in combination
 	// with the worst case delay from current time to ekf fusion time
@@ -605,6 +605,9 @@ void EstimatorInterface::print_status()
 {
 	ECL_INFO("local position valid: %s", local_position_is_valid() ? "yes" : "no");
 	ECL_INFO("global position valid: %s", global_position_is_valid() ? "yes" : "no");
+
+	ECL_INFO("EKF average dt: %.4f", (double)_dt_ekf_avg);
+	ECL_INFO("IMU average dt: %.4f", (double)_dt_imu_avg);
 
 	ECL_INFO("imu buffer: %d (%d Bytes)", _imu_buffer.get_length(), _imu_buffer.get_total_size());
 	ECL_INFO("gps buffer: %d (%d Bytes)", _gps_buffer.get_length(), _gps_buffer.get_total_size());

--- a/EKF/estimator_interface.h
+++ b/EKF/estimator_interface.h
@@ -59,7 +59,7 @@ class EstimatorInterface
 public:
 	typedef AlphaFilter<Vector3f> AlphaFilterVector3f;
 
-	EstimatorInterface():_imu_down_sampler(FILTER_UPDATE_PERIOD_S){};
+	EstimatorInterface() = default;
 	virtual ~EstimatorInterface() = default;
 
 	virtual bool init(uint64_t timestamp) = 0;
@@ -394,31 +394,25 @@ public:
 	// return a bitmask integer that describes which state estimates can be used for flight control
 	virtual void get_ekf_soln_status(uint16_t *status) = 0;
 
-	// Getter for the average imu update period in s
+	// Getter for the average EKF update period in s
+	float get_dt_ekf_avg() const { return _dt_ekf_avg; }
+
+	// Getter for the average IMU update period in s
 	float get_dt_imu_avg() const { return _dt_imu_avg; }
 
 	// Getter for the imu sample on the delayed time horizon
-	imuSample get_imu_sample_delayed()
-	{
-		return _imu_sample_delayed;
-	}
+	imuSample get_imu_sample_delayed() { return _imu_sample_delayed; }
 
 	// Getter for the baro sample on the delayed time horizon
-	baroSample get_baro_sample_delayed()
-	{
-		return _baro_sample_delayed;
-	}
+	baroSample get_baro_sample_delayed() { return _baro_sample_delayed; }
 
 	void print_status();
-
-	static constexpr unsigned FILTER_UPDATE_PERIOD_MS{8};	// ekf prediction period in milliseconds - this should ideally be an integer multiple of the IMU time delta
-	static constexpr float FILTER_UPDATE_PERIOD_S{FILTER_UPDATE_PERIOD_MS * 0.001f};
 
 protected:
 
 	parameters _params;		// filter parameters
 
-	ImuDownSampler _imu_down_sampler;
+	ImuDownSampler _imu_down_sampler{_params.filter_update_imu_samples};
 
 	/*
 	 OBS_BUFFER_LENGTH defines how many observations (non-IMU measurements) we can buffer
@@ -439,7 +433,8 @@ protected:
 
 	unsigned _min_obs_interval_us{0}; // minimum time interval between observations that will guarantee data is not lost (usec)
 
-	float _dt_imu_avg{0.0f};	// average imu update period in s
+	float _dt_ekf_avg{0.008f}; ///< average update rate of the ekf in s
+	float _dt_imu_avg{0.004f};	// average imu update period in s
 
 	imuSample _imu_sample_delayed{};	// captures the imu sample on the delayed time horizon
 

--- a/EKF/imu_down_sampler.cpp
+++ b/EKF/imu_down_sampler.cpp
@@ -1,14 +1,16 @@
 #include "imu_down_sampler.hpp"
 
-ImuDownSampler::ImuDownSampler(float target_dt_sec) : _target_dt{target_dt_sec} { reset(); }
+ImuDownSampler::ImuDownSampler(const int32_t& imu_samples) : _imu_samples{imu_samples} { reset(); }
 
 // integrate imu samples until target dt reached
 // assumes that dt of the gyroscope is close to the dt of the accelerometer
 // returns true if target dt is reached
-bool ImuDownSampler::update(const imuSample &imu_sample_new) {
+bool ImuDownSampler::update(const imuSample& imu_sample_new) {
 	if (_do_reset) {
 		reset();
 	}
+
+	_samples++;
 
 	// accumulate time deltas
 	_imu_down_sampled.delta_ang_dt += imu_sample_new.delta_ang_dt;
@@ -29,18 +31,12 @@ bool ImuDownSampler::update(const imuSample &imu_sample_new) {
 	// assume effective sample time is halfway between the previous and current rotation frame
 	_imu_down_sampled.delta_vel += (imu_sample_new.delta_vel + delta_R * imu_sample_new.delta_vel) * 0.5f;
 
-	// check if the target time delta between filter prediction steps has been exceeded
-	if (_imu_down_sampled.delta_ang_dt >= _target_dt - _imu_collection_time_adj) {
-		// accumulate the amount of time to advance the IMU collection time so that we meet the
-		// average EKF update rate requirement
-		_imu_collection_time_adj += 0.01f * (_imu_down_sampled.delta_ang_dt - _target_dt);
-		_imu_collection_time_adj = math::constrain(_imu_collection_time_adj, -0.5f * _target_dt,
-							   0.5f * _target_dt);
+	// check if we have enough IMU samples (and at least 2 ms of data) or if it's already more than 20 ms
+	if (((_samples >= _imu_samples) && (_imu_down_sampled.delta_ang_dt >= 0.002f)) ||
+	    (_imu_down_sampled.delta_ang_dt >= 0.020f)) {
 
 		_imu_down_sampled.delta_ang = _delta_angle_accumulated.to_axis_angle();
-
 		return true;
-
 	} else {
 		return false;
 	}
@@ -52,5 +48,6 @@ void ImuDownSampler::reset() {
 	_imu_down_sampled.delta_ang_dt = 0.0f;
 	_imu_down_sampled.delta_vel_dt = 0.0f;
 	_delta_angle_accumulated.setIdentity();
+	_samples = 0;
 	_do_reset = false;
 }

--- a/EKF/imu_down_sampler.hpp
+++ b/EKF/imu_down_sampler.hpp
@@ -46,10 +46,10 @@ using namespace estimator;
 
 class ImuDownSampler {
 public:
-	explicit ImuDownSampler(float target_dt_sec);
+	explicit ImuDownSampler(const int32_t& imu_samples);
 	~ImuDownSampler() = default;
 
-	bool update(const imuSample &imu_sample_new);
+	bool update(const imuSample& imu_sample_new);
 
 	imuSample getDownSampledImuAndTriggerReset() {
 		_do_reset = true;
@@ -61,7 +61,7 @@ private:
 
 	imuSample _imu_down_sampled{};
 	Quatf _delta_angle_accumulated{};
-	const float _target_dt;  // [sec]
-	float _imu_collection_time_adj{0.f};
+	int32_t _samples{0};
+	const int32_t& _imu_samples;
 	bool _do_reset{true};
 };

--- a/EKF/range_finder_checks.cpp
+++ b/EKF/range_finder_checks.cpp
@@ -47,7 +47,7 @@ void Ekf::updateRangeDataContinuity()
 	/* Timing in micro seconds */
 
 	/* Apply a 2.0 sec low pass filter to the time delta from the last range finder updates */
-	float alpha = 0.5f * _dt_update;
+	float alpha = 0.5f * _dt_ekf_avg;
 	_dt_last_range_update_filt_us = _dt_last_range_update_filt_us * (1.0f - alpha) + alpha *
 					(_imu_sample_delayed.time_us - _range_sample_delayed.time_us);
 

--- a/test/test_EKF_imuSampling.cpp
+++ b/test/test_EKF_imuSampling.cpp
@@ -64,8 +64,8 @@ TEST_P(EkfImuSamplingTest, imuSamplingAtMultipleRates)
 	// WHEN: adding imu samples at a same or lower rate than the update loop
 	// THEN: imu sample should reach buffer unchanged
 
-	uint32_t dt_us = std::get<0>(GetParam()) * (_ekf.FILTER_UPDATE_PERIOD_MS * 1000);
-	uint32_t expected_dt_us = std::get<1>(GetParam()) * (_ekf.FILTER_UPDATE_PERIOD_MS * 1000);
+	uint32_t dt_us = std::get<0>(GetParam()) * (_ekf.get_dt_ekf_avg() * 1000);
+	uint32_t expected_dt_us = std::get<1>(GetParam()) * (_ekf.get_dt_ekf_avg() * 1000);
 
 	Vector3f ang_vel= std::get<2>(GetParam());
 	Vector3f accel = std::get<3>(GetParam());


### PR DESCRIPTION
WORK IN PROGRESS

Instead of relying on the hard coded FILTER_UPDATE_PERIOD_MS (8 milliseconds) should we update as a multiple of IMU samples (parameterized)?  This would more closely align with actual sensor differences and allow optimization across the range of new and old boards.

The most common InvenSense IMUs we've used historically provide gyro at 8 kHz and accel at 1 or 4 kHz. The newer InvenSense options have 9 kHz gyro and 4.5 kHz accel.

With newer Bosch IMUs (eg BMI088 or BMI055) if we want synchronized accel (1600 Hz) + gyro (2000 Hz) data we need a multiple of 2500 us (400 Hz)

Things are even more awkward with some ST or Analog Devices IMUs.
Examples:
 - ST ISM330DLC 6664 Hz
 - Analog Devices ADIS16448 819.2 Hz



PX4/Firmware change for testing. https://github.com/PX4/Firmware/pull/14379

``` Console

nsh> ekf2 status
INFO  [ekf2] local position: invalid
INFO  [ekf2] global position: invalid
INFO  [ekf2] time slip: 59983 us
ekf2: update: 159545 events, 63190133us elapsed, 396.06us avg, min 3us max 1296us 229.070us rms

INFO  [ecl/EKF] local position valid: no
INFO  [ecl/EKF] global position valid: no

INFO  [ecl/EKF] EKF average dt: 0.0080
INFO  [ecl/EKF] IMU average dt: 0.0040

INFO  [ecl/EKF] imu buffer: 22 (888 Bytes)
INFO  [ecl/EKF] gps buffer: 14 (680 Bytes)
INFO  [ecl/EKF] mag buffer: 14 (344 Bytes)
INFO  [ecl/EKF] baro buffer: 14 (232 Bytes)
INFO  [ecl/EKF] range buffer: 1 (32 Bytes)
INFO  [ecl/EKF] airspeed buffer: 1 (24 Bytes)
INFO  [ecl/EKF] flow buffer: 1 (48 Bytes)
INFO  [ecl/EKF] vision buffer: 1 (88 Bytes)
INFO  [ecl/EKF] output buffer: 22 (1064 Bytes)
INFO  [ecl/EKF] output vert buffer: 22 (536 Bytes)
INFO  [ecl/EKF] drag buffer: 1 (24 Bytes)
```