### PR TITLE
Fix GPS altitude not fused if GPS checks fail and GPS is primary height source

### DIFF
--- a/EKF/control.cpp
+++ b/EKF/control.cpp
@@ -1003,16 +1003,16 @@ void Ekf::controlHeightFusion()
 
 	case VDIST_SENSOR_GPS:
 
-		// Do switching between GPS and rangefinder if using range finder as
-		// a height source when close to ground and moving slowly
+		// NOTE: emergency fallback due to extended loss of currently selected sensor data or failure
+		// to pass innovation cinsistency checks is handled elsewhere in Ekf::controlHeightSensorTimeouts.
+		// Do switching between GPS and rangefinder if using range finder as a height source when close
+		// to ground and moving slowly. Also handle switch back from emergency Baro sensor when GPS recovers.
 		if (!_control_status_prev.flags.rng_hgt && do_range_aid && _range_sensor.isDataHealthy()) {
 			setControlRangeHeight();
 
 			// we have just switched to using range finder, calculate height sensor offset such that current
 			// measurement matches our current height estimate
-			if (_control_status_prev.flags.rng_hgt != _control_status.flags.rng_hgt) {
-				_hgt_sensor_offset = _terrain_vpos;
-			}
+			_hgt_sensor_offset = _terrain_vpos;
 
 		} else if (_control_status_prev.flags.rng_hgt && !do_range_aid) {
 			// must stop using range finder so find another sensor now


### PR DESCRIPTION
See https://github.com/PX4/ecl/issues/786 for description of problem

This fixes the failure case where if GPS quality resulted in GPS pre-flight checks failing, no height sensor was used. The intended behaviour is now:

1) Once GPS height use commences, it will continue to be use provided 3D fix data is available. 

2) If range finder is being used as part of the user selectable 'range aid' functionality (uses range finder when low and slow), then switch back to using GPS height does require quality checks to pass. This is because GPS glitches combined with use of GPS height at low altitude is undesirable. If GPS quality checks do not pass then baro will be used as a backup. Using baro as a backup may be something that is undesirable for some vehicles.

3) If using baro and GPS checks pass, then switch back to GPs height will occur.

SITL testing with EKF2_HGT_MODE = 1 was performed by reducing EKF check thresholds to force the check to fail. No loss of height fusion was encountered. Further testing of the switching between GPSand  range finder and fallback to baro including the 'range aid' functionality is pending.