### PR TITLE
Fix EKF does emergency yaw reset after intermittent gps data

### DIFF
--- a/EKF/ekf.h
+++ b/EKF/ekf.h
@@ -335,6 +335,7 @@ private:
 	bool _tas_data_ready{false};	///< true when new true airspeed data has fallen behind the fusion time horizon and is available to be fused
 	bool _flow_for_terrain_data_ready{false}; /// same flag as "_flow_data_ready" but used for separate terrain estimator
 
+	uint64_t _time_prev_gps_us{0};	///< time stamp of previous GPS data retrieved from the buffer (uSec)
 	uint64_t _time_last_aiding{0};	///< amount of time we have been doing inertial only deadreckoning (uSec)
 	bool _using_synthetic_position{false};	///< true if we are using a synthetic position to constrain drift
 


### PR DESCRIPTION
Fixes https://github.com/PX4/ecl/issues/804

Testing was performed using jmavsim SITL. Log here: https://logs.px4.io/plot_app?log=141aa81d-6ea4-411e-9f89-4387dd6ca1c4

The following steps were performed:

1) Takeoff in ALTCTRL and climb to approx 5m
2 Perform a series of horizontal maneouvres for 15 seconds to ensure GSF yaw was fully aligned.
3) Turn off GPS using SIM_GPS_BLOCK = 1
4) Turn GPS back on using SIM_GPS_BLOCK = 0 when the stopping navigation message was received.
5) Verify GPS position and velocity states are reset and no yaw reset is performed.

Console messages:
![Screen Shot 2020-04-30 at 5 31 07 pm](https://user-images.githubusercontent.com/3596952/80684011-65138a00-8b08-11ea-9590-5cb1bad9bba1.png)

Velocity and position states:
![Screen Shot 2020-04-30 at 5 31 59 pm](https://user-images.githubusercontent.com/3596952/80684094-83798580-8b08-11ea-9840-8bc47bfdbcf9.png)

Yaw:
![Screen Shot 2020-04-30 at 5 33 29 pm](https://user-images.githubusercontent.com/3596952/80684248-b91e6e80-8b08-11ea-9ea0-bf7e627baa2e.png)

