### PR TITLE
Attempt to fix CI firmware build test

### DIFF
--- a/.github/workflows/firmware_build_test.yml
+++ b/.github/workflows/firmware_build_test.yml
@@ -31,7 +31,7 @@ jobs:
     - name: Configure Firmware to include current ECL version
       working-directory: ../Firmware/src/lib/ecl
       run: |
-        git fetch origin +${{ github.ref }}
+        git fetch origin ${{ github.ref }}
         git checkout ${{ github.sha }}
     - name: Add and commit new ECL version
       run: |


### PR DESCRIPTION
At the moment Firmware build checks fail on pull requests from forks. I hope this is change is indeed enough.