### PR TITLE
cmake update CXX standard 11 -> 14

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,7 +56,7 @@ execute_process(
 
 message(STATUS "PX4 ECL: Very lightweight Estimation & Control Library ${git_tag}")
 
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 


### PR DESCRIPTION
 - stay in sync with PX4/Firmware


This doesn't really change anything, just keeping it consistent with PX4/Firmware.