### PR TITLE
Refactor velocity resets

### DIFF
--- a/EKF/ekf.h
+++ b/EKF/ekf.h
@@ -574,6 +574,14 @@ private:
 	// reset velocity states of the ekf
 	bool resetVelocity();
 
+	void resetVelocityToGps();
+
+	void resetHorizontalVelocityToOpticalFlow();
+
+	void resetVelocityToVision();
+
+	void resetHorizontalVelocityToZero();
+
 	void resetVelocityTo(const Vector3f &vel);
 
 	inline void resetHorizontalVelocityTo(const Vector2f &new_horz_vel);


### PR DESCRIPTION
This is splitting up the `resetVelocity` into smaller parts. This is making the intention of the `resetVelocity` function more clear and will help in the future to command a velocity reset to a specific sensor from else where in the code.