### PR TITLE
Add tests for velocity reset logging

### DIFF
--- a/test/test_helper/CMakeLists.txt
+++ b/test/test_helper/CMakeLists.txt
@@ -31,29 +31,10 @@
 #
 ############################################################################
 
-include(gtest.cmake)
-
-add_subdirectory(sensor_simulator)
-add_subdirectory(test_helper)
 
 set(SRCS
-	main.cpp
-	test_EKF_basics.cpp
-	test_EKF_ringbuffer.cpp
-	test_EKF_measurementSampling.cpp
-	test_EKF_imuSampling.cpp
-	test_AlphaFilter.cpp
-	test_EKF_fusionLogic.cpp
-	test_EKF_initialization.cpp
-	test_EKF_gps.cpp
-	test_EKF_externalVision.cpp
-	test_EKF_airspeed.cpp
-	test_EKF_withReplayData.cpp
-	test_EKF_flow.cpp
-	test_SensorRangeFinder.cpp
+	reset_logging_checker.cpp
    )
-add_executable(ECL_GTESTS ${SRCS})
 
-target_link_libraries(ECL_GTESTS gtest_main ecl_EKF ecl_sensor_sim ecl_test_helper)
-
-add_test(NAME ECL_GTESTS COMMAND ECL_GTESTS)
+add_library(ecl_test_helper ${SRCS})
+target_link_libraries(ecl_test_helper ecl_EKF)

--- a/test/test_helper/reset_logging_checker.cpp
+++ b/test/test_helper/reset_logging_checker.cpp
@@ -1,0 +1,81 @@
+#include "reset_logging_checker.h"
+
+// call immediately after state reset
+void ResetLoggingChecker::capturePreResetState() {
+	float a[2];
+	float b;
+	uint8_t c;
+	_ekf->get_velNE_reset(a, &c);
+	horz_vel_reset_counter_before_reset = c;
+	_ekf->get_velD_reset(&b, &c);
+	vert_vel_reset_counter_before_reset = c;
+	_ekf->get_posNE_reset(a, &c);
+	horz_pos_reset_counter_before_reset = c;
+	_ekf->get_posD_reset(&b, &c);
+	vert_pos_reset_counter_before_reset = c;
+
+	velocity_before_reset = _ekf->getVelocity();
+	position_before_reset = _ekf->getPosition();
+}
+
+// call immediately after state reset
+void ResetLoggingChecker::capturePostResetState() {
+	float a[2];
+	float b;
+	uint8_t c;
+	_ekf->get_velNE_reset(a, &c);
+	logged_delta_velocity(0) = a[0];
+	logged_delta_velocity(1) = a[1];
+	horz_vel_reset_counter_after_reset = c;
+	_ekf->get_velD_reset(&b, &c);
+	logged_delta_velocity(2) = b;
+	vert_vel_reset_counter_after_reset = c;
+	_ekf->get_posNE_reset(a, &c);
+	logged_delta_position(0) = a[0];
+	logged_delta_position(1) = a[1];
+	horz_pos_reset_counter_after_reset = c;
+	_ekf->get_posD_reset(&b, &c);
+	logged_delta_position(2) = b;
+	vert_pos_reset_counter_after_reset = c;
+
+	velocity_after_reset = _ekf->getVelocity();
+	position_after_reset = _ekf->getPosition();
+}
+
+bool ResetLoggingChecker::isVelocityDeltaLoggedCorrectly(float accuracy) {
+	const  Vector3f measured_delta_velocity = velocity_after_reset -
+							velocity_before_reset;
+
+	return matrix::isEqual(logged_delta_velocity,
+				measured_delta_velocity,
+				accuracy);
+}
+
+bool ResetLoggingChecker::isHorizontalVelocityResetCounterIncreasedBy(int offset) {
+	return horz_vel_reset_counter_after_reset ==
+		horz_vel_reset_counter_before_reset + offset;
+}
+
+bool ResetLoggingChecker::isVerticalVelocityResetCounterIncreasedBy(int offset) {
+	return vert_vel_reset_counter_after_reset ==
+		vert_vel_reset_counter_before_reset + offset;
+}
+
+bool ResetLoggingChecker::isPositionDeltaLoggedCorrectly(float accuracy) {
+	const  Vector3f measured_delta_position = position_after_reset -
+							position_before_reset;
+
+	return matrix::isEqual(logged_delta_position,
+				measured_delta_position,
+				accuracy);
+}
+
+bool ResetLoggingChecker::isHorizontalPositionResetCounterIncreasedBy(int offset) {
+	return horz_pos_reset_counter_after_reset ==
+		horz_pos_reset_counter_before_reset + offset;
+}
+
+bool ResetLoggingChecker::isVerticalPositionResetCounterIncreasedBy(int offset) {
+	return vert_pos_reset_counter_after_reset ==
+		vert_pos_reset_counter_before_reset + offset;
+}

--- a/test/test_helper/reset_logging_checker.h
+++ b/test/test_helper/reset_logging_checker.h
@@ -1,0 +1,86 @@
+/****************************************************************************
+ *
+ *   Copyright (c) 2020 ECL Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * Helper class to check the state_reset_status member of the ekf object.
+ * Used for checking if state resets are logged correctly.
+ * @author Kamil Ritz <ka.ritz@hotmail.com>
+ */
+
+#pragma once
+
+#include <memory>
+#include "EKF/ekf.h"
+
+class ResetLoggingChecker {
+public:
+	ResetLoggingChecker(std::shared_ptr<Ekf> ekf) : _ekf(ekf) {}
+
+	// call immediately before state reset
+	void capturePreResetState();
+
+	// call immediately after state reset
+	void capturePostResetState();
+
+	bool isVelocityDeltaLoggedCorrectly(float accuracy);
+
+	bool isHorizontalVelocityResetCounterIncreasedBy(int offset);
+
+	bool isVerticalVelocityResetCounterIncreasedBy(int offset);
+
+	bool isPositionDeltaLoggedCorrectly(float accuracy);
+
+	bool isHorizontalPositionResetCounterIncreasedBy(int offset);
+
+	bool isVerticalPositionResetCounterIncreasedBy(int offset);
+
+private:
+	std::shared_ptr<Ekf> _ekf;
+
+	Vector3f velocity_before_reset;
+	Vector3f position_before_reset;
+	int horz_vel_reset_counter_before_reset;
+	int vert_vel_reset_counter_before_reset;
+	int horz_pos_reset_counter_before_reset;
+	int vert_pos_reset_counter_before_reset;
+
+	Vector3f velocity_after_reset;
+	Vector3f position_after_reset;
+	int horz_vel_reset_counter_after_reset;
+	int vert_vel_reset_counter_after_reset;
+	int horz_pos_reset_counter_after_reset;
+	int vert_pos_reset_counter_after_reset;
+
+	Vector3f logged_delta_velocity;
+	Vector3f logged_delta_position;
+};


### PR DESCRIPTION
This is a follow up to the velocity reset refactoring in https://github.com/PX4/ecl/pull/788. I now added also tests for the correct storing of the reset -deltas/-counters. Those are important for the position/velocity controller, as they are used for control.