### PR TITLE
Fix baro fail-over in GPS hgt mode

### DIFF
--- a/EKF/control.cpp
+++ b/EKF/control.cpp
@@ -822,7 +822,7 @@ void Ekf::controlHeightSensorTimeouts()
 				// set height sensor health
 				_baro_hgt_faulty = true;
 
-				setControlGPSHeight();
+				startGpsHgtFusion();
 
 				request_height_reset = true;
 				ECL_WARN_TIMESTAMPED("baro hgt timeout - reset to GPS");
@@ -1018,14 +1018,8 @@ void Ekf::controlHeightFusion()
 			}
 
 		} else if (!do_range_aid && _gps_data_ready && !_gps_hgt_intermittent && _gps_checks_passed) {
-			setControlGPSHeight();
 			fuse_height = true;
-
-			// we have just switched to using gps height, calculate height sensor offset such that current
-			// measurement matches our current height estimate
-			if (_control_status_prev.flags.gps_hgt != _control_status.flags.gps_hgt) {
-				_hgt_sensor_offset = _gps_sample_delayed.hgt - _gps_alt_ref + _state.pos(2);
-			}
+			startGpsHgtFusion();
 
 		} else if (_control_status.flags.baro_hgt && _baro_data_ready && !_baro_hgt_faulty) {
 			// switch to baro if there was a reset to baro

--- a/EKF/control.cpp
+++ b/EKF/control.cpp
@@ -1050,16 +1050,7 @@ void Ekf::controlHeightFusion()
 		break;
 	}
 
-	// calculate a filtered offset between the baro origin and local NED origin if we are not using the baro as a height reference
-	if (!_control_status.flags.baro_hgt && _baro_data_ready) {
-		float local_time_step = 1e-6f * _delta_time_baro_us;
-		local_time_step = math::constrain(local_time_step, 0.0f, 1.0f);
-
-		// apply a 10 second first order low pass filter to baro offset
-		float offset_rate_correction =  0.1f * (_baro_sample_delayed.hgt + _state.pos(
-				2) - _baro_hgt_offset);
-		_baro_hgt_offset += local_time_step * math::constrain(offset_rate_correction, -0.1f, 0.1f);
-	}
+	updateBaroHgtOffset();
 
 	if (isTimedOut(_time_last_hgt_fuse, 2 * RNG_MAX_INTERVAL) && _control_status.flags.rng_hgt
 	    && (!_range_sensor.isDataHealthy())) {

--- a/EKF/ekf.h
+++ b/EKF/ekf.h
@@ -758,6 +758,8 @@ private:
 	void startMagHdgFusion();
 	void startMag3DFusion();
 
+	void startBaroHgtFusion();
+
 	// calculate the measurement variance for the optical flow sensor
 	float calcOptFlowMeasVar();
 

--- a/EKF/ekf.h
+++ b/EKF/ekf.h
@@ -759,6 +759,7 @@ private:
 	void startMag3DFusion();
 
 	void startBaroHgtFusion();
+	void startGpsHgtFusion();
 
 	// calculate the measurement variance for the optical flow sensor
 	float calcOptFlowMeasVar();

--- a/EKF/ekf.h
+++ b/EKF/ekf.h
@@ -761,6 +761,8 @@ private:
 	void startBaroHgtFusion();
 	void startGpsHgtFusion();
 
+	void updateBaroHgtOffset();
+
 	// calculate the measurement variance for the optical flow sensor
 	float calcOptFlowMeasVar();
 

--- a/EKF/ekf_helper.cpp
+++ b/EKF/ekf_helper.cpp
@@ -1487,6 +1487,17 @@ void Ekf::startBaroHgtFusion()
 	}
 }
 
+void Ekf::startGpsHgtFusion()
+{
+	setControlGPSHeight();
+
+	// we have just switched to using gps height, calculate height sensor offset such that current
+	// measurement matches our current height estimate
+	if (_control_status_prev.flags.gps_hgt != _control_status.flags.gps_hgt) {
+		_hgt_sensor_offset = _gps_sample_delayed.hgt - _gps_alt_ref + _state.pos(2);
+	}
+}
+
 // update the rotation matrix which rotates EV measurements into the EKF's navigation frame
 void Ekf::calcExtVisRotMat()
 {

--- a/EKF/ekf_helper.cpp
+++ b/EKF/ekf_helper.cpp
@@ -1498,6 +1498,21 @@ void Ekf::startGpsHgtFusion()
 	}
 }
 
+void Ekf::updateBaroHgtOffset()
+{
+	// calculate a filtered offset between the baro origin and local NED origin if we are not
+	// using the baro as a height reference
+	if (!_control_status.flags.baro_hgt && _baro_data_ready) {
+		float local_time_step = 1e-6f * _delta_time_baro_us;
+		local_time_step = math::constrain(local_time_step, 0.0f, 1.0f);
+
+		// apply a 10 second first order low pass filter to baro offset
+		float offset_rate_correction =  0.1f * (_baro_sample_delayed.hgt + _state.pos(
+				2) - _baro_hgt_offset);
+		_baro_hgt_offset += local_time_step * math::constrain(offset_rate_correction, -0.1f, 0.1f);
+	}
+}
+
 // update the rotation matrix which rotates EV measurements into the EKF's navigation frame
 void Ekf::calcExtVisRotMat()
 {

--- a/EKF/ekf_helper.cpp
+++ b/EKF/ekf_helper.cpp
@@ -252,7 +252,7 @@ void Ekf::resetHeight()
 		const baroSample &baro_newest = _baro_buffer.get_newest();
 
 		if (!_baro_hgt_faulty) {
-			_state.pos(2) = _hgt_sensor_offset - baro_newest.hgt + _baro_hgt_offset;
+			_state.pos(2) = -baro_newest.hgt + _baro_hgt_offset;
 
 			// the state variance is the same as the observation
 			P.uncorrelateCovarianceSetVariance<1>(9, sq(_params.baro_noise));
@@ -1467,6 +1467,23 @@ void Ekf::startMag3DFusion()
 		zeroMagCov();
 		loadMagCovData();
 		_control_status.flags.mag_3D = true;
+	}
+}
+
+void Ekf::startBaroHgtFusion()
+{
+	setControlBaroHeight();
+
+	// We don't need to set a height sensor offset
+	// since we track a separate _baro_hgt_offset
+	_hgt_sensor_offset = 0.0f;
+
+	// Turn off ground effect compensation if it times out
+	if (_control_status.flags.gnd_effect) {
+		if (isTimedOut(_time_last_gnd_effect_on, GNDEFFECT_TIMEOUT)) {
+
+			_control_status.flags.gnd_effect = false;
+		}
 	}
 }
 

--- a/EKF/gps_checks.cpp
+++ b/EKF/gps_checks.cpp
@@ -100,9 +100,7 @@ bool Ekf::collect_gps(const gps_message &gps)
 
 		if (_params.vdist_sensor_type == VDIST_SENSOR_GPS) {
 			ECL_INFO_TIMESTAMPED("GPS checks passed (WGS-84 origin set, using GPS height)");
-			setControlGPSHeight();
-			// zero the sensor offset
-			_hgt_sensor_offset = 0.0f;
+			startGpsHgtFusion();
 		} else {
 			ECL_INFO_TIMESTAMPED("GPS checks passed (WGS-84 origin set)");
 		}


### PR DESCRIPTION
When the primary height source is GPS but the GPS data times out, EKF2 switches to baro and makes a reset. However, the `_hgt_sensor_offset` was not set to 0 and the height reset creates an incorrect jump in the state.

partially fixing https://github.com/PX4/Firmware/issues/14677