### PR TITLE
EKF: Allow reset of yaw to EKF-GSF later in flight

### DIFF
--- a/EKF/common.h
+++ b/EKF/common.h
@@ -367,8 +367,9 @@ struct parameters {
 
 	// Parameters used to control when yaw is reset to the EKF-GSF yaw estimator value
 	float EKFGSF_tas_default{15.0f};	///< default airspeed value assumed during fixed wing flight if no airspeed measurement available (m/s)
-	unsigned EKFGSF_reset_delay{1000000};	///< Number of uSec of bad innovations on main filter inpost takeoff phase before yaw is reset to EKF-GSF value
+	unsigned EKFGSF_reset_delay{1000000};	///< Number of uSec of bad innovations on main filter in immediate post-takeoff phase before yaw is reset to EKF-GSF value
 	float EKFGSF_yaw_err_max{0.262f}; 	///< Composite yaw 1-sigma uncertainty threshold used to check for convergence (rad)
+	unsigned EKFGSF_reset_count_limit{3};	///< Maximum number of times the yaw can be reset to the EKF-GSF yaw estimator value
 };
 
 struct stateSample {

--- a/EKF/ekf.h
+++ b/EKF/ekf.h
@@ -876,6 +876,7 @@ private:
 	int64_t _ekfgsf_yaw_reset_time{0};	///< timestamp of last emergency yaw reset (uSec)
 	uint64_t _time_last_on_ground_us{0};	///< last tine we were on the ground (uSec)
 	bool _do_ekfgsf_yaw_reset{false};	// true when an emergency yaw reset has been requested
+	uint8_t _ekfgsf_yaw_reset_count{0};	// number of times the yaw has been reset to the EKF-GSF estimate
 
 	// Call once per _imu_sample_delayed update after all main EKF data fusion oeprations have been completed
 	void runYawEKFGSF();


### PR DESCRIPTION
**Problem**

Currently the main EKF will only make use of the yaw estimator if a gps fusion timeout happens within 30 seconds after takeoff. Given that the estimator works quite well we should enable it always as it could save the vehicle in the case of a mag failure (broken cable, mag coming loose, ...)

**Solution**

This change enables a yaw reset later in flight but  with some limitations:

- The criteria is modified, requiring a complete loss of position and velocity observation for the current nav reset interval
- The total number of resets is limited to 3.
- Resets can't be less than 5 seconds apart
- Resets won't be performed if GPS signal has been lost in the immediate past
- Resets won't be performed if the loss of navigation preceded commencement of flight (we may need to modify that criteria to handle a race condition)

**Testing**

A fixed wing simulation using gazebo was performed with a distant waypoint. ekf2_main.cpp was modified to rotate the compass 90 deg after takeoff to make the compass yaw. innovation checks fail. The Z gyro bias offset parameter was then set to 0.01 to cause a buildup in yaw error. When error reached approx 60 degrees an RTL was commanded. When the turn back commenced, global position loss casued temporary activation fo the failsafe, followed by a yaw reset and recovery:

INFO  [navigator] RTL LAND activated
INFO  [navigator] RTL: landing at mission landing.
INFO  [navigator] RTL: using mission landing
WARN  [commander] Failsafe enabled: no global position
INFO  [commander] Failsafe mode activated
WARN  [navigator] Global position failure: fixed bank loiter
INFO  [commander] Failsafe mode deactivated
INFO  [navigator] RTL LAND activated
INFO  [ecl/EKF] 436040000: reset velocity to GPS
INFO  [ecl/EKF] 436040000: reset position to GPS
INFO  [ecl/EKF] 436040000: Emergency yaw reset - mag use stopped
WARN  [commander] Stopping compass use! Check calibration on landing

Test log : https://logs.px4.io/plot_app?log=ad7170b5-69e9-430a-9c58-cf00eaebd863