### PR TITLE
Refactor resetPosition

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -132,7 +132,7 @@ if(CMAKE_SOURCE_DIR STREQUAL PROJECT_SOURCE_DIR)
 	include(ExternalProject)
 	ExternalProject_Add(matrix
 			GIT_REPOSITORY "https://github.com/PX4/Matrix.git"
-			GIT_TAG d18be0d0fa17d9a0b60ab34bad3e33160f907b09
+			GIT_TAG d613055462bcbeacfd188cbd53de56c1dbc7b94d
 			UPDATE_COMMAND ""
 			PATCH_COMMAND ""
 			CONFIGURE_COMMAND ""

--- a/EKF/ekf.h
+++ b/EKF/ekf.h
@@ -583,6 +583,8 @@ private:
 
 	inline void resetVerticalVelocityTo(float new_vert_vel);
 
+	inline void resetHorizontalPositionTo(const Vector2f &new_horz_pos);
+
 	// fuse optical flow line of sight rate measurements
 	void fuseOptFlow();
 

--- a/EKF/ekf_helper.cpp
+++ b/EKF/ekf_helper.cpp
@@ -112,11 +112,9 @@ void Ekf::resetHorizontalVelocityTo(const Vector2f &new_horz_vel) {
 	_state.vel.xy() = new_horz_vel;
 
 	for (uint8_t index = 0; index < _output_buffer.get_length(); index++) {
-		_output_buffer[index].vel(0) += delta_horz_vel(0);
-		_output_buffer[index].vel(1) += delta_horz_vel(1);
+		_output_buffer[index].vel.xy() += delta_horz_vel;
 	}
-	_output_new.vel(0) += delta_horz_vel(0);
-	_output_new.vel(1) += delta_horz_vel(1);
+	_output_new.vel.xy() += delta_horz_vel;
 
 	_state_reset_status.velNE_change = delta_horz_vel;
 	_state_reset_status.velNE_counter++;
@@ -193,11 +191,9 @@ void Ekf::resetHorizontalPositionTo(const Vector2f &new_horz_pos) {
 	_state.pos.xy() = new_horz_pos;
 
 	for (uint8_t index = 0; index < _output_buffer.get_length(); index++) {
-		_output_buffer[index].pos(0) += delta_horz_pos(0);
-		_output_buffer[index].pos(1) += delta_horz_pos(1);
+		_output_buffer[index].pos.xy() += delta_horz_pos;
 	}
-	_output_new.pos(0) += delta_horz_pos(0);
-	_output_new.pos(1) += delta_horz_pos(1);
+	_output_new.pos.xy() += delta_horz_pos;
 
 	_state_reset_status.posNE_change = delta_horz_pos;
 	_state_reset_status.posNE_counter++;

--- a/test/sensor_simulator/gps.cpp
+++ b/test/sensor_simulator/gps.cpp
@@ -68,13 +68,17 @@ void Gps::stepHorizontalPositionByMeters(Vector2f hpos_change)
 {
 	float hposN_curr;
 	float hposE_curr;
-	map_projection_global_project((float)_gps_data.lat, (float)_gps_data.lon, &hposN_curr, &hposE_curr);
+	map_projection_reference_s origin;
+	uint64_t time;
+	float alt;
+	_ekf->get_ekf_origin(&time, &origin, &alt);
+	map_projection_project(&origin, _gps_data.lat * 1e-7, _gps_data.lon * 1e-7, &hposN_curr, &hposE_curr);
 	Vector2f hpos_new = Vector2f{hposN_curr, hposE_curr} + hpos_change;
 	double lat_new;
 	double lon_new;
-	map_projection_global_reproject(hpos_new(0), hpos_new(1), &lat_new, &lon_new);
-	_gps_data.lon = (uint32_t)lon_new;
-	_gps_data.lat = (uint32_t)lat_new;
+	map_projection_reproject(&origin, hpos_new(0), hpos_new(1), &lat_new, &lon_new);
+	_gps_data.lon = static_cast<int32_t>(lon_new * 1e7);
+	_gps_data.lat = static_cast<int32_t>(lat_new * 1e7);
 }
 
 

--- a/test/test_EKF_externalVision.cpp
+++ b/test/test_EKF_externalVision.cpp
@@ -162,6 +162,44 @@ TEST_F(EkfExternalVisionTest, visionVelocityResetWithAlignment)
 	EXPECT_TRUE(reset_logging_checker.isVelocityDeltaLoggedCorrectly(0.01f));
 }
 
+TEST_F(EkfExternalVisionTest, visionHorizontalPositionReset)
+{
+	const Vector3f simulated_position(8.3f, -1.0f, 0.0f);
+
+	_sensor_simulator._vio.setPosition(simulated_position);
+	_ekf_wrapper.enableExternalVisionPositionFusion();
+	_sensor_simulator.startExternalVision();
+	_sensor_simulator.runMicroseconds(2e5);
+
+	// THEN: a reset to Vision velocity should be done
+	const Vector3f estimated_position = _ekf->getPosition();
+	EXPECT_TRUE(isEqual(estimated_position, simulated_position, 1e-5f));
+}
+
+TEST_F(EkfExternalVisionTest, visionHorizontalPositionResetWithAlignment)
+{
+	// GIVEN: Drone is pointing north, and we use mag (ROTATE_EV)
+	//        Heading of drone in EKF frame is 0°
+
+	// WHEN: Vision frame is rotate +90°. The reported heading is -90°
+	Quatf vision_to_ekf(Eulerf(0.0f,0.0f,math::radians(-90.0f)));
+	_sensor_simulator._vio.setOrientation(vision_to_ekf.inversed());
+	_ekf_wrapper.enableExternalVisionAlignment();
+
+	const Vector3f simulated_position_in_vision_frame(8.3f, -1.0f, 0.0f);
+	const Vector3f simulated_position_in_ekf_frame =
+		Dcmf(vision_to_ekf) * simulated_position_in_vision_frame;
+	_sensor_simulator._vio.setPosition(simulated_position_in_vision_frame);
+	_ekf_wrapper.enableExternalVisionPositionFusion();
+	_sensor_simulator.startExternalVision();
+	_sensor_simulator.runMicroseconds(2e5);
+
+	// THEN: a reset to Vision velocity should be done
+	const Vector3f estimated_position_in_ekf_frame = _ekf->getPosition();
+	EXPECT_TRUE(isEqual(estimated_position_in_ekf_frame, simulated_position_in_ekf_frame, 1e-2f));
+}
+
+
 TEST_F(EkfExternalVisionTest, visionVarianceCheck)
 {
 	const Vector3f velVar_init = _ekf->getVelocityVariance();

--- a/test/test_EKF_fusionLogic.cpp
+++ b/test/test_EKF_fusionLogic.cpp
@@ -139,7 +139,7 @@ TEST_F(EkfFusionLogicTest, rejectGpsSignalJump)
 	const Vector3f pos_old = _ekf->getPosition();
 	const Vector3f vel_old = _ekf->getVelocity();
 	const Vector3f accel_bias_old = _ekf->getAccelBias();
-	_sensor_simulator._gps.stepHorizontalPositionByMeters(Vector2f{10.0f, 0.0f});
+	_sensor_simulator._gps.stepHorizontalPositionByMeters(Vector2f{20.0f, 0.0f});
 	_sensor_simulator.runSeconds(2);
 
 	// THEN: The estimate should not change much in the short run


### PR DESCRIPTION
This PR contains:
- refactor resetPosition()
- use new assignment operators from matrix library during velocity and position resets
- fix horizontal GPS position step functionality in sensor simulator's GPS sensor.
- Add unit tests for reset to GPS and vision position.

When bringing this to the Firmware the newest Matrix library is needed: https://github.com/PX4/Matrix/commit/d613055462bcbeacfd188cbd53de56c1dbc7b94d

TODO: 

- [x] Fix failing unit tests