### PR TITLE
GPS Yaw: use fuseYaw321/312 functions

### DIFF
--- a/EKF/ekf.h
+++ b/EKF/ekf.h
@@ -537,20 +537,23 @@ private:
 	// yaw : angle observation defined as the first rotation in a 321 Tait-Bryan rotation sequence (rad)
 	// yaw_variance : variance of the yaw angle observation (rad^2)
 	// zero_innovation : Fuse data with innovation set to zero
-	void fuseYaw321(const float yaw, const float yaw_variance, bool zero_innovation);
+	// return true if the fusion was successful
+	bool fuseYaw321(const float yaw, const float yaw_variance, bool zero_innovation = false);
 
 	// fuse the yaw angle defined as the first rotation in a 312 Tait-Bryan rotation sequence
 	// yaw : angle observation defined as the first rotation in a 312 Tait-Bryan rotation sequence (rad)
 	// yaw_variance : variance of the yaw angle observation (rad^2)
 	// zero_innovation : Fuse data with innovation set to zero
-	void fuseYaw312(const float yaw, const float yaw_variance, bool zero_innovation);
+	// return true if the fusion was successful
+	bool fuseYaw312(const float yaw, const float yaw_variance, bool zero_innovation = false);
 
 	// update quaternion states and covariances using an innovation, observation variance and Jacobian vector
 	// innovation : prediction - measurement
 	// variance : observaton variance
 	// gate_sigma : innovation consistency check gate size (Sigma)
 	// jacobian : 4x1 vector of partial derivatives of observation wrt each quaternion state
-	void updateQuaternion(const float innovation, const float variance, const float gate_sigma, const float (&yaw_jacobian)[4]);
+	// return true if the fusion was successful
+	bool updateQuaternion(const float innovation, const float variance, const float gate_sigma, const float (&yaw_jacobian)[4]);
 
 	// fuse the yaw angle obtained from a dual antenna GPS unit
 	void fuseGpsYaw();


### PR DESCRIPTION
Saves 840 bytes of flash space


With the current implementation:
![2020-07-02_13-03-29_01_plot](https://user-images.githubusercontent.com/14822839/86353515-a7238e00-bc67-11ea-90f9-e28bbbf9878e.png)
![Screen Capture_select-area_20200702134057](https://user-images.githubusercontent.com/14822839/86354728-d76c2c00-bc69-11ea-87db-febf82fae084.png)


Replayed with this PR:
![2020-07-02_13-03-44_01_plot](https://user-images.githubusercontent.com/14822839/86353531-ad196f00-bc67-11ea-9f33-63efc26091c9.png)
![Screen Capture_select-area_20200702133840](https://user-images.githubusercontent.com/14822839/86354753-e18e2a80-bc69-11ea-9511-83ae94c81c37.png)


Original log file:
https://logs.px4.io/plot_app?log=46feda49-d644-4ed0-acbd-868ff70779eb
