### PR TITLE
AlphaFilter: prevent setParameters division by zero

### DIFF
--- a/EKF/AlphaFilter.hpp
+++ b/EKF/AlphaFilter.hpp
@@ -42,6 +42,8 @@
 
 #pragma once
 
+#include "../ecl.h"
+
 template <typename T>
 class AlphaFilter {
 public:
@@ -65,7 +67,11 @@ public:
 	 *
 	 * @param alpha [0,1] filter weight for the previous state. High value - long time constant.
 	 */
-	void setAlpha(float alpha) { _alpha = alpha; }
+	void setAlpha(float alpha) {
+		if (ISFINITE(alpha)) {
+			_alpha = alpha;
+		}
+	}
 
 	/**
 	 * Set filter state to an initial value


### PR DESCRIPTION
fixes https://github.com/PX4/Firmware/issues/15065

The denominator of `setParameters()` can get zero if `time_constant` and `sample_interval` both are exactly zero. In this case updating the filter coefficient needs to be prevented.