### PR TITLE
Negative distances go in the opposite direction

### DIFF
--- a/geo/geo.cpp
+++ b/geo/geo.cpp
@@ -304,7 +304,7 @@ void waypoint_from_heading_and_distance(double lat_start, double lon_start, floa
 					double *lat_target, double *lon_target)
 {
 	bearing = wrap_2pi(bearing);
-	double radius_ratio = (double)fabs((double)dist) / CONSTANTS_RADIUS_OF_EARTH;
+	double radius_ratio = dist / CONSTANTS_RADIUS_OF_EARTH;
 
 	double lat_start_rad = math::radians(lat_start);
 	double lon_start_rad = math::radians(lon_start);

--- a/test/test_geo.cpp
+++ b/test/test_geo.cpp
@@ -95,3 +95,43 @@ TEST_F(GeoTest, projectReproject)
 	EXPECT_FLOAT_EQ(lat, lat_new);
 	EXPECT_FLOAT_EQ(lon, lon_new);
 }
+
+TEST_F(GeoTest, waypoint_from_heading_and_zero_distance)
+{
+	// GIVEN: a starting waypoint, a heading and a distance of 0
+	double lat_start = -33;
+	double lon_start = 18;
+	float bearing = 0;
+	float dist = 0;
+
+	double lat_target = 0;
+	double lon_target = 0;
+
+	// WHEN: we get the next waypoint
+	waypoint_from_heading_and_distance(lat_start, lon_start, bearing, dist, &lat_target, &lon_target);
+
+	// THEN: it should be the same
+	EXPECT_DOUBLE_EQ(lat_start, lat_target);
+	EXPECT_DOUBLE_EQ(lon_start, lon_target);
+}
+
+
+TEST_F(GeoTest, waypoint_from_heading_and_negative_distance)
+{
+	// GIVEN: a starting waypoint, a heading and a distance of 0
+	double lat_start = -33;
+	double lon_start = 18;
+	float bearing = 0;
+	float lat_offset = -0.01f;
+	float dist = CONSTANTS_RADIUS_OF_EARTH * std::sin(M_PI/180) * lat_offset;
+
+	double lat_target = 0;
+	double lon_target = 0;
+
+	// WHEN: we get the next waypoint
+	waypoint_from_heading_and_distance(lat_start, lon_start, bearing, dist, &lat_target, &lon_target);
+
+	// THEN: it should be the same
+	EXPECT_FLOAT_EQ(lat_start + lat_offset, lat_target);
+	EXPECT_DOUBLE_EQ(lon_start, lon_target);
+}


### PR DESCRIPTION
Previous 2D (and 3D) projection functions I've worked with have all responded to negative distance with as being in the opposite of the positive distance. Up for discussion whether this should be changed.

(part of my demo for the dev summit)