### PR TITLE
EKF: Reduce EKF-GSF vulnerability to large yaw gyro bias errors

### DIFF
--- a/EKF/EKFGSF_yaw.cpp
+++ b/EKF/EKFGSF_yaw.cpp
@@ -14,8 +14,9 @@ EKFGSF_yaw::EKFGSF_yaw()
 }
 
 void EKFGSF_yaw::update(const imuSample& imu_sample,
-                	bool run_EKF,           // set to true when flying or movement is suitable for yaw estimation
-                	float airspeed)   	// true airspeed used for centripetal accel compensation - set to 0 when not required.
+			bool run_EKF,			// set to true when flying or movement is suitable for yaw estimation
+			float airspeed,			// true airspeed used for centripetal accel compensation - set to 0 when not required.
+			const Vector3f &imu_gyro_bias)  // estimated rate gyro bias (rad/sec)
 {
 	// copy to class variables
 	_delta_ang = imu_sample.delta_ang;
@@ -60,6 +61,11 @@ void EKFGSF_yaw::update(const imuSample& imu_sample,
 		if (!_ekf_gsf_vel_fuse_started) {
 			initialiseEKFGSF();
 			ahrsAlignYaw();
+			// Initialise to gyro bias estimate from main filter because there could be a large
+			// uncorrected rate gyro bias error about the grabity vector
+			for (uint8_t model_index = 0; model_index < N_MODELS_EKFGSF; model_index ++) {
+				_ahrs_ekf_gsf[model_index].gyro_bias = imu_gyro_bias;
+			}
 			_ekf_gsf_vel_fuse_started = true;
 		} else {
 			bool bad_update = false;

--- a/EKF/EKFGSF_yaw.cpp
+++ b/EKF/EKFGSF_yaw.cpp
@@ -62,7 +62,7 @@ void EKFGSF_yaw::update(const imuSample& imu_sample,
 			initialiseEKFGSF();
 			ahrsAlignYaw();
 			// Initialise to gyro bias estimate from main filter because there could be a large
-			// uncorrected rate gyro bias error about the grabity vector
+			// uncorrected rate gyro bias error about the gravity vector
 			for (uint8_t model_index = 0; model_index < N_MODELS_EKFGSF; model_index ++) {
 				_ahrs_ekf_gsf[model_index].gyro_bias = imu_gyro_bias;
 			}

--- a/EKF/EKFGSF_yaw.h
+++ b/EKF/EKFGSF_yaw.h
@@ -31,11 +31,12 @@ public:
 
     	// Update Filter States - this should be called whenever new IMU data is available
 	void update(const imuSample &imu_sample,
-                	bool run_EKF,           // set to true when flying or movement is suitable for yaw estimation
-                	float airspeed);   	// true airspeed used for centripetal accel compensation - set to 0 when not required.
+			bool run_EKF,  			// set to true when flying or movement is suitable for yaw estimation
+			float airspeed,			// true airspeed used for centripetal accel compensation - set to 0 when not required.
+			const Vector3f &imu_gyro_bias); // estimated rate gyro bias (rad/sec)
 
-	void setVelocity(const Vector2f &velocity,	// NE velocity measurement (m/s)
-                     	float accuracy);	// 1-sigma accuracy of velocity measurement (m/s)
+	void setVelocity(const Vector2f &velocity, // NE velocity measurement (m/s)
+			float accuracy);	   // 1-sigma accuracy of velocity measurement (m/s)
 
 	// get solution data for logging
 	bool getLogData(float *yaw_composite,

--- a/EKF/ekf_helper.cpp
+++ b/EKF/ekf_helper.cpp
@@ -1858,7 +1858,8 @@ void Ekf::runYawEKFGSF()
 		TAS = _airspeed_sample_delayed.true_airspeed;
 	}
 
-	yawEstimator.update(_imu_sample_delayed, _control_status.flags.in_air, TAS);
+	Vector3f imu_gyro_bias = getGyroBias();
+	yawEstimator.update(_imu_sample_delayed, _control_status.flags.in_air, TAS, imu_gyro_bias);
 
 	// basic sanity check on GPS velocity data
 	if (_gps_data_ready && _gps_sample_delayed.vacc > FLT_EPSILON && ISFINITE(_gps_sample_delayed.vel(0)) && ISFINITE(_gps_sample_delayed.vel(1))) {

--- a/EKF/ekf_helper.cpp
+++ b/EKF/ekf_helper.cpp
@@ -1858,7 +1858,7 @@ void Ekf::runYawEKFGSF()
 		TAS = _airspeed_sample_delayed.true_airspeed;
 	}
 
-	Vector3f imu_gyro_bias = getGyroBias();
+	const Vector3f imu_gyro_bias = getGyroBias();
 	yawEstimator.update(_imu_sample_delayed, _control_status.flags.in_air, TAS, imu_gyro_bias);
 
 	// basic sanity check on GPS velocity data


### PR DESCRIPTION
The EKF-GSF yaw estimator uses a bank of AHRS filters that are unable to estimate rate gyro bias about the gravity vector. This can result in poor yaw estimates when large yaw gyro bias errors are present before takeoff. This is the effect of a 0.05 rad/sec yaw rate bias applied in SITL:

![Screen Shot 2020-05-28 at 3 22 34 pm](https://user-images.githubusercontent.com/3596952/83106156-56b49000-a0ff-11ea-9a76-5c634cd7915d.png)

After application of the patch, yaw drift during hover is corrected:

![Screen Shot 2020-05-28 at 4 14 27 pm](https://user-images.githubusercontent.com/3596952/83106232-7481f500-a0ff-11ea-83a0-13e52bf1b44a.png)
