### PR TITLE
Update RingBuffer.h

### DIFF
--- a/EKF/RingBuffer.h
+++ b/EKF/RingBuffer.h
@@ -141,7 +141,7 @@ public:
 					_tail = (index + 1) % _size;
 				}
 
-				_buffer[index].time_us = 0;
+				//_buffer[index].time_us = 0;
 
 				return true;
 			}


### PR DESCRIPTION
*RingBuffer: Do not reset the timestamp.
When calling 'pop_first_older_than' function, it will reset the older data timestamp to 0. If the function is called faster than the new data push in, all the timestamp of the data in the buffer will be 0. In this case, calling 'get_newest' function will return data with 0 timestamp, this will case problem for which needs the right timestamp.