### PR TITLE
EKF: fix initialization of local position validity

### DIFF
--- a/EKF/ekf_helper.cpp
+++ b/EKF/ekf_helper.cpp
@@ -1213,7 +1213,7 @@ void Ekf::update_deadreckoning_status()
 	}
 
 	// report if we have been deadreckoning for too long
-	_deadreckon_time_exceeded = isTimedOut(_time_last_aiding, (uint64_t)_params.valid_timeout_max);
+	_deadreckon_time_exceeded = (_time_last_aiding != 0) && isTimedOut(_time_last_aiding, (uint64_t)_params.valid_timeout_max);
 }
 
 // calculate the inverse rotation matrix from a quaternion rotation


### PR DESCRIPTION
The `_deadreckon_time_exceeded` flag is used in `local_position_is_valid()`. This means that
`_params.valid_timeout_max` after startup, in my observed case 5 seconds, the local position switches from valid to invalid and then after a while back to valid again.

With this fix, the local position is flagged valid after alignment and then stays valid as it should, in my opinion.

Maybe related to https://github.com/PX4/Firmware/issues/14835 and https://github.com/mavlink/MAVSDK/pull/1100.