### PR TITLE
YawEst: simplify AHRS accelerometer gain computation

### DIFF
--- a/EKF/EKFGSF_yaw.h
+++ b/EKF/EKFGSF_yaw.h
@@ -81,7 +81,7 @@ private:
 	float _ahrs_accel_norm;			// length of _ahrs_accel specific force vector used by AHRS calculation (m/s/s)
 
 	// calculate the gain from gravity vector misalingment to tilt correction to be used by all AHRS filters
-	void ahrsCalcAccelGain();
+	float ahrsCalcAccelGain() const;
 
 	// update specified AHRS rotation matrix using IMU and optionally true airspeed data
 	void ahrsPredict(const uint8_t model_index);
@@ -121,7 +121,7 @@ private:
 	// return false if update failed
 	bool updateEKF(const uint8_t model_index);
 
-	inline float sq(float x) { return x * x; };
+	inline float sq(float x) const { return x * x; };
 
 	// converts Tait-Bryan 312 sequence of rotations from frame 1 to frame 2
 	// to the corresponding rotation matrix that rotates from frame 2 to frame 1


### PR DESCRIPTION
I just remembered that I found a nice generic equation to compute the accel gain for the AHRS (https://github.com/PX4/ecl/pull/751#discussion_r381228066)
https://www.desmos.com/calculator/dbqbxvnwfg

![DeepinScreenshot_select-area_20200220135708](https://user-images.githubusercontent.com/14822839/74935644-e0f6a500-53e8-11ea-8f29-8bac149e4298.png)

Replace the multiple if-else statements by a generic equation.
- For a multicopter, the attenuation factor is 2 and symmetrical
- For a fixedwing, the attenuation factor is 1 if the acceleration is positive and that centripetal correction is available and 2 otherwise.

Note that the function `sq` needs to be `const` in order to be used in a `const` function.