### PR TITLE
GPS Yaw: fix heading initialisation and add unit tests

### DIFF
--- a/EKF/control.cpp
+++ b/EKF/control.cpp
@@ -515,15 +515,12 @@ void Ekf::controlGpsFusion()
 	// Check for new GPS data that has fallen behind the fusion time horizon
 	if (_gps_data_ready) {
 
-		// Detect if coming back after significant time without GPS data
-		bool gps_signal_was_lost = isTimedOut(_time_prev_gps_us, 1000000);
-
 		controlGpsYawFusion();
 
 		// Determine if we should use GPS aiding for velocity and horizontal position
 		// To start using GPS we need angular alignment completed, the local NED origin set and GPS data that has not failed checks recently
-		bool gps_checks_passing = isTimedOut(_last_gps_fail_us, (uint64_t)5e6);
-		bool gps_checks_failing = isTimedOut(_last_gps_pass_us, (uint64_t)5e6);
+		const bool gps_checks_passing = isTimedOut(_last_gps_fail_us, (uint64_t)5e6);
+		const bool gps_checks_failing = isTimedOut(_last_gps_pass_us, (uint64_t)5e6);
 		if ((_params.fusion_mode & MASK_USE_GPS) && !_control_status.flags.gps) {
 			if (_control_status.flags.tilt_align && _NED_origin_initialised && gps_checks_passing) {
 				// If the heading is not aligned, reset the yaw and magnetic field states
@@ -577,7 +574,7 @@ void Ekf::controlGpsFusion()
 
 		// handle case where we are not currently using GPS, but need to align yaw angle using EKF-GSF before
 		// we can start using GPS
-		bool align_yaw_using_gsf = !_control_status.flags.gps && _do_ekfgsf_yaw_reset && isTimedOut(_ekfgsf_yaw_reset_time, 5000000);
+		const bool align_yaw_using_gsf = !_control_status.flags.gps && _do_ekfgsf_yaw_reset && isTimedOut(_ekfgsf_yaw_reset_time, 5000000);
 		if (align_yaw_using_gsf) {
 			if (resetYawToEKFGSF()) {
 				_ekfgsf_yaw_reset_time = _time_last_imu;
@@ -631,6 +628,8 @@ void Ekf::controlGpsFusion()
 							  (_time_last_hor_vel_fuse > _time_last_on_ground_us) &&
 							  (_time_last_hor_pos_fuse > _time_last_on_ground_us);
 
+			// Detect if coming back after significant time without GPS data
+			const bool gps_signal_was_lost = isTimedOut(_time_prev_gps_us, 1000000);
 			const bool do_yaw_vel_pos_reset = (_do_ekfgsf_yaw_reset || recent_takeoff_nav_failure || inflight_nav_failure) &&
 							  _ekfgsf_yaw_reset_count < _params.EKFGSF_reset_count_limit &&
 							  isTimedOut(_ekfgsf_yaw_reset_time, 5000000) &&

--- a/EKF/ekf.h
+++ b/EKF/ekf.h
@@ -553,11 +553,11 @@ private:
 	void updateQuaternion(const float innovation, const float variance, const float gate_sigma, const float (&yaw_jacobian)[4]);
 
 	// fuse the yaw angle obtained from a dual antenna GPS unit
-	void fuseGpsAntYaw();
+	void fuseGpsYaw();
 
 	// reset the quaternions states using the yaw angle obtained from a dual antenna GPS unit
 	// return true if the reset was successful
-	bool resetGpsAntYaw();
+	bool resetYawToGps();
 
 	// fuse magnetometer declination measurement
 	// argument passed in is the declination uncertainty in radians
@@ -691,6 +691,7 @@ private:
 
 	// control fusion of GPS observations
 	void controlGpsFusion();
+	void controlGpsYawFusion();
 
 	// control fusion of magnetometer observations
 	void controlMagFusion();

--- a/EKF/gps_yaw_fusion.cpp
+++ b/EKF/gps_yaw_fusion.cpp
@@ -277,8 +277,8 @@ bool Ekf::resetGpsAntYaw()
 		return false;
 	}
 
-	// get measurement and correct for antenna array yaw offset
-	const float measured_yaw = _gps_sample_delayed.yaw + _gps_yaw_offset;
+	// GPS yaw measurement is alreday compensated for antenna offset in the driver
+	const float measured_yaw = _gps_sample_delayed.yaw;
 
 	const float yaw_variance = sq(fmaxf(_params.mag_heading_noise, 1.0e-2f));
 	resetQuatStateYaw(measured_yaw, yaw_variance, true);

--- a/EKF/gps_yaw_fusion.cpp
+++ b/EKF/gps_yaw_fusion.cpp
@@ -45,7 +45,7 @@
 #include <mathlib/mathlib.h>
 #include <cstdlib>
 
-void Ekf::fuseGpsAntYaw()
+void Ekf::fuseGpsYaw()
 {
 	// assign intermediate state variables
 	const float q0 = _state.quat_nominal(0);
@@ -266,7 +266,7 @@ void Ekf::fuseGpsAntYaw()
 	}
 }
 
-bool Ekf::resetGpsAntYaw()
+bool Ekf::resetYawToGps()
 {
 	// define the predicted antenna array vector and rotate into earth frame
 	const Vector3f ant_vec_bf = {cosf(_gps_yaw_offset), sinf(_gps_yaw_offset), 0.0f};
@@ -282,6 +282,8 @@ bool Ekf::resetGpsAntYaw()
 
 	const float yaw_variance = sq(fmaxf(_params.mag_heading_noise, 1.0e-2f));
 	resetQuatStateYaw(measured_yaw, yaw_variance, true);
+
+	_time_last_gps_yaw_fuse = _time_last_imu;
 
 	return true;
 }

--- a/test/sensor_simulator/gps.cpp
+++ b/test/sensor_simulator/gps.cpp
@@ -58,6 +58,10 @@ void Gps::setYaw(float yaw) {
 	_gps_data.yaw = yaw;
 }
 
+void Gps::setYawOffset(float yaw_offset) {
+	_gps_data.yaw_offset = yaw_offset;
+}
+
 void Gps::setFixType(int n)
 {
 	_gps_data.fix_type = n;

--- a/test/sensor_simulator/gps.h
+++ b/test/sensor_simulator/gps.h
@@ -59,6 +59,7 @@ public:
 	void setLongitude(int32_t lon);
 	void setVelocity(const Vector3f& vel);
 	void setYaw(float yaw);
+	void setYawOffset(float yaw);
 	void setFixType(int n);
 	void setNumberOfSatellites(int n);
 	void setPdop(float pdop);


### PR DESCRIPTION
When the antennas are not parallel to the x body axis, the GPS message contains the angular offset but the data is already corrected in the driver. EKF2 should then not add this offset during the initialization.

I also added unit tests with different initial orientations and antenna offsets.