### PR TITLE
EKF: fix initialization of local position validity 2

### DIFF
--- a/EKF/ekf_helper.cpp
+++ b/EKF/ekf_helper.cpp
@@ -1212,8 +1212,8 @@ void Ekf::update_deadreckoning_status()
 		_time_last_aiding = _time_last_imu - _params.no_aid_timeout_max;
 	}
 
-	// report if we have been deadreckoning for too long
-	_deadreckon_time_exceeded = isTimedOut(_time_last_aiding, (uint64_t)_params.valid_timeout_max);
+	// report if we have been deadreckoning for too long, intial state is deadreckoning until aiding is present
+	_deadreckon_time_exceeded = (_time_last_aiding == 0) || isTimedOut(_time_last_aiding, (uint64_t)_params.valid_timeout_max);
 }
 
 // calculate the inverse rotation matrix from a quaternion rotation

--- a/EKF/ekf_helper.cpp
+++ b/EKF/ekf_helper.cpp
@@ -1212,7 +1212,7 @@ void Ekf::update_deadreckoning_status()
 		_time_last_aiding = _time_last_imu - _params.no_aid_timeout_max;
 	}
 
-	// report if we have been deadreckoning for too long, intial state is deadreckoning until aiding is present
+	// report if we have been deadreckoning for too long, initial state is deadreckoning until aiding is present
 	_deadreckon_time_exceeded = (_time_last_aiding == 0) || isTimedOut(_time_last_aiding, (uint64_t)_params.valid_timeout_max);
 }
 

--- a/test/test_EKF_fusionLogic.cpp
+++ b/test/test_EKF_fusionLogic.cpp
@@ -71,11 +71,9 @@ class EkfFusionLogicTest : public ::testing::Test {
 TEST_F(EkfFusionLogicTest, doNoFusion)
 {
 	// GIVEN: a tilt and heading aligned filter
-	// WHEN: having no aiding source EKF should not have a valid position estimate
-
-	// TODO: for the first 5 second it still has some valid local position
-	//       that needs to change
-	EXPECT_TRUE(_ekf->local_position_is_valid());
+	// WHEN: having no aiding source
+	// THEN: EKF should not have a valid position estimate
+	EXPECT_FALSE(_ekf->local_position_is_valid());
 
 	_sensor_simulator.runSeconds(4);
 


### PR DESCRIPTION
Alternative solution to https://github.com/PX4/ecl/pull/819.

> The _deadreckon_time_exceeded flag is used in local_position_is_valid(). This means that
_params.valid_timeout_max after startup, in my observed case 5 seconds, the local position switches from valid to invalid and then after a while back to valid again. @julianoes 

Since the local position flag is also responsible for entering into position control mode, the initial value should be false in my opinion. Otherwise take off in position control could be possible even tough there is no observation constraining the state. 
Only after a first aiding event we should allow it to get valid until the aiding gets timedout eventually.

SITL log:

Before
![Screenshot from 2020-05-16 09-42-01](https://user-images.githubusercontent.com/23532607/82114251-eea79680-975b-11ea-99bd-97675f68118d.png)

After
![Screenshot from 2020-05-16 09-42-27](https://user-images.githubusercontent.com/23532607/82114257-f36c4a80-975b-11ea-9861-b9b2f28631f9.png)

