### PR TITLE
GPS yaw improvements

### DIFF
--- a/EKF/control.cpp
+++ b/EKF/control.cpp
@@ -526,6 +526,7 @@ void Ekf::controlGpsFusion()
 
 		} else {
 			if (ISFINITE(_gps_sample_delayed.yaw)) {
+
 				if (!_control_status.flags.gps_yaw
 				    && _control_status.flags.tilt_align
 				    && !_gps_hgt_intermittent) {
@@ -548,7 +549,8 @@ void Ekf::controlGpsFusion()
 			// Check if the data is constantly fused by the estimator,
 			// if not, declare the sensor faulty and stop the fusion
 			// By doing this, another source of yaw aiding is allowed to start
-			if (isTimedOut(_time_last_gps_yaw_fuse, (uint64_t)5e6)) {
+			if (isTimedOut(_time_last_gps_yaw_fuse, (uint64_t)5e6)
+			    && _control_status.flags.gps_yaw) {
 				_is_gps_yaw_faulty = true;
 				stopGpsYawFusion();
 			}

--- a/EKF/control.cpp
+++ b/EKF/control.cpp
@@ -522,20 +522,14 @@ void Ekf::controlGpsFusion()
 		if ((_params.fusion_mode & MASK_USE_GPSYAW)
 				&& ISFINITE(_gps_sample_delayed.yaw)
 				&& _control_status.flags.tilt_align
-				&& (!_control_status.flags.gps_yaw || !_control_status.flags.yaw_align)
+				&& !_control_status.flags.gps_yaw
 				&& !_gps_hgt_intermittent) {
 
 			if (resetGpsAntYaw()) {
 				// flag the yaw as aligned
 				_control_status.flags.yaw_align = true;
 
-				// turn on fusion of external vision yaw measurements and disable all other yaw fusion
-				_control_status.flags.gps_yaw = true;
-				_control_status.flags.ev_yaw = false;
-				_control_status.flags.mag_dec = false;
-
-				stopMagHdgFusion();
-				stopMag3DFusion();
+				startGpsYawFusion();
 
 				ECL_INFO_TIMESTAMPED("starting GPS yaw fusion");
 			}

--- a/EKF/control.cpp
+++ b/EKF/control.cpp
@@ -534,10 +534,7 @@ void Ekf::controlGpsFusion()
 					// Activate GPS yaw fusion
 					if (resetGpsAntYaw()) {
 						_control_status.flags.yaw_align = true;
-
 						startGpsYawFusion();
-
-						ECL_INFO_TIMESTAMPED("starting GPS yaw fusion");
 					}
 				}
 

--- a/EKF/ekf.h
+++ b/EKF/ekf.h
@@ -351,6 +351,8 @@ private:
 	uint64_t _time_last_beta_fuse{0};	///< time the last fusion of synthetic sideslip measurements were performed (uSec)
 	uint64_t _time_last_fake_pos{0};	///< last time we faked position measurements to constrain tilt errors during operation without external aiding (uSec)
 
+	uint64_t _time_last_gps_yaw_fuse{0};	///< time the last fusion of GPS yaw measurements were performed (uSec)
+
 	Vector2f _last_known_posNE;		///< last known local NE position vector (m)
 	float _imu_collection_time_adj{0.0f};	///< the amount of time the IMU collection needs to be advanced to meet the target set by FILTER_UPDATE_PERIOD_MS (sec)
 

--- a/EKF/ekf.h
+++ b/EKF/ekf.h
@@ -499,6 +499,7 @@ private:
 	// height sensor status
 	bool _baro_hgt_faulty{false};		///< true if valid baro data is unavailable for use
 	bool _gps_hgt_intermittent{false};	///< true if gps height into the buffer is intermittent
+	bool _is_gps_yaw_faulty{false};		///< true if gps yaw data is rejected by the filter for too long
 
 	// imu fault status
 	uint64_t _time_bad_vert_accel{0};	///< last time a bad vertical accel was detected (uSec)

--- a/EKF/ekf.h
+++ b/EKF/ekf.h
@@ -693,7 +693,7 @@ private:
 	void controlMagFusion();
 	void updateMagFilter();
 
-	bool canRunMagFusion() const;
+	bool noOtherYawAidingThanMag() const;
 
 	void checkHaglYawResetReq();
 	float getTerrainVPos() const;
@@ -848,6 +848,7 @@ private:
 
 	void stopGpsVelFusion();
 
+	void startGpsYawFusion();
 	void stopGpsYawFusion();
 
 	void stopEvFusion();

--- a/EKF/ekf_helper.cpp
+++ b/EKF/ekf_helper.cpp
@@ -1671,6 +1671,15 @@ void Ekf::stopGpsVelFusion()
 	_gps_vel_test_ratio.setZero();
 }
 
+void Ekf::startGpsYawFusion()
+{
+	_control_status.flags.mag_dec = false;
+	stopEvYawFusion();
+	stopMagHdgFusion();
+	stopMag3DFusion();
+	_control_status.flags.gps_yaw = true;
+}
+
 void Ekf::stopGpsYawFusion()
 {
 	_control_status.flags.gps_yaw = false;

--- a/EKF/gps_yaw_fusion.cpp
+++ b/EKF/gps_yaw_fusion.cpp
@@ -303,20 +303,11 @@ bool Ekf::resetGpsAntYaw()
 			return false;
 		}
 
-		const float predicted_yaw =  atan2f(ant_vec_ef(1),ant_vec_ef(0));
-
 		// get measurement and correct for antenna array yaw offset
 		const float measured_yaw = _gps_sample_delayed.yaw + _gps_yaw_offset;
 
-		// calculate the amount the yaw needs to be rotated by
-		const float yaw_delta = wrap_pi(measured_yaw - predicted_yaw);
-
-		// update the quaternion state estimates and corresponding covariances only if
-		// the change in angle has been large or the yaw is not yet aligned
-		if(fabsf(yaw_delta) > math::radians(15.0f) || !_control_status.flags.yaw_align) {
-			const float yaw_variance = sq(fmaxf(_params.mag_heading_noise, 1.0e-2f));
-			resetQuatStateYaw(measured_yaw, yaw_variance, true);
-		}
+		const float yaw_variance = sq(fmaxf(_params.mag_heading_noise, 1.0e-2f));
+		resetQuatStateYaw(measured_yaw, yaw_variance, true);
 
 		return true;
 	}

--- a/EKF/gps_yaw_fusion.cpp
+++ b/EKF/gps_yaw_fusion.cpp
@@ -53,17 +53,14 @@ void Ekf::fuseGpsAntYaw()
 	const float q2 = _state.quat_nominal(2);
 	const float q3 = _state.quat_nominal(3);
 
-	float R_YAW = 1.0f;
-	float predicted_hdg;
 	float H_YAW[4];
-	float measured_hdg;
 
 	// calculate the observed yaw angle of antenna array, converting a from body to antenna yaw measurement
-	measured_hdg = _gps_sample_delayed.yaw + _gps_yaw_offset;
+	const float measured_hdg = wrap_pi(_gps_sample_delayed.yaw + _gps_yaw_offset);
 
 	// define the predicted antenna array vector and rotate into earth frame
-	Vector3f ant_vec_bf = {cosf(_gps_yaw_offset), sinf(_gps_yaw_offset), 0.0f};
-	Vector3f ant_vec_ef = _R_to_earth * ant_vec_bf;
+	const Vector3f ant_vec_bf = {cosf(_gps_yaw_offset), sinf(_gps_yaw_offset), 0.0f};
+	const Vector3f ant_vec_ef = _R_to_earth * ant_vec_bf;
 
 	// check if antenna array vector is within 30 degrees of vertical and therefore unable to provide a reliable heading
 	if (fabsf(ant_vec_ef(2)) > cosf(math::radians(30.0f)))  {
@@ -71,7 +68,7 @@ void Ekf::fuseGpsAntYaw()
 	}
 
 	// calculate predicted antenna yaw angle
-	predicted_hdg =  atan2f(ant_vec_ef(1),ant_vec_ef(0));
+	const float predicted_hdg =  atan2f(ant_vec_ef(1),ant_vec_ef(0));
 
 	// calculate observation jacobian
 	float t2 = sinf(_gps_yaw_offset);
@@ -126,10 +123,7 @@ void Ekf::fuseGpsAntYaw()
 	H_YAW[3] = t30*(t26*t32+t16*t22*t35);
 
 	// using magnetic heading tuning parameter
-	R_YAW = sq(fmaxf(_params.mag_heading_noise, 1.0e-2f));
-
-	// wrap the heading to the interval between +-pi
-	measured_hdg = wrap_pi(measured_hdg);
+	const float R_YAW = sq(fmaxf(_params.mag_heading_noise, 1.0e-2f));
 
 	// calculate the innovation and define the innovation gate
 	float innov_gate = math::max(_params.heading_innov_gate, 1.0f);

--- a/EKF/gps_yaw_fusion.cpp
+++ b/EKF/gps_yaw_fusion.cpp
@@ -58,82 +58,75 @@ void Ekf::fuseGpsAntYaw()
 	float H_YAW[4];
 	float measured_hdg;
 
-	// check if data has been set to NAN indicating no measurement
-	if (ISFINITE(_gps_sample_delayed.yaw)) {
-		// calculate the observed yaw angle of antenna array, converting a from body to antenna yaw measurement
-		measured_hdg = _gps_sample_delayed.yaw + _gps_yaw_offset;
+	// calculate the observed yaw angle of antenna array, converting a from body to antenna yaw measurement
+	measured_hdg = _gps_sample_delayed.yaw + _gps_yaw_offset;
 
-		// define the predicted antenna array vector and rotate into earth frame
-		Vector3f ant_vec_bf = {cosf(_gps_yaw_offset), sinf(_gps_yaw_offset), 0.0f};
-		Vector3f ant_vec_ef = _R_to_earth * ant_vec_bf;
+	// define the predicted antenna array vector and rotate into earth frame
+	Vector3f ant_vec_bf = {cosf(_gps_yaw_offset), sinf(_gps_yaw_offset), 0.0f};
+	Vector3f ant_vec_ef = _R_to_earth * ant_vec_bf;
 
-		// check if antenna array vector is within 30 degrees of vertical and therefore unable to provide a reliable heading
-		if (fabsf(ant_vec_ef(2)) > cosf(math::radians(30.0f)))  {
-			return;
-		}
-
-		// calculate predicted antenna yaw angle
-		predicted_hdg =  atan2f(ant_vec_ef(1),ant_vec_ef(0));
-
-		// calculate observation jacobian
-		float t2 = sinf(_gps_yaw_offset);
-		float t3 = cosf(_gps_yaw_offset);
-		float t4 = q0*q3*2.0f;
-		float t5 = q0*q0;
-		float t6 = q1*q1;
-		float t7 = q2*q2;
-		float t8 = q3*q3;
-		float t9 = q1*q2*2.0f;
-		float t10 = t5+t6-t7-t8;
-		float t11 = t3*t10;
-		float t12 = t4+t9;
-		float t13 = t3*t12;
-		float t14 = t5-t6+t7-t8;
-		float t15 = t2*t14;
-		float t16 = t13+t15;
-		float t17 = t4-t9;
-		float t19 = t2*t17;
-		float t20 = t11-t19;
-		float t18 = (t20*t20);
-		if (t18 < 1e-6f) {
-			return;
-		}
-		t18 = 1.0f / t18;
-		float t21 = t16*t16;
-		float t22 = sq(t11-t19);
-		if (t22 < 1e-6f) {
-			return;
-		}
-		t22 = 1.0f/t22;
-		float t23 = q1*t3*2.0f;
-		float t24 = q2*t2*2.0f;
-		float t25 = t23+t24;
-		float t26 = 1.0f/t20;
-		float t27 = q1*t2*2.0f;
-		float t28 = t21*t22;
-		float t29 = t28+1.0f;
-		if (fabsf(t29) < 1e-6f) {
-			return;
-		}
-		float t30 = 1.0f/t29;
-		float t31 = q0*t3*2.0f;
-		float t32 = t31-q3*t2*2.0f;
-		float t33 = q3*t3*2.0f;
-		float t34 = q0*t2*2.0f;
-		float t35 = t33+t34;
-
-		H_YAW[0] = (t35/(t11-t2*(t4-q1*q2*2.0f))-t16*t18*t32)/(t18*t21+1.0f);
-		H_YAW[1] = -t30*(t26*(t27-q2*t3*2.0f)+t16*t22*t25);
-		H_YAW[2] = t30*(t25*t26-t16*t22*(t27-q2*t3*2.0f));
-		H_YAW[3] = t30*(t26*t32+t16*t22*t35);
-
-		// using magnetic heading tuning parameter
-		R_YAW = sq(fmaxf(_params.mag_heading_noise, 1.0e-2f));
-
-	} else {
-		// there is nothing to fuse
+	// check if antenna array vector is within 30 degrees of vertical and therefore unable to provide a reliable heading
+	if (fabsf(ant_vec_ef(2)) > cosf(math::radians(30.0f)))  {
 		return;
 	}
+
+	// calculate predicted antenna yaw angle
+	predicted_hdg =  atan2f(ant_vec_ef(1),ant_vec_ef(0));
+
+	// calculate observation jacobian
+	float t2 = sinf(_gps_yaw_offset);
+	float t3 = cosf(_gps_yaw_offset);
+	float t4 = q0*q3*2.0f;
+	float t5 = q0*q0;
+	float t6 = q1*q1;
+	float t7 = q2*q2;
+	float t8 = q3*q3;
+	float t9 = q1*q2*2.0f;
+	float t10 = t5+t6-t7-t8;
+	float t11 = t3*t10;
+	float t12 = t4+t9;
+	float t13 = t3*t12;
+	float t14 = t5-t6+t7-t8;
+	float t15 = t2*t14;
+	float t16 = t13+t15;
+	float t17 = t4-t9;
+	float t19 = t2*t17;
+	float t20 = t11-t19;
+	float t18 = (t20*t20);
+	if (t18 < 1e-6f) {
+		return;
+	}
+	t18 = 1.0f / t18;
+	float t21 = t16*t16;
+	float t22 = sq(t11-t19);
+	if (t22 < 1e-6f) {
+		return;
+	}
+	t22 = 1.0f/t22;
+	float t23 = q1*t3*2.0f;
+	float t24 = q2*t2*2.0f;
+	float t25 = t23+t24;
+	float t26 = 1.0f/t20;
+	float t27 = q1*t2*2.0f;
+	float t28 = t21*t22;
+	float t29 = t28+1.0f;
+	if (fabsf(t29) < 1e-6f) {
+		return;
+	}
+	float t30 = 1.0f/t29;
+	float t31 = q0*t3*2.0f;
+	float t32 = t31-q3*t2*2.0f;
+	float t33 = q3*t3*2.0f;
+	float t34 = q0*t2*2.0f;
+	float t35 = t33+t34;
+
+	H_YAW[0] = (t35/(t11-t2*(t4-q1*q2*2.0f))-t16*t18*t32)/(t18*t21+1.0f);
+	H_YAW[1] = -t30*(t26*(t27-q2*t3*2.0f)+t16*t22*t25);
+	H_YAW[2] = t30*(t25*t26-t16*t22*(t27-q2*t3*2.0f));
+	H_YAW[3] = t30*(t26*t32+t16*t22*t35);
+
+	// using magnetic heading tuning parameter
+	R_YAW = sq(fmaxf(_params.mag_heading_noise, 1.0e-2f));
 
 	// wrap the heading to the interval between +-pi
 	measured_hdg = wrap_pi(measured_hdg);
@@ -210,7 +203,6 @@ void Ekf::fuseGpsAntYaw()
 	// we are no longer using 3-axis fusion so set the reported test levels to zero
 	memset(_mag_test_ratio, 0, sizeof(_mag_test_ratio));
 
-	// set the magnetometer unhealthy if the test fails
 	if (_yaw_test_ratio > 1.0f) {
 		_innov_check_fail_status.flags.reject_yaw = true;
 
@@ -273,6 +265,7 @@ void Ekf::fuseGpsAntYaw()
 
 	// only apply covariance and state corrections if healthy
 	if (healthy) {
+		_time_last_gps_yaw_fuse = _time_last_imu;
 		// apply the covariance corrections
 		for (unsigned row = 0; row < _k_num_states; row++) {
 			for (unsigned column = 0; column < _k_num_states; column++) {
@@ -291,26 +284,20 @@ void Ekf::fuseGpsAntYaw()
 
 bool Ekf::resetGpsAntYaw()
 {
-	// check if data has been set to NAN indicating no measurement
-	if (ISFINITE(_gps_sample_delayed.yaw)) {
+	// define the predicted antenna array vector and rotate into earth frame
+	const Vector3f ant_vec_bf = {cosf(_gps_yaw_offset), sinf(_gps_yaw_offset), 0.0f};
+	const Vector3f ant_vec_ef = _R_to_earth * ant_vec_bf;
 
-		// define the predicted antenna array vector and rotate into earth frame
-		const Vector3f ant_vec_bf = {cosf(_gps_yaw_offset), sinf(_gps_yaw_offset), 0.0f};
-		const Vector3f ant_vec_ef = _R_to_earth * ant_vec_bf;
-
-		// check if antenna array vector is within 30 degrees of vertical and therefore unable to provide a reliable heading
-		if (fabsf(ant_vec_ef(2)) > cosf(math::radians(30.0f)))  {
-			return false;
-		}
-
-		// get measurement and correct for antenna array yaw offset
-		const float measured_yaw = _gps_sample_delayed.yaw + _gps_yaw_offset;
-
-		const float yaw_variance = sq(fmaxf(_params.mag_heading_noise, 1.0e-2f));
-		resetQuatStateYaw(measured_yaw, yaw_variance, true);
-
-		return true;
+	// check if antenna array vector is within 30 degrees of vertical and therefore unable to provide a reliable heading
+	if (fabsf(ant_vec_ef(2)) > cosf(math::radians(30.0f)))  {
+		return false;
 	}
 
-	return false;
+	// get measurement and correct for antenna array yaw offset
+	const float measured_yaw = _gps_sample_delayed.yaw + _gps_yaw_offset;
+
+	const float yaw_variance = sq(fmaxf(_params.mag_heading_noise, 1.0e-2f));
+	resetQuatStateYaw(measured_yaw, yaw_variance, true);
+
+	return true;
 }

--- a/test/sensor_simulator/ekf_wrapper.cpp
+++ b/test/sensor_simulator/ekf_wrapper.cpp
@@ -170,6 +170,20 @@ void EkfWrapper::disableExternalVisionAlignment()
 	_ekf_params->fusion_mode &= ~MASK_ROTATE_EV;
 }
 
+bool EkfWrapper::isIntendingMagHeadingFusion() const
+{
+	filter_control_status_u control_status;
+	_ekf->get_control_mode(&control_status.value);
+	return control_status.flags.mag_hdg;
+}
+
+bool EkfWrapper::isIntendingMag3DFusion() const
+{
+	filter_control_status_u control_status;
+	_ekf->get_control_mode(&control_status.value);
+	return control_status.flags.mag_3D;
+}
+
 bool EkfWrapper::isWindVelocityEstimated() const
 {
 	filter_control_status_u control_status;

--- a/test/sensor_simulator/ekf_wrapper.h
+++ b/test/sensor_simulator/ekf_wrapper.h
@@ -84,6 +84,9 @@ public:
 	void disableExternalVisionHeadingFusion();
 	bool isIntendingExternalVisionHeadingFusion() const;
 
+	bool isIntendingMagHeadingFusion() const;
+	bool isIntendingMag3DFusion() const;
+
 	void enableExternalVisionAlignment();
 	void disableExternalVisionAlignment();
 

--- a/test/sensor_simulator/gps.cpp
+++ b/test/sensor_simulator/gps.cpp
@@ -102,7 +102,7 @@ gps_message Gps::getDefaultGpsData()
 	gps_data.lat = 473566094;
 	gps_data.lon = 85190237;
 	gps_data.alt = 422056;
-	gps_data.yaw = 0.0f;
+	gps_data.yaw = NAN;
 	gps_data.yaw_offset = 0.0f;
 	gps_data.fix_type = 3;
 	gps_data.eph = 0.5f;

--- a/test/sensor_simulator/gps.h
+++ b/test/sensor_simulator/gps.h
@@ -66,7 +66,7 @@ public:
 	gps_message getDefaultGpsData();
 
 private:
-	gps_message _gps_data;
+	gps_message _gps_data{};
 	Vector3f _gps_pos_rate{};
 
 	void send(uint64_t time) override;

--- a/test/test_EKF_gps_yaw.cpp
+++ b/test/test_EKF_gps_yaw.cpp
@@ -58,8 +58,10 @@ class EkfGpsHeadingTest : public ::testing::Test {
 	void SetUp() override
 	{
 		_ekf->init(0);
+		_sensor_simulator._gps.setYaw(NAN);
 		_sensor_simulator.runSeconds(2);
 		_ekf_wrapper.enableGpsFusion();
+		_ekf_wrapper.enableGpsHeadingFusion();
 		_sensor_simulator.startGps();
 		_sensor_simulator.runSeconds(11);
 	}
@@ -121,11 +123,13 @@ TEST_F(EkfGpsHeadingTest, yawConvergence)
 TEST_F(EkfGpsHeadingTest, fallBackToMag)
 {
 	// GIVEN: an initial GPS yaw, not aligned with the current one
+	// GPS yaw is expected to arrive a bit later, first feed some NANs
+	// to the filter
+	_sensor_simulator.runSeconds(6);
 	float gps_heading = _ekf_wrapper.getYawAngle() + math::radians(10.f);
 	_sensor_simulator._gps.setYaw(gps_heading);
 
 	// WHEN: the GPS yaw fusion is activated
-	_ekf_wrapper.enableGpsHeadingFusion();
 	_sensor_simulator.runSeconds(1);
 
 	// THEN: GPS heading fusion should have started, and mag


### PR DESCRIPTION
Summary of the changes:
- always reset yaw estimate when starting GPS yaw fusion
   - This is done because otherwise, if close to the limit (15 degrees), a large gyro bias can be learned and it takes a loooong time for the estimate to converge to the yaw GPS value
- disable GPS yaw fusion if there is no yaw data in the GPS message, if the fusion is rejected or if disabled by the user. The estimator will automatically fall back to another source of yaw aiding if possible (e.g.: mag fusion if enabled).
- add unit tests

non-functional change:
- do not check if the GPS yaw data is nan in the fusion function but only in `control.cpp`