### PR TITLE
Do not update time_last_imu outside of setGpsData

### DIFF
--- a/EKF/control.cpp
+++ b/EKF/control.cpp
@@ -553,7 +553,6 @@ void Ekf::controlGpsFusion()
 
 					ECL_INFO_TIMESTAMPED("starting GPS fusion");
 					_control_status.flags.gps = true;
-					_time_last_gps = _time_last_imu;
 				}
 			}
 


### PR DESCRIPTION
For each sensor we keep the timestamp of the latest measurement in the buffer. This timestamp is used to not push data in the buffer to often, which would lead to a lose of measurements.

Surprisingly, the `_time_last_gps` timestamp was updated with the imu timestamp once when we start the GPS fusion. I think this is not correct and should be removed.