### PR TITLE
EKF: mag_control: Reset yaw to mag when restarting fusion

### DIFF
--- a/EKF/control.cpp
+++ b/EKF/control.cpp
@@ -331,7 +331,7 @@ void Ekf::controlExternalVisionFusion()
 			fuseHeading();
 		}
 
-	} else if ((_control_status.flags.ev_pos || _control_status.flags.ev_vel ||  _control_status.flags.ev_yaw)
+	} else if ((_control_status.flags.ev_pos || _control_status.flags.ev_vel || _control_status.flags.ev_yaw)
 		   && isTimedOut(_time_last_ext_vision, (uint64_t)_params.reset_timeout_max)) {
 
 		// Turn off EV fusion mode if no data has been received

--- a/EKF/mag_control.cpp
+++ b/EKF/mag_control.cpp
@@ -75,6 +75,9 @@ void Ekf::controlMagFusion()
 	_mag_yaw_reset_req |= otherHeadingSourcesHaveStopped();
 
 	if (noOtherYawAidingThanMag() && _mag_data_ready) {
+		// Restarting mag aiding after a period of no aiding
+		_mag_yaw_reset_req |= !_control_status.flags.mag_hdg;
+
 		if (_control_status.flags.in_air) {
 			checkHaglYawResetReq();
 			runInAirYawReset();

--- a/EKF/mag_control.cpp
+++ b/EKF/mag_control.cpp
@@ -76,7 +76,7 @@ void Ekf::controlMagFusion()
 
 	if (noOtherYawAidingThanMag() && _mag_data_ready) {
 		// Restarting mag aiding after a period of no aiding
-		_mag_yaw_reset_req |= !_control_status.flags.mag_hdg;
+		_mag_yaw_reset_req |= !_control_status.flags.mag_hdg && !_control_status.flags.mag_3D;
 
 		if (_control_status.flags.in_air) {
 			checkHaglYawResetReq();


### PR DESCRIPTION
When mag fusion was stopped (e.g when EV yaw data fusion was started) and restarted, the yaw angle was not reset to that provided by the mag, leading to filter divergence.

The fix is to make sure we reset the yaw when re-starting mag fusion.

**Before this PR:**
![image](https://user-images.githubusercontent.com/5557676/81211938-1cdde700-8fa2-11ea-8033-0a333a029645.png)

**After this PR:**
![image](https://user-images.githubusercontent.com/5557676/81211881-09328080-8fa2-11ea-93e9-44813b5fd38a.png)

**EV Data is stopped at the 79s mark, and restarted at the 95s mark**

Also see https://github.com/PX4/Firmware/issues/14840 where this discovered.

Flight log which illustrates old issue: https://logs.px4.io/plot_app?log=c0a43438-fb28-45fd-9a5b-92329748fb93. 

The fix was tested by running replay on the above log. 