### PR TITLE
Fix GPS reference altitude in case gps checks pass quickly

### DIFF
--- a/EKF/ekf.cpp
+++ b/EKF/ekf.cpp
@@ -93,6 +93,10 @@ void Ekf::reset()
 	_accel_magnitude_filt = 0.0f;
 	_ang_rate_magnitude_filt = 0.0f;
 	_prev_dvel_bias_var.zero();
+
+	_gps_alt_ref = 0.0f;
+
+	resetGpsDriftCheckFilters();
 }
 
 bool Ekf::update()
@@ -188,10 +192,6 @@ bool Ekf::initialiseFilter()
 	} else {
 		// we use baro height initially and switch to GPS/range/EV finder later when it passes checks.
 		setControlBaroHeight();
-
-		// reset variables that are shared with post alignment GPS checks
-		_gps_pos_deriv_filt(2) = 0.0f;
-		_gps_alt_ref = 0.0f;
 
 		if(!initialiseTilt()){
 			return false;

--- a/EKF/ekf.h
+++ b/EKF/ekf.h
@@ -893,4 +893,5 @@ private:
 	// Returns true if the reset was successful
 	bool resetYawToEKFGSF();
 
+	void resetGpsDriftCheckFilters();
 };

--- a/EKF/ekf_helper.cpp
+++ b/EKF/ekf_helper.cpp
@@ -1866,3 +1866,9 @@ void Ekf::runYawEKFGSF()
 		yawEstimator.setVelocity(_gps_sample_delayed.vel.xy(), _gps_sample_delayed.vacc);
 	}
 }
+
+void Ekf::resetGpsDriftCheckFilters()
+{
+	_gps_velNE_filt.setZero();
+	_gps_pos_deriv_filt.setZero();
+}

--- a/EKF/gps_checks.cpp
+++ b/EKF/gps_checks.cpp
@@ -194,10 +194,13 @@ bool Ekf::gps_is_good(const gps_message &gps)
 		_gps_check_fail_status.flags.hspeed = false;
 		_gps_drift_updated = false;
 
+		resetGpsDriftCheckFilters();
+
 	} else {
 		// This is the case where the vehicle is on ground and IMU movement is blocking the drift calculation
 		_gps_drift_updated = true;
 
+		resetGpsDriftCheckFilters();
 	}
 
 	// save GPS fix for next time


### PR DESCRIPTION
In SITL the gps reference altitude was always set to zero as the gps checks passed before the main filtered initialized.
This PR also sets the gps velocity and position derivative filter states to zero if they are not being updated (vehicle is in air or there is movement.)