### PR TITLE
TerrainEstimator initialization fix

### DIFF
--- a/EKF/control.cpp
+++ b/EKF/control.cpp
@@ -1001,7 +1001,7 @@ void Ekf::controlHeightFusion()
 					_hgt_sensor_offset = _terrain_vpos;
 
 				} else if (_control_status.flags.in_air) {
-					_hgt_sensor_offset = _range_sensor.getCosTilt() * _range_sensor.getRange() + _state.pos(2);
+					_hgt_sensor_offset = _range_sensor.getDistBottom() + _state.pos(2);
 
 				} else {
 					_hgt_sensor_offset = _params.rng_gnd_clearance;
@@ -1161,10 +1161,11 @@ void Ekf::controlHeightFusion()
 			Vector2f rng_hgt_innov_gate;
 			Vector3f rng_hgt_obs_var;
 			// use range finder with tilt correction
-			_rng_hgt_innov(2) = _state.pos(2) - (-math::max(_range_sensor.getRange() * _range_sensor.getCosTilt(),
+			_rng_hgt_innov(2) = _state.pos(2) - (-math::max(_range_sensor.getDistBottom(),
 							 _params.rng_gnd_clearance)) - _hgt_sensor_offset;
 			// observation variance - user parameter defined
-			rng_hgt_obs_var(2) = fmaxf((sq(_params.range_noise) + sq(_params.range_noise_scaler * _range_sensor.getRange())) * sq(_range_sensor.getCosTilt()), 0.01f);
+			rng_hgt_obs_var(2) = fmaxf(sq(_params.range_noise)
+						   + sq(_params.range_noise_scaler * _range_sensor.getDistBottom()), 0.01f);
 			// innovation gate size
 			rng_hgt_innov_gate(1) = fmaxf(_params.range_innov_gate, 1.0f);
 			// fuse height information

--- a/EKF/ekf_helper.cpp
+++ b/EKF/ekf_helper.cpp
@@ -227,7 +227,7 @@ void Ekf::resetHeight()
 
 	// reset the vertical position
 	if (_control_status.flags.rng_hgt) {
-		const float new_pos_down = _hgt_sensor_offset - _range_sensor.getRange() * _range_sensor.getCosTilt();
+		const float new_pos_down = _hgt_sensor_offset - _range_sensor.getDistBottom();
 
 		// update the state and associated variance
 		_state.pos(2) = new_pos_down;

--- a/EKF/sensor_range_finder.hpp
+++ b/EKF/sensor_range_finder.hpp
@@ -88,6 +88,8 @@ public:
 	void setRange(float rng) { _sample.rng = rng; }
 	float getRange() const { return _sample.rng; }
 
+	float getDistBottom() const { return _sample.rng * _cos_tilt_rng_to_earth; }
+
 	void setDataReadiness(bool is_ready) { _is_sample_ready = is_ready; }
 	void setValidity(bool is_valid) { _is_sample_valid = is_valid; }
 

--- a/EKF/terrain_estimator.cpp
+++ b/EKF/terrain_estimator.cpp
@@ -57,7 +57,7 @@ bool Ekf::initHagl()
 	} else if ((_params.terrain_fusion_mode & TerrainFusionMask::TerrainFuseRangeFinder)
 		   && _range_sensor.isDataHealthy()) {
 		// if we have a fresh measurement, use it to initialise the terrain estimator
-		_terrain_vpos = _state.pos(2) + _range_sensor.getRange() * _range_sensor.getCosTilt();
+		_terrain_vpos = _state.pos(2) + _range_sensor.getDistBottom();
 		// initialise state variance to variance of measurement
 		_terrain_var = sq(_params.range_noise);
 		// success
@@ -130,7 +130,7 @@ void Ekf::runTerrainEstimator()
 void Ekf::fuseHagl()
 {
 	// get a height above ground measurement from the range finder assuming a flat earth
-	const float meas_hagl = _range_sensor.getRange() * _range_sensor.getCosTilt();
+	const float meas_hagl = _range_sensor.getDistBottom();
 
 	// predict the hagl from the vehicle position and terrain height
 	const float pred_hagl = _terrain_vpos - _state.pos(2);

--- a/EKF/terrain_estimator.cpp
+++ b/EKF/terrain_estimator.cpp
@@ -46,8 +46,6 @@
 bool Ekf::initHagl()
 {
 	bool initialized = false;
-	// get most recent range measurement from buffer
-	const rangeSample &latest_measurement = _range_buffer.get_newest();
 
 	if (!_control_status.flags.in_air) {
 		// if on ground, do not trust the range sensor, but assume a ground clearance
@@ -57,11 +55,9 @@ bool Ekf::initHagl()
 		initialized = true;
 
 	} else if ((_params.terrain_fusion_mode & TerrainFusionMask::TerrainFuseRangeFinder)
-		   && _range_sensor.isHealthy()
-		   && isRecent(latest_measurement.time_us, (uint64_t)2e5)) {
+		   && _range_sensor.isDataHealthy()) {
 		// if we have a fresh measurement, use it to initialise the terrain estimator
-		// TODO: the latest measurment did not go through the checks and could be invalid!
-		_terrain_vpos = _state.pos(2) + latest_measurement.rng * _range_sensor.getCosTilt();
+		_terrain_vpos = _state.pos(2) + _range_sensor.getRange() * _range_sensor.getCosTilt();
 		// initialise state variance to variance of measurement
 		_terrain_var = sq(_params.range_noise);
 		// success

--- a/test/test_SensorRangeFinder.cpp
+++ b/test/test_SensorRangeFinder.cpp
@@ -297,3 +297,20 @@ TEST_F(SensorRangeFinderTest, continuity)
 	EXPECT_TRUE(_range_finder.isDataHealthy());
 	EXPECT_TRUE(_range_finder.isHealthy());
 }
+
+TEST_F(SensorRangeFinderTest, distBottom)
+{
+	const Dcmf attitude{Eulerf(0.f, 0.f, 0.f)};
+	rangeSample sample{};
+	sample.rng = 1.f;
+	sample.time_us = 1e6;
+	sample.quality = 9;
+
+	_range_finder.setSample(sample);
+	_range_finder.runChecks(sample.time_us, attitude);
+	EXPECT_FLOAT_EQ(_range_finder.getDistBottom(), sample.rng);
+
+	const Dcmf attitude20{Eulerf(-0.35f, 0.f, 0.f)};
+	_range_finder.runChecks(sample.time_us, attitude20);
+	EXPECT_FLOAT_EQ(_range_finder.getDistBottom(), sample.rng * cosf(-0.35));
+}


### PR DESCRIPTION
Following #782, we identified an inconsistency where the newest sample was used to initialize the terrain estimator instead of the delayed -and verified- measurement (fixed in https://github.com/PX4/ecl/commit/45de501e19a2bf866bfbc60b48d96683b24f43b2 ).

Additionally, in https://github.com/PX4/ecl/commit/b4f35d47bf95c3832446ce5ac085b09ab6ad154a I added the `distBottom` function to the `SensorRangeFinder` class to directly get the vertical measured distance below the drone, corrected for tilt.

**Please answer** https://github.com/PX4/ecl/pull/792/files#r402776911