### PR TITLE
Fix firmware-build-test

### DIFF
--- a/.github/workflows/firmware_build_test.yml
+++ b/.github/workflows/firmware_build_test.yml
@@ -1,9 +1,6 @@
 name: Firmware Build Test
 
 on:
-  push:
-    branches:
-      - master
   pull_request:
     branches:
       - '*'

--- a/.github/workflows/firmware_build_test.yml
+++ b/.github/workflows/firmware_build_test.yml
@@ -11,35 +11,36 @@ on:
 jobs:
   Firmware-build:
     runs-on: ubuntu-latest
-    container: px4io/px4-dev-base-bionic:2020-03-29
+    container: px4io/px4-dev-base-focal:2020-05-12
     env:
       GIT_COMMITTER_EMAIL: bot@px4.io
       GIT_COMMITTER_NAME: PX4BuildBot
     steps:
     - name: Checkout Firmware master
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2.3.1
       with:
         repository: PX4/Firmware
         ref: master
+        path: Firmware
+        fetch-depth: 0
         submodules: recurvise
     - name: Checkout matching branch on PX4/Firmware if possible
       run: |
-        git fetch origin
         git checkout ${{github.head_ref}} || echo "Firmware branch: ${{github.head_ref}} not found, using master instead"
         git submodule update --init --recursive
-      working-directory: ../Firmware
+      working-directory: Firmware
     - name: Configure Firmware to include current ECL version
-      working-directory: ../Firmware/src/lib/ecl
+      working-directory: Firmware/src/lib/ecl
       run: |
-        git fetch origin ${{ github.ref }}
-        git checkout ${{ github.sha }}
+        git fetch origin pull/${{github.event.pull_request.number}}/head:${{github.head_ref}}
+        git checkout ${{github.head_ref}}
     - name: Add and commit new ECL version
       run: |
         git config --global user.email "${GIT_COMMITTER_EMAIL}"
         git config --global user.name "${GIT_COMMITTER_NAME}"
         git add src/lib/ecl
         git commit -m "Update ECL"
-      working-directory: ../Firmware
+      working-directory: Firmware
     - name: Build Firmware
-      working-directory: ../Firmware
+      working-directory: Firmware
       run: make


### PR DESCRIPTION
It seems that I finally got it.
There is a [race condition in the Github checkout action v1](https://github.com/actions/checkout/issues/23#issuecomment-553994987), which likely caused the issue.
This PR uses the newest version of the checkout action. But for creating a local git repository during the checkout a git version >2.18 is now necessary. Therefore the dev-base-focal container needs to be used.