### PR TITLE
Variadic KHP computation

### DIFF
--- a/EKF/airspeed_fusion.cpp
+++ b/EKF/airspeed_fusion.cpp
@@ -159,9 +159,6 @@ void Ekf::fuseAirspeed()
 			_innov_check_fail_status.flags.reject_airspeed = false;
 		}
 
-		// Airspeed measurement sample has passed check so record it
-		_time_last_arsp_fuse = _time_last_imu;
-
 		// apply covariance correction via P_new = (I -K*H)*P
 		// first calculate expression for KHP
 		// then calculate P - KHP
@@ -211,6 +208,7 @@ void Ekf::fuseAirspeed()
 			// apply the state corrections
 			fuse(Kfusion, _airspeed_innov);
 
+			_time_last_arsp_fuse = _time_last_imu;
 		}
 	}
 }

--- a/EKF/airspeed_fusion.cpp
+++ b/EKF/airspeed_fusion.cpp
@@ -71,12 +71,12 @@ void Ekf::fuseAirspeed()
 		SH_TAS[2] = (SH_TAS[0]*(2.0f*vn - 2.0f*vwn))*0.5f;
 
 		// Observation Jacobian
-		float H_TAS[24] = {};
-		H_TAS[4] = SH_TAS[2];
-		H_TAS[5] = SH_TAS[1];
-		H_TAS[6] = vd*SH_TAS[0];
-		H_TAS[22] = -SH_TAS[2];
-		H_TAS[23] = -SH_TAS[1];
+		Vector24f H_TAS;
+		H_TAS(4) = SH_TAS[2];
+		H_TAS(5) = SH_TAS[1];
+		H_TAS(6) = vd*SH_TAS[0];
+		H_TAS(22) = -SH_TAS[2];
+		H_TAS(23) = -SH_TAS[1];
 
 		_airspeed_innov_var = (R_TAS + SH_TAS[2]*(P(4,4)*SH_TAS[2] + P(5,4)*SH_TAS[1] - P(22,4)*SH_TAS[2] - P(23,4)*SH_TAS[1] + P(6,4)*vd*SH_TAS[0]) + SH_TAS[1]*(P(4,5)*SH_TAS[2] + P(5,5)*SH_TAS[1] - P(22,5)*SH_TAS[2] - P(23,5)*SH_TAS[1] + P(6,5)*vd*SH_TAS[0]) - SH_TAS[2]*(P(4,22)*SH_TAS[2] + P(5,22)*SH_TAS[1] - P(22,22)*SH_TAS[2] - P(23,22)*SH_TAS[1] + P(6,22)*vd*SH_TAS[0]) - SH_TAS[1]*(P(4,23)*SH_TAS[2] + P(5,23)*SH_TAS[1] - P(22,23)*SH_TAS[2] - P(23,23)*SH_TAS[1] + P(6,23)*vd*SH_TAS[0]) + vd*SH_TAS[0]*(P(4,6)*SH_TAS[2] + P(5,6)*SH_TAS[1] - P(22,6)*SH_TAS[2] - P(23,6)*SH_TAS[1] + P(6,6)*vd*SH_TAS[0]));
 
@@ -161,11 +161,11 @@ void Ekf::fuseAirspeed()
 
 		for (unsigned row = 0; row < _k_num_states; row++) {
 
-			KH[0] = Kfusion(row) * H_TAS[4];
-			KH[1] = Kfusion(row) * H_TAS[5];
-			KH[2] = Kfusion(row) * H_TAS[6];
-			KH[3] = Kfusion(row) * H_TAS[22];
-			KH[4] = Kfusion(row) * H_TAS[23];
+			KH[0] = Kfusion(row) * H_TAS(4);
+			KH[1] = Kfusion(row) * H_TAS(5);
+			KH[2] = Kfusion(row) * H_TAS(6);
+			KH[3] = Kfusion(row) * H_TAS(22);
+			KH[4] = Kfusion(row) * H_TAS(23);
 
 			for (unsigned column = 0; column < _k_num_states; column++) {
 				float tmp = KH[0] * P(4,column);

--- a/EKF/airspeed_fusion.cpp
+++ b/EKF/airspeed_fusion.cpp
@@ -177,21 +177,9 @@ void Ekf::fuseAirspeed()
 			}
 		}
 
-		// if the covariance correction will result in a negative variance, then
-		// the covariance matrix is unhealthy and must be corrected
-		bool healthy = true;
-		_fault_status.flags.bad_airspeed = false;
+		const bool healthy = isCovarianceUpdateHealthy(KHP);
 
-		for (int i = 0; i < _k_num_states; i++) {
-			if (P(i,i) < KHP(i,i)) {
-				P.uncorrelateCovarianceSetVariance<1>(i, 0.0f);
-
-				healthy = false;
-
-				_fault_status.flags.bad_airspeed = true;
-
-			}
-		}
+		_fault_status.flags.bad_airspeed = !healthy;
 
 		if (healthy) {
 			// apply the covariance corrections

--- a/EKF/airspeed_fusion.cpp
+++ b/EKF/airspeed_fusion.cpp
@@ -156,26 +156,7 @@ void Ekf::fuseAirspeed()
 		// apply covariance correction via P_new = (I -K*H)*P
 		// first calculate expression for KHP
 		// then calculate P - KHP
-		SquareMatrix24f KHP;
-		float KH[5];
-
-		for (unsigned row = 0; row < _k_num_states; row++) {
-
-			KH[0] = Kfusion(row) * H_TAS(4);
-			KH[1] = Kfusion(row) * H_TAS(5);
-			KH[2] = Kfusion(row) * H_TAS(6);
-			KH[3] = Kfusion(row) * H_TAS(22);
-			KH[4] = Kfusion(row) * H_TAS(23);
-
-			for (unsigned column = 0; column < _k_num_states; column++) {
-				float tmp = KH[0] * P(4,column);
-				tmp += KH[1] * P(5,column);
-				tmp += KH[2] * P(6,column);
-				tmp += KH[3] * P(22,column);
-				tmp += KH[4] * P(23,column);
-				KHP(row,column) = tmp;
-			}
-		}
+		const SquareMatrix24f KHP = computeKHP<4, 5, 6, 22, 23>(Kfusion, H_TAS);
 
 		const bool healthy = isCovarianceUpdateHealthy(KHP);
 

--- a/EKF/control.cpp
+++ b/EKF/control.cpp
@@ -1279,8 +1279,6 @@ void Ekf::controlFakePosFusion()
 		// Fuse synthetic position observations every 200msec
 		if (isTimedOut(_time_last_fake_pos, (uint64_t)2e5)) {
 
-			Vector3f fake_pos_obs_var;
-
 			// Reset position and velocity states if we re-commence this aiding method
 			if (isTimedOut(_time_last_fake_pos, (uint64_t)4e5)) {
 				resetHorizontalPosition();
@@ -1293,6 +1291,8 @@ void Ekf::controlFakePosFusion()
 
 			}
 			_time_last_fake_pos = _time_last_imu;
+
+			Vector3f fake_pos_obs_var;
 
 			if (_control_status.flags.in_air && _control_status.flags.tilt_align) {
 				fake_pos_obs_var(0) = fake_pos_obs_var(1) = sq(fmaxf(_params.pos_noaid_noise, _params.gps_pos_noise));

--- a/EKF/control.cpp
+++ b/EKF/control.cpp
@@ -132,8 +132,8 @@ void Ekf::controlFusionModes()
 
 	if (_range_sensor.isDataHealthy()) {
 		// correct the range data for position offset relative to the IMU
-		Vector3f pos_offset_body = _params.rng_pos_body - _params.imu_pos_body;
-		Vector3f pos_offset_earth = _R_to_earth * pos_offset_body;
+		const Vector3f pos_offset_body = _params.rng_pos_body - _params.imu_pos_body;
+		const Vector3f pos_offset_earth = _R_to_earth * pos_offset_body;
 		_range_sensor.setRange(_range_sensor.getRange() + pos_offset_earth(2) / _range_sensor.getCosTilt());
 	}
 

--- a/EKF/control.cpp
+++ b/EKF/control.cpp
@@ -391,12 +391,7 @@ void Ekf::controlOpticalFlowFusion()
 	if (_flow_data_ready) {
 		// Inhibit flow use if motion is un-suitable or we have good quality GPS
 		// Apply hysteresis to prevent rapid mode switching
-		float gps_err_norm_lim;
-		if (_control_status.flags.opt_flow) {
-			gps_err_norm_lim = 0.7f;
-		} else {
-			gps_err_norm_lim = 1.0f;
-		}
+		const float gps_err_norm_lim = _control_status.flags.opt_flow ? 0.7f : 1.0f;
 
 		// Check if we are in-air and require optical flow to control position drift
 		bool flow_required = _control_status.flags.in_air &&

--- a/EKF/control.cpp
+++ b/EKF/control.cpp
@@ -771,10 +771,10 @@ void Ekf::controlHeightSensorTimeouts()
 	checkVerticalAccelerationHealth();
 
 	// check if height is continuously failing because of accel errors
-	bool continuous_bad_accel_hgt = isTimedOut(_time_good_vert_accel, (uint64_t)_params.bad_acc_reset_delay_us);
+	const bool continuous_bad_accel_hgt = isTimedOut(_time_good_vert_accel, (uint64_t)_params.bad_acc_reset_delay_us);
 
 	// check if height has been inertial deadreckoning for too long
-	bool hgt_fusion_timeout = isTimedOut(_time_last_hgt_fuse, (uint64_t)5e6);
+	const bool hgt_fusion_timeout = isTimedOut(_time_last_hgt_fuse, (uint64_t)5e6);
 
 	if (hgt_fusion_timeout || continuous_bad_accel_hgt) {
 
@@ -1079,8 +1079,8 @@ void Ekf::controlHeightFusion()
 
 			// Compensate for positive static pressure transients (negative vertical position innovations)
 			// caused by rotor wash ground interaction by applying a temporary deadzone to baro innovations.
-			float deadzone_start = 0.0f;
-			float deadzone_end = deadzone_start + _params.gnd_effect_deadzone;
+			const float deadzone_start = 0.0f;
+			const float deadzone_end = deadzone_start + _params.gnd_effect_deadzone;
 
 			if (_control_status.flags.gnd_effect) {
 				if (_baro_hgt_innov(2) < -deadzone_start) {
@@ -1225,7 +1225,7 @@ void Ekf::controlBetaFusion()
 	// Perform synthetic sideslip fusion when in-air and sideslip fuson had been enabled externally in addition to the following criteria:
 
 	// Sufficient time has lapsed sice the last fusion
-	bool beta_fusion_time_triggered = isTimedOut(_time_last_beta_fuse, _params.beta_avg_ft_us);
+	const bool beta_fusion_time_triggered = isTimedOut(_time_last_beta_fuse, _params.beta_avg_ft_us);
 
 	if (beta_fusion_time_triggered && _control_status.flags.fuse_beta && _control_status.flags.in_air) {
 		// If starting wind state estimation, reset the wind states and covariances before fusing any data

--- a/EKF/covariance.cpp
+++ b/EKF/covariance.cpp
@@ -848,6 +848,20 @@ void Ekf::fixCovarianceErrors(bool force_symmetry)
 	}
 }
 
+// if the covariance correction will result in a negative variance, then
+// the covariance matrix is unhealthy and must be corrected
+bool Ekf::isCovarianceUpdateHealthy(const SquareMatrix24f& KHP) {
+	bool healthy = true;
+	for (int i = 0; i < _k_num_states; i++) {
+		if (P(i, i) < KHP(i, i)) {
+			P.uncorrelateCovarianceSetVariance<1>(i, 0.0f);
+			healthy = false;
+		}
+	}
+	return healthy;
+}
+
+
 void Ekf::resetMagRelatedCovariances()
 {
 	resetQuatCov();

--- a/EKF/drag_fusion.cpp
+++ b/EKF/drag_fusion.cpp
@@ -46,7 +46,7 @@
 void Ekf::fuseDrag()
 {
 	float SH_ACC[4] = {}; // Variable used to optimise calculations of measurement jacobian
-	float H_ACC[24] = {}; // Observation Jacobian
+	Vector24f H_ACC; // Observation Jacobian
 	float SK_ACC[9] = {}; // Variable used to optimise calculations of the Kalman gain vector
 	Vector24f Kfusion; // Kalman gain vector
 	// TODO: resolve variance vs stdDev bug
@@ -97,15 +97,15 @@ void Ekf::fuseDrag()
 			SH_ACC[1] = vn - vwn;
 			SH_ACC[2] = ve - vwe;
 			SH_ACC[3] = 2.0f*q0*q3 + 2.0f*q1*q2;
-			H_ACC[0] = -Kacc*(2.0f*q0*SH_ACC[1] + 2.0f*q3*SH_ACC[2] - 2.0f*q2*vd);
-			H_ACC[1] = -Kacc*(2.0f*q1*SH_ACC[1] + 2.0f*q2*SH_ACC[2] + 2.0f*q3*vd);
-			H_ACC[2] = Kacc*(2.0f*q2*SH_ACC[1] - 2.0f*q1*SH_ACC[2] + 2.0f*q0*vd);
-			H_ACC[3] = -Kacc*(2.0f*q0*SH_ACC[2] - 2.0f*q3*SH_ACC[1] + 2.0f*q1*vd);
-			H_ACC[4] = -Kacc*SH_ACC[0];
-			H_ACC[5] = -Kacc*SH_ACC[3];
-			H_ACC[6] = Kacc*(2.0f*q0*q2 - 2.0f*q1*q3);
-			H_ACC[22] = Kacc*SH_ACC[0];
-			H_ACC[23] = Kacc*SH_ACC[3];
+			H_ACC(0) = -Kacc*(2.0f*q0*SH_ACC[1] + 2.0f*q3*SH_ACC[2] - 2.0f*q2*vd);
+			H_ACC(1) = -Kacc*(2.0f*q1*SH_ACC[1] + 2.0f*q2*SH_ACC[2] + 2.0f*q3*vd);
+			H_ACC(2) = Kacc*(2.0f*q2*SH_ACC[1] - 2.0f*q1*SH_ACC[2] + 2.0f*q0*vd);
+			H_ACC(3) = -Kacc*(2.0f*q0*SH_ACC[2] - 2.0f*q3*SH_ACC[1] + 2.0f*q1*vd);
+			H_ACC(4) = -Kacc*SH_ACC[0];
+			H_ACC(5) = -Kacc*SH_ACC[3];
+			H_ACC(6) = Kacc*(2.0f*q0*q2 - 2.0f*q1*q3);
+			H_ACC(22) = Kacc*SH_ACC[0];
+			H_ACC(23) = Kacc*SH_ACC[3];
 			_drag_innov_var[0] = (R_ACC + Kacc*SH_ACC[0]*(Kacc*P(4,4)*SH_ACC[0] + Kacc*P(5,4)*SH_ACC[3] - Kacc*P(22,4)*SH_ACC[0] - Kacc*P(23,4)*SH_ACC[3] - Kacc*P(6,4)*(2.0f*q0*q2 - 2.0f*q1*q3) + Kacc*P(0,4)*(2.0f*q0*SH_ACC[1] + 2.0f*q3*SH_ACC[2] - 2.0f*q2*vd) + Kacc*P(1,4)*(2.0f*q1*SH_ACC[1] + 2.0f*q2*SH_ACC[2] + 2.0f*q3*vd) - Kacc*P(2,4)*(2.0f*q2*SH_ACC[1] - 2.0f*q1*SH_ACC[2] + 2.0f*q0*vd) + Kacc*P(3,4)*(2.0f*q0*SH_ACC[2] - 2.0f*q3*SH_ACC[1] + 2.0f*q1*vd)) + Kacc*SH_ACC[3]*(Kacc*P(4,5)*SH_ACC[0] + Kacc*P(5,5)*SH_ACC[3] - Kacc*P(22,5)*SH_ACC[0] - Kacc*P(23,5)*SH_ACC[3] - Kacc*P(6,5)*(2.0f*q0*q2 - 2.0f*q1*q3) + Kacc*P(0,5)*(2.0f*q0*SH_ACC[1] + 2.0f*q3*SH_ACC[2] - 2.0f*q2*vd) + Kacc*P(1,5)*(2.0f*q1*SH_ACC[1] + 2.0f*q2*SH_ACC[2] + 2.0f*q3*vd) - Kacc*P(2,5)*(2.0f*q2*SH_ACC[1] - 2.0f*q1*SH_ACC[2] + 2.0f*q0*vd) + Kacc*P(3,5)*(2.0f*q0*SH_ACC[2] - 2.0f*q3*SH_ACC[1] + 2.0f*q1*vd)) - Kacc*SH_ACC[0]*(Kacc*P(4,22)*SH_ACC[0] + Kacc*P(5,22)*SH_ACC[3] - Kacc*P(22,22)*SH_ACC[0] - Kacc*P(23,22)*SH_ACC[3] - Kacc*P(6,22)*(2.0f*q0*q2 - 2.0f*q1*q3) + Kacc*P(0,22)*(2.0f*q0*SH_ACC[1] + 2.0f*q3*SH_ACC[2] - 2.0f*q2*vd) + Kacc*P(1,22)*(2.0f*q1*SH_ACC[1] + 2.0f*q2*SH_ACC[2] + 2.0f*q3*vd) - Kacc*P(2,22)*(2.0f*q2*SH_ACC[1] - 2.0f*q1*SH_ACC[2] + 2.0f*q0*vd) + Kacc*P(3,22)*(2.0f*q0*SH_ACC[2] - 2.0f*q3*SH_ACC[1] + 2.0f*q1*vd)) - Kacc*SH_ACC[3]*(Kacc*P(4,23)*SH_ACC[0] + Kacc*P(5,23)*SH_ACC[3] - Kacc*P(22,23)*SH_ACC[0] - Kacc*P(23,23)*SH_ACC[3] - Kacc*P(6,23)*(2.0f*q0*q2 - 2.0f*q1*q3) + Kacc*P(0,23)*(2.0f*q0*SH_ACC[1] + 2.0f*q3*SH_ACC[2] - 2.0f*q2*vd) + Kacc*P(1,23)*(2.0f*q1*SH_ACC[1] + 2.0f*q2*SH_ACC[2] + 2.0f*q3*vd) - Kacc*P(2,23)*(2.0f*q2*SH_ACC[1] - 2.0f*q1*SH_ACC[2] + 2.0f*q0*vd) + Kacc*P(3,23)*(2.0f*q0*SH_ACC[2] - 2.0f*q3*SH_ACC[1] + 2.0f*q1*vd)) - Kacc*(2.0f*q0*q2 - 2.0f*q1*q3)*(Kacc*P(4,6)*SH_ACC[0] + Kacc*P(5,6)*SH_ACC[3] - Kacc*P(22,6)*SH_ACC[0] - Kacc*P(23,6)*SH_ACC[3] - Kacc*P(6,6)*(2.0f*q0*q2 - 2.0f*q1*q3) + Kacc*P(0,6)*(2.0f*q0*SH_ACC[1] + 2.0f*q3*SH_ACC[2] - 2.0f*q2*vd) + Kacc*P(1,6)*(2.0f*q1*SH_ACC[1] + 2.0f*q2*SH_ACC[2] + 2.0f*q3*vd) - Kacc*P(2,6)*(2.0f*q2*SH_ACC[1] - 2.0f*q1*SH_ACC[2] + 2.0f*q0*vd) + Kacc*P(3,6)*(2.0f*q0*SH_ACC[2] - 2.0f*q3*SH_ACC[1] + 2.0f*q1*vd)) + Kacc*(2.0f*q0*SH_ACC[1] + 2.0f*q3*SH_ACC[2] - 2.0f*q2*vd)*(Kacc*P(4,0)*SH_ACC[0] + Kacc*P(5,0)*SH_ACC[3] - Kacc*P(22,0)*SH_ACC[0] - Kacc*P(23,0)*SH_ACC[3] - Kacc*P(6,0)*(2.0f*q0*q2 - 2.0f*q1*q3) + Kacc*P(0,0)*(2.0f*q0*SH_ACC[1] + 2.0f*q3*SH_ACC[2] - 2.0f*q2*vd) + Kacc*P(1,0)*(2.0f*q1*SH_ACC[1] + 2.0f*q2*SH_ACC[2] + 2.0f*q3*vd) - Kacc*P(2,0)*(2.0f*q2*SH_ACC[1] - 2.0f*q1*SH_ACC[2] + 2.0f*q0*vd) + Kacc*P(3,0)*(2.0f*q0*SH_ACC[2] - 2.0f*q3*SH_ACC[1] + 2.0f*q1*vd)) + Kacc*(2.0f*q1*SH_ACC[1] + 2.0f*q2*SH_ACC[2] + 2.0f*q3*vd)*(Kacc*P(4,1)*SH_ACC[0] + Kacc*P(5,1)*SH_ACC[3] - Kacc*P(22,1)*SH_ACC[0] - Kacc*P(23,1)*SH_ACC[3] - Kacc*P(6,1)*(2.0f*q0*q2 - 2.0f*q1*q3) + Kacc*P(0,1)*(2.0f*q0*SH_ACC[1] + 2.0f*q3*SH_ACC[2] - 2.0f*q2*vd) + Kacc*P(1,1)*(2.0f*q1*SH_ACC[1] + 2.0f*q2*SH_ACC[2] + 2.0f*q3*vd) - Kacc*P(2,1)*(2.0f*q2*SH_ACC[1] - 2.0f*q1*SH_ACC[2] + 2.0f*q0*vd) + Kacc*P(3,1)*(2.0f*q0*SH_ACC[2] - 2.0f*q3*SH_ACC[1] + 2.0f*q1*vd)) - Kacc*(2.0f*q2*SH_ACC[1] - 2.0f*q1*SH_ACC[2] + 2.0f*q0*vd)*(Kacc*P(4,2)*SH_ACC[0] + Kacc*P(5,2)*SH_ACC[3] - Kacc*P(22,2)*SH_ACC[0] - Kacc*P(23,2)*SH_ACC[3] - Kacc*P(6,2)*(2.0f*q0*q2 - 2.0f*q1*q3) + Kacc*P(0,2)*(2.0f*q0*SH_ACC[1] + 2.0f*q3*SH_ACC[2] - 2.0f*q2*vd) + Kacc*P(1,2)*(2.0f*q1*SH_ACC[1] + 2.0f*q2*SH_ACC[2] + 2.0f*q3*vd) - Kacc*P(2,2)*(2.0f*q2*SH_ACC[1] - 2.0f*q1*SH_ACC[2] + 2.0f*q0*vd) + Kacc*P(3,2)*(2.0f*q0*SH_ACC[2] - 2.0f*q3*SH_ACC[1] + 2.0f*q1*vd)) + Kacc*(2.0f*q0*SH_ACC[2] - 2.0f*q3*SH_ACC[1] + 2.0f*q1*vd)*(Kacc*P(4,3)*SH_ACC[0] + Kacc*P(5,3)*SH_ACC[3] - Kacc*P(22,3)*SH_ACC[0] - Kacc*P(23,3)*SH_ACC[3] - Kacc*P(6,3)*(2.0f*q0*q2 - 2.0f*q1*q3) + Kacc*P(0,3)*(2.0f*q0*SH_ACC[1] + 2.0f*q3*SH_ACC[2] - 2.0f*q2*vd) + Kacc*P(1,3)*(2.0f*q1*SH_ACC[1] + 2.0f*q2*SH_ACC[2] + 2.0f*q3*vd) - Kacc*P(2,3)*(2.0f*q2*SH_ACC[1] - 2.0f*q1*SH_ACC[2] + 2.0f*q0*vd) + Kacc*P(3,3)*(2.0f*q0*SH_ACC[2] - 2.0f*q3*SH_ACC[1] + 2.0f*q1*vd)));
 			if (_drag_innov_var[0] < R_ACC) {
 				return;
@@ -148,15 +148,15 @@ void Ekf::fuseDrag()
 			SH_ACC[0] = sq(q0) - sq(q1) + sq(q2) - sq(q3);
 			SH_ACC[1] = vn - vwn;
 			SH_ACC[2] = ve - vwe;
-			H_ACC[0] = -Kacc*(2.0f*q0*SH_ACC[2] - 2.0f*q3*SH_ACC[1] + 2.0f*q1*vd);
-			H_ACC[1] = -Kacc*(2.0f*q2*SH_ACC[1] - 2.0f*q1*SH_ACC[2] + 2.0f*q0*vd);
-			H_ACC[2] = -Kacc*(2.0f*q1*SH_ACC[1] + 2.0f*q2*SH_ACC[2] + 2.0f*q3*vd);
-			H_ACC[3] = Kacc*(2.0f*q0*SH_ACC[1] + 2.0f*q3*SH_ACC[2] - 2.0f*q2*vd);
-			H_ACC[4] = Kacc*(2.0f*q0*q3 - 2.0f*q1*q2);
-			H_ACC[5] = -Kacc*SH_ACC[0];
-			H_ACC[6] = -Kacc*(2.0f*q0*q1 + 2.0f*q2*q3);
-			H_ACC[22] = -2.0f*Kacc*(q0*q3 - q1*q2);
-			H_ACC[23] = Kacc*SH_ACC[0];
+			H_ACC(0) = -Kacc*(2.0f*q0*SH_ACC[2] - 2.0f*q3*SH_ACC[1] + 2.0f*q1*vd);
+			H_ACC(1) = -Kacc*(2.0f*q2*SH_ACC[1] - 2.0f*q1*SH_ACC[2] + 2.0f*q0*vd);
+			H_ACC(2) = -Kacc*(2.0f*q1*SH_ACC[1] + 2.0f*q2*SH_ACC[2] + 2.0f*q3*vd);
+			H_ACC(3) = Kacc*(2.0f*q0*SH_ACC[1] + 2.0f*q3*SH_ACC[2] - 2.0f*q2*vd);
+			H_ACC(4) = Kacc*(2.0f*q0*q3 - 2.0f*q1*q2);
+			H_ACC(5) = -Kacc*SH_ACC[0];
+			H_ACC(6) = -Kacc*(2.0f*q0*q1 + 2.0f*q2*q3);
+			H_ACC(22) = -2.0f*Kacc*(q0*q3 - q1*q2);
+			H_ACC(23) = Kacc*SH_ACC[0];
 			_drag_innov_var[1] = (R_ACC + Kacc*SH_ACC[0]*(Kacc*P(5,5)*SH_ACC[0] - Kacc*P(23,5)*SH_ACC[0] - Kacc*P(4,5)*(2.0f*q0*q3 - 2.0f*q1*q2) + Kacc*P(6,5)*(2.0f*q0*q1 + 2.0f*q2*q3) + 2*Kacc*P(22,5)*(q0*q3 - q1*q2) + Kacc*P(0,5)*(2.0f*q0*SH_ACC[2] - 2.0f*q3*SH_ACC[1] + 2.0f*q1*vd) + Kacc*P(1,5)*(2.0f*q2*SH_ACC[1] - 2.0f*q1*SH_ACC[2] + 2.0f*q0*vd) + Kacc*P(2,5)*(2.0f*q1*SH_ACC[1] + 2.0f*q2*SH_ACC[2] + 2.0f*q3*vd) - Kacc*P(3,5)*(2.0f*q0*SH_ACC[1] + 2.0f*q3*SH_ACC[2] - 2.0f*q2*vd)) - Kacc*SH_ACC[0]*(Kacc*P(5,23)*SH_ACC[0] - Kacc*P(23,23)*SH_ACC[0] - Kacc*P(4,23)*(2.0f*q0*q3 - 2.0f*q1*q2) + Kacc*P(6,23)*(2.0f*q0*q1 + 2.0f*q2*q3) + 2*Kacc*P(22,23)*(q0*q3 - q1*q2) + Kacc*P(0,23)*(2.0f*q0*SH_ACC[2] - 2.0f*q3*SH_ACC[1] + 2.0f*q1*vd) + Kacc*P(1,23)*(2.0f*q2*SH_ACC[1] - 2.0f*q1*SH_ACC[2] + 2.0f*q0*vd) + Kacc*P(2,23)*(2.0f*q1*SH_ACC[1] + 2.0f*q2*SH_ACC[2] + 2.0f*q3*vd) - Kacc*P(3,23)*(2.0f*q0*SH_ACC[1] + 2.0f*q3*SH_ACC[2] - 2.0f*q2*vd)) - Kacc*(2.0f*q0*q3 - 2.0f*q1*q2)*(Kacc*P(5,4)*SH_ACC[0] - Kacc*P(23,4)*SH_ACC[0] - Kacc*P(4,4)*(2.0f*q0*q3 - 2.0f*q1*q2) + Kacc*P(6,4)*(2.0f*q0*q1 + 2.0f*q2*q3) + 2*Kacc*P(22,4)*(q0*q3 - q1*q2) + Kacc*P(0,4)*(2.0f*q0*SH_ACC[2] - 2.0f*q3*SH_ACC[1] + 2.0f*q1*vd) + Kacc*P(1,4)*(2.0f*q2*SH_ACC[1] - 2.0f*q1*SH_ACC[2] + 2.0f*q0*vd) + Kacc*P(2,4)*(2.0f*q1*SH_ACC[1] + 2.0f*q2*SH_ACC[2] + 2.0f*q3*vd) - Kacc*P(3,4)*(2.0f*q0*SH_ACC[1] + 2.0f*q3*SH_ACC[2] - 2.0f*q2*vd)) + Kacc*(2.0f*q0*q1 + 2.0f*q2*q3)*(Kacc*P(5,6)*SH_ACC[0] - Kacc*P(23,6)*SH_ACC[0] - Kacc*P(4,6)*(2.0f*q0*q3 - 2.0f*q1*q2) + Kacc*P(6,6)*(2.0f*q0*q1 + 2.0f*q2*q3) + 2*Kacc*P(22,6)*(q0*q3 - q1*q2) + Kacc*P(0,6)*(2.0f*q0*SH_ACC[2] - 2.0f*q3*SH_ACC[1] + 2.0f*q1*vd) + Kacc*P(1,6)*(2.0f*q2*SH_ACC[1] - 2.0f*q1*SH_ACC[2] + 2.0f*q0*vd) + Kacc*P(2,6)*(2.0f*q1*SH_ACC[1] + 2.0f*q2*SH_ACC[2] + 2.0f*q3*vd) - Kacc*P(3,6)*(2.0f*q0*SH_ACC[1] + 2.0f*q3*SH_ACC[2] - 2.0f*q2*vd)) + 2*Kacc*(q0*q3 - q1*q2)*(Kacc*P(5,22)*SH_ACC[0] - Kacc*P(23,22)*SH_ACC[0] - Kacc*P(4,22)*(2.0f*q0*q3 - 2.0f*q1*q2) + Kacc*P(6,22)*(2.0f*q0*q1 + 2.0f*q2*q3) + 2*Kacc*P(22,22)*(q0*q3 - q1*q2) + Kacc*P(0,22)*(2.0f*q0*SH_ACC[2] - 2.0f*q3*SH_ACC[1] + 2.0f*q1*vd) + Kacc*P(1,22)*(2.0f*q2*SH_ACC[1] - 2.0f*q1*SH_ACC[2] + 2.0f*q0*vd) + Kacc*P(2,22)*(2.0f*q1*SH_ACC[1] + 2.0f*q2*SH_ACC[2] + 2.0f*q3*vd) - Kacc*P(3,22)*(2.0f*q0*SH_ACC[1] + 2.0f*q3*SH_ACC[2] - 2.0f*q2*vd)) + Kacc*(2.0f*q0*SH_ACC[2] - 2.0f*q3*SH_ACC[1] + 2.0f*q1*vd)*(Kacc*P(5,0)*SH_ACC[0] - Kacc*P(23,0)*SH_ACC[0] - Kacc*P(4,0)*(2.0f*q0*q3 - 2.0f*q1*q2) + Kacc*P(6,0)*(2.0f*q0*q1 + 2.0f*q2*q3) + 2*Kacc*P(22,0)*(q0*q3 - q1*q2) + Kacc*P(0,0)*(2.0f*q0*SH_ACC[2] - 2.0f*q3*SH_ACC[1] + 2.0f*q1*vd) + Kacc*P(1,0)*(2.0f*q2*SH_ACC[1] - 2.0f*q1*SH_ACC[2] + 2.0f*q0*vd) + Kacc*P(2,0)*(2.0f*q1*SH_ACC[1] + 2.0f*q2*SH_ACC[2] + 2.0f*q3*vd) - Kacc*P(3,0)*(2.0f*q0*SH_ACC[1] + 2.0f*q3*SH_ACC[2] - 2.0f*q2*vd)) + Kacc*(2.0f*q2*SH_ACC[1] - 2.0f*q1*SH_ACC[2] + 2.0f*q0*vd)*(Kacc*P(5,1)*SH_ACC[0] - Kacc*P(23,1)*SH_ACC[0] - Kacc*P(4,1)*(2.0f*q0*q3 - 2.0f*q1*q2) + Kacc*P(6,1)*(2.0f*q0*q1 + 2.0f*q2*q3) + 2*Kacc*P(22,1)*(q0*q3 - q1*q2) + Kacc*P(0,1)*(2.0f*q0*SH_ACC[2] - 2.0f*q3*SH_ACC[1] + 2.0f*q1*vd) + Kacc*P(1,1)*(2.0f*q2*SH_ACC[1] - 2.0f*q1*SH_ACC[2] + 2.0f*q0*vd) + Kacc*P(2,1)*(2.0f*q1*SH_ACC[1] + 2.0f*q2*SH_ACC[2] + 2.0f*q3*vd) - Kacc*P(3,1)*(2.0f*q0*SH_ACC[1] + 2.0f*q3*SH_ACC[2] - 2.0f*q2*vd)) + Kacc*(2.0f*q1*SH_ACC[1] + 2.0f*q2*SH_ACC[2] + 2.0f*q3*vd)*(Kacc*P(5,2)*SH_ACC[0] - Kacc*P(23,2)*SH_ACC[0] - Kacc*P(4,2)*(2.0f*q0*q3 - 2.0f*q1*q2) + Kacc*P(6,2)*(2.0f*q0*q1 + 2.0f*q2*q3) + 2*Kacc*P(22,2)*(q0*q3 - q1*q2) + Kacc*P(0,2)*(2.0f*q0*SH_ACC[2] - 2.0f*q3*SH_ACC[1] + 2.0f*q1*vd) + Kacc*P(1,2)*(2.0f*q2*SH_ACC[1] - 2.0f*q1*SH_ACC[2] + 2.0f*q0*vd) + Kacc*P(2,2)*(2.0f*q1*SH_ACC[1] + 2.0f*q2*SH_ACC[2] + 2.0f*q3*vd) - Kacc*P(3,2)*(2.0f*q0*SH_ACC[1] + 2.0f*q3*SH_ACC[2] - 2.0f*q2*vd)) - Kacc*(2.0f*q0*SH_ACC[1] + 2.0f*q3*SH_ACC[2] - 2.0f*q2*vd)*(Kacc*P(5,3)*SH_ACC[0] - Kacc*P(23,3)*SH_ACC[0] - Kacc*P(4,3)*(2.0f*q0*q3 - 2.0f*q1*q2) + Kacc*P(6,3)*(2.0f*q0*q1 + 2.0f*q2*q3) + 2*Kacc*P(22,3)*(q0*q3 - q1*q2) + Kacc*P(0,3)*(2.0f*q0*SH_ACC[2] - 2.0f*q3*SH_ACC[1] + 2.0f*q1*vd) + Kacc*P(1,3)*(2.0f*q2*SH_ACC[1] - 2.0f*q1*SH_ACC[2] + 2.0f*q0*vd) + Kacc*P(2,3)*(2.0f*q1*SH_ACC[1] + 2.0f*q2*SH_ACC[2] + 2.0f*q3*vd) - Kacc*P(3,3)*(2.0f*q0*SH_ACC[1] + 2.0f*q3*SH_ACC[2] - 2.0f*q2*vd)));
 			if (_drag_innov_var[1] < R_ACC) {
 				// calculation is badly conditioned
@@ -215,15 +215,15 @@ void Ekf::fuseDrag()
 
 			for (unsigned row = 0; row < _k_num_states; row++) {
 
-				KH[0] = Kfusion(row) * H_ACC[0];
-				KH[1] = Kfusion(row) * H_ACC[1];
-				KH[2] = Kfusion(row) * H_ACC[2];
-				KH[3] = Kfusion(row) * H_ACC[3];
-				KH[4] = Kfusion(row) * H_ACC[4];
-				KH[5] = Kfusion(row) * H_ACC[5];
-				KH[6] = Kfusion(row) * H_ACC[6];
-				KH[7] = Kfusion(row) * H_ACC[22];
-				KH[8] = Kfusion(row) * H_ACC[23];
+				KH[0] = Kfusion(row) * H_ACC(0);
+				KH[1] = Kfusion(row) * H_ACC(1);
+				KH[2] = Kfusion(row) * H_ACC(2);
+				KH[3] = Kfusion(row) * H_ACC(3);
+				KH[4] = Kfusion(row) * H_ACC(4);
+				KH[5] = Kfusion(row) * H_ACC(5);
+				KH[6] = Kfusion(row) * H_ACC(6);
+				KH[7] = Kfusion(row) * H_ACC(22);
+				KH[8] = Kfusion(row) * H_ACC(23);
 
 				for (unsigned column = 0; column < _k_num_states; column++) {
 					float tmp = KH[0] * P(0,column);

--- a/EKF/drag_fusion.cpp
+++ b/EKF/drag_fusion.cpp
@@ -239,17 +239,7 @@ void Ekf::fuseDrag()
 				}
 			}
 
-			// if the covariance correction will result in a negative variance, then
-			// the covariance matrix is unhealthy and must be corrected
-			bool healthy = true;
-
-			for (int i = 0; i < _k_num_states; i++) {
-				if (P(i,i) < KHP(i,i)) {
-					P.uncorrelateCovarianceSetVariance<1>(i, 0.0f);
-
-					healthy = false;
-				}
-			}
+			bool healthy = isCovarianceUpdateHealthy(KHP);
 
 			if (healthy) {
 				// apply the covariance corrections

--- a/EKF/drag_fusion.cpp
+++ b/EKF/drag_fusion.cpp
@@ -210,34 +210,7 @@ void Ekf::fuseDrag()
 			// apply covariance correction via P_new = (I -K*H)*P
 			// first calculate expression for KHP
 			// then calculate P - KHP
-			SquareMatrix24f KHP;
-			float KH[9];
-
-			for (unsigned row = 0; row < _k_num_states; row++) {
-
-				KH[0] = Kfusion(row) * H_ACC(0);
-				KH[1] = Kfusion(row) * H_ACC(1);
-				KH[2] = Kfusion(row) * H_ACC(2);
-				KH[3] = Kfusion(row) * H_ACC(3);
-				KH[4] = Kfusion(row) * H_ACC(4);
-				KH[5] = Kfusion(row) * H_ACC(5);
-				KH[6] = Kfusion(row) * H_ACC(6);
-				KH[7] = Kfusion(row) * H_ACC(22);
-				KH[8] = Kfusion(row) * H_ACC(23);
-
-				for (unsigned column = 0; column < _k_num_states; column++) {
-					float tmp = KH[0] * P(0,column);
-					tmp += KH[1] * P(1,column);
-					tmp += KH[2] * P(2,column);
-					tmp += KH[3] * P(3,column);
-					tmp += KH[4] * P(4,column);
-					tmp += KH[5] * P(5,column);
-					tmp += KH[6] * P(6,column);
-					tmp += KH[7] * P(22,column);
-					tmp += KH[8] * P(23,column);
-					KHP(row,column) = tmp;
-				}
-			}
+			const SquareMatrix24f KHP = computeKHP<0, 1, 2, 3, 4, 5, 6, 22, 23>(Kfusion, H_ACC);
 
 			bool healthy = isCovarianceUpdateHealthy(KHP);
 

--- a/EKF/ekf.cpp
+++ b/EKF/ekf.cpp
@@ -236,8 +236,7 @@ bool Ekf::initialiseTilt()
 	}
 
 	// get initial roll and pitch estimate from delta velocity vector, assuming vehicle is static
-	Vector3f gravity_in_body = _accel_lpf.getState();
-	gravity_in_body.normalize();
+	const Vector3f gravity_in_body = _accel_lpf.getState().normalized();
 	const float pitch = asinf(gravity_in_body(0));
 	const float roll = atan2f(-gravity_in_body(1), -gravity_in_body(2));
 

--- a/EKF/ekf.cpp
+++ b/EKF/ekf.cpp
@@ -269,8 +269,8 @@ void Ekf::predictState()
 	// calculate a filtered horizontal acceleration with a 1 sec time constant
 	// this are used for manoeuvre detection elsewhere
 	float alpha = 1.0f - _imu_sample_delayed.delta_vel_dt;
-	_accel_lpf_NE(0) = _accel_lpf_NE(0) * alpha + corrected_delta_vel_ef(0);
-	_accel_lpf_NE(1) = _accel_lpf_NE(1) * alpha + corrected_delta_vel_ef(1);
+	_accel_lpf_NE = _accel_lpf_NE * alpha + corrected_delta_vel_ef.xy();
+
 	// save the previous value of velocity so we can use trapzoidal integration
 	const Vector3f vel_last = _state.vel;
 

--- a/EKF/ekf.cpp
+++ b/EKF/ekf.cpp
@@ -324,7 +324,7 @@ void Ekf::calculateOutputStates()
 	const float dt_scale_correction = _dt_imu_avg / _dt_ekf_avg;
 
 	// Apply corrections to the delta angle required to track the quaternion states at the EKF fusion time horizon
-	const Vector3f delta_angle{imu.delta_ang - _state.delta_ang_bias * dt_scale_correction + _delta_angle_corr};
+	const Vector3f delta_angle(imu.delta_ang - _state.delta_ang_bias * dt_scale_correction + _delta_angle_corr);
 
 	// calculate a yaw change about the earth frame vertical
 	const float spin_del_ang_D = _R_to_earth_now(2, 0) * delta_angle(0) +
@@ -363,7 +363,7 @@ void Ekf::calculateOutputStates()
 	}
 
 	// save the previous velocity so we can use trapezoidal integration
-	const Vector3f vel_last{_output_new.vel};
+	const Vector3f vel_last(_output_new.vel);
 
 	// increment the INS velocity states by the measurement plus corrections
 	// do the same for vertical state used by alternative correction algorithm

--- a/EKF/ekf.cpp
+++ b/EKF/ekf.cpp
@@ -268,7 +268,7 @@ void Ekf::predictState()
 
 	// calculate a filtered horizontal acceleration with a 1 sec time constant
 	// this are used for manoeuvre detection elsewhere
-	float alpha = 1.0f - _imu_sample_delayed.delta_vel_dt;
+	const float alpha = 1.0f - _imu_sample_delayed.delta_vel_dt;
 	_accel_lpf_NE = _accel_lpf_NE * alpha + corrected_delta_vel_ef.xy();
 
 	// save the previous value of velocity so we can use trapzoidal integration

--- a/EKF/ekf.h
+++ b/EKF/ekf.h
@@ -514,6 +514,8 @@ private:
 	// update the real time complementary filter states. This includes the prediction
 	// and the correction step
 	void calculateOutputStates();
+	void applyCorrectionToVerticalOutputBuffer(float vel_gain, float pos_gain);
+	void applyCorrectionToOutputBuffer(float vel_gain, float pos_gain);
 
 	// initialise filter states of both the delayed ekf and the real time complementary filter
 	bool initialiseFilter(void);

--- a/EKF/ekf.h
+++ b/EKF/ekf.h
@@ -658,9 +658,9 @@ private:
 	// update the rotation matrix which transforms EV navigation frame measurements into NED
 	void calcExtVisRotMat();
 
-	Vector3f getVisionVelocityInEkfFrame();
+	Vector3f getVisionVelocityInEkfFrame() const;
 
-	Vector3f getVisionVelocityVarianceInEkfFrame();
+	Vector3f getVisionVelocityVarianceInEkfFrame() const;
 
 	// limit the diagonal of the covariance matrix
 	// force symmetry when the argument is true

--- a/EKF/ekf.h
+++ b/EKF/ekf.h
@@ -662,6 +662,10 @@ private:
 
 	Vector3f getVisionVelocityVarianceInEkfFrame() const;
 
+	// if the covariance correction will result in a negative variance, then
+	// the covariance matrix is unhealthy and must be corrected
+	bool isCovarianceUpdateHealthy(const SquareMatrix24f& KHP);
+
 	// limit the diagonal of the covariance matrix
 	// force symmetry when the argument is true
 	void fixCovarianceErrors(bool force_symmetry);

--- a/EKF/ekf.h
+++ b/EKF/ekf.h
@@ -769,6 +769,28 @@ private:
 	// return the square of two floating point numbers - used in auto coded sections
 	static constexpr float sq(float var) { return var * var; }
 
+	template<size_t idx>
+	float recursiveCumulativeSum(const Vector24f& H, unsigned column) {
+		return H(idx) * P(idx, column);
+	}
+
+	template<size_t idx1, size_t idx2, size_t ...rest>
+	float recursiveCumulativeSum(const Vector24f& H, unsigned column) {
+		return H(idx1) * P(idx1, column) + recursiveCumulativeSum<idx2, rest...>(H, column);
+	}
+
+	// Sparse matrix multiplication
+	template<size_t ...nonzero_elements>  // non zero elements in observation jacobian H
+	SquareMatrix24f computeKHP(const Vector24f& K, const Vector24f& H) {
+		SquareMatrix24f KHP;
+		for (unsigned row = 0; row < _k_num_states; row++) {
+			for (unsigned column = 0; column < _k_num_states; column++) {
+				KHP(row,column) = K(row) * recursiveCumulativeSum<nonzero_elements...>(H, column);
+			}
+		}
+		return KHP;
+	}
+
 	// set control flags to use baro height
 	void setControlBaroHeight();
 

--- a/EKF/ekf.h
+++ b/EKF/ekf.h
@@ -380,7 +380,7 @@ private:
 	bool _mag_decl_cov_reset{false};	///< true after the fuseDeclination() function has been used to modify the earth field covariances after a magnetic field reset event.
 	bool _synthetic_mag_z_active{false};	///< true if we are generating synthetic magnetometer Z measurements
 
-	bool _yaw_use_inhibit{false};		///< true when yaw sensor use is being inhibited
+	bool _yaw_fusion_is_inhibited{false};		///< true when yaw sensor use is being inhibited
 
 	SquareMatrix24f P;	///< state covariance matrix
 

--- a/EKF/ekf_helper.cpp
+++ b/EKF/ekf_helper.cpp
@@ -411,7 +411,7 @@ bool Ekf::realignYawGPS()
 		if (!_control_status.flags.mag_aligned_in_flight) {
 			// This is our first flight alignment so we can assume that the recent change in velocity has occurred due to a
 			// forward direction takeoff or launch and therefore the inertial and GPS ground course discrepancy is due to yaw error
-			Eulerf euler321(_state.quat_nominal);
+			const Eulerf euler321(_state.quat_nominal);
 			yaw_new = euler321(2) + courseYawError;
 			_control_status.flags.mag_aligned_in_flight = true;
 
@@ -1639,10 +1639,9 @@ void Ekf::resetQuatStateYaw(float yaw, float yaw_variance, bool update_buffer)
 		// Calculate the 312 Tait-Bryan rotation sequence that rotates from earth to body frame
 		// We use a 312 sequence as an alternate when there is more pitch tilt than roll tilt
 		// to avoid gimbal lock
-		Vector3f rot312;
-		rot312(0) = yaw;
-		rot312(1) = asinf(_R_to_earth(2, 1));
-		rot312(2) = atan2f(-_R_to_earth(2, 0), _R_to_earth(2, 2));
+		const Vector3f rot312(yaw,
+				      asinf(_R_to_earth(2, 1)),
+				      atan2f(-_R_to_earth(2, 0), _R_to_earth(2, 2)));
 		_R_to_earth = taitBryan312ToRotMat(rot312);
 
 	}

--- a/EKF/ekf_helper.cpp
+++ b/EKF/ekf_helper.cpp
@@ -219,7 +219,7 @@ void Ekf::resetHeight()
 	const gpsSample &gps_newest = _gps_buffer.get_newest();
 
 	// store the current vertical position and velocity for reference so we can calculate and publish the reset amount
-	float old_vert_pos = _state.pos(2);
+	const float old_vert_pos = _state.pos(2);
 	bool vert_pos_reset = false;
 
 	// reset the vertical position
@@ -277,8 +277,8 @@ void Ekf::resetHeight()
 		const extVisionSample &ev_newest = _ext_vision_buffer.get_newest();
 
 		// use the most recent data if it's time offset from the fusion time horizon is smaller
-		int32_t dt_newest = ev_newest.time_us - _imu_sample_delayed.time_us;
-		int32_t dt_delayed = _ev_sample_delayed.time_us - _imu_sample_delayed.time_us;
+		const int32_t dt_newest = ev_newest.time_us - _imu_sample_delayed.time_us;
+		const int32_t dt_delayed = _ev_sample_delayed.time_us - _imu_sample_delayed.time_us;
 
 		vert_pos_reset = true;
 
@@ -1090,9 +1090,9 @@ void Ekf::get_ekf_soln_status(uint16_t *status)
 	soln_status.flags.const_pos_mode = !soln_status.flags.velocity_horiz;
 	soln_status.flags.pred_pos_horiz_rel = soln_status.flags.pos_horiz_rel;
 	soln_status.flags.pred_pos_horiz_abs = soln_status.flags.pos_horiz_abs;
-	bool gps_vel_innov_bad = (_gps_vel_test_ratio(0) > 1.0f) || (_gps_vel_test_ratio(1) > 1.0f);
-	bool gps_pos_innov_bad = (_gps_pos_test_ratio(0) > 1.0f);
-	bool mag_innov_good = (_mag_test_ratio.max() < 1.0f) && (_yaw_test_ratio < 1.0f);
+	const bool gps_vel_innov_bad = (_gps_vel_test_ratio(0) > 1.0f) || (_gps_vel_test_ratio(1) > 1.0f);
+	const bool gps_pos_innov_bad = (_gps_pos_test_ratio(0) > 1.0f);
+	const bool mag_innov_good = (_mag_test_ratio.max() < 1.0f) && (_yaw_test_ratio < 1.0f);
 	soln_status.flags.gps_glitch = (gps_vel_innov_bad || gps_pos_innov_bad) && mag_innov_good;
 	soln_status.flags.accel_error = _bad_vert_accel_detected;
 	*status = soln_status.value;
@@ -1127,14 +1127,14 @@ bool Ekf::global_position_is_valid()
 // return true if we are totally reliant on inertial dead-reckoning for position
 void Ekf::update_deadreckoning_status()
 {
-	bool velPosAiding = (_control_status.flags.gps || _control_status.flags.ev_pos || _control_status.flags.ev_vel)
-			    && (isRecent(_time_last_hor_pos_fuse, _params.no_aid_timeout_max)
+	const bool velPosAiding = (_control_status.flags.gps || _control_status.flags.ev_pos || _control_status.flags.ev_vel)
+				&& (isRecent(_time_last_hor_pos_fuse, _params.no_aid_timeout_max)
 				|| isRecent(_time_last_hor_vel_fuse, _params.no_aid_timeout_max)
 				|| isRecent(_time_last_delpos_fuse, _params.no_aid_timeout_max));
-	bool optFlowAiding = _control_status.flags.opt_flow && isRecent(_time_last_of_fuse, _params.no_aid_timeout_max);
-	bool airDataAiding = _control_status.flags.wind &&
-			     isRecent(_time_last_arsp_fuse, _params.no_aid_timeout_max) &&
-			     isRecent(_time_last_beta_fuse, _params.no_aid_timeout_max);
+	const bool optFlowAiding = _control_status.flags.opt_flow && isRecent(_time_last_of_fuse, _params.no_aid_timeout_max);
+	const bool airDataAiding = _control_status.flags.wind &&
+				   isRecent(_time_last_arsp_fuse, _params.no_aid_timeout_max) &&
+				   isRecent(_time_last_beta_fuse, _params.no_aid_timeout_max);
 
 	_is_wind_dead_reckoning = !velPosAiding && !optFlowAiding && airDataAiding;
 	_is_dead_reckoning = !velPosAiding && !optFlowAiding && !airDataAiding;
@@ -1398,12 +1398,11 @@ void Ekf::updateBaroHgtOffset()
 	// calculate a filtered offset between the baro origin and local NED origin if we are not
 	// using the baro as a height reference
 	if (!_control_status.flags.baro_hgt && _baro_data_ready) {
-		float local_time_step = 1e-6f * _delta_time_baro_us;
-		local_time_step = math::constrain(local_time_step, 0.0f, 1.0f);
+		const float local_time_step = math::constrain(1e-6f * _delta_time_baro_us, 0.0f, 1.0f);
 
 		// apply a 10 second first order low pass filter to baro offset
-		float offset_rate_correction =  0.1f * (_baro_sample_delayed.hgt + _state.pos(
-				2) - _baro_hgt_offset);
+		const float offset_rate_correction =  0.1f * (_baro_sample_delayed.hgt + _state.pos(2) -
+								_baro_hgt_offset);
 		_baro_hgt_offset += local_time_step * math::constrain(offset_rate_correction, -0.1f, 0.1f);
 	}
 }

--- a/EKF/ekf_helper.cpp
+++ b/EKF/ekf_helper.cpp
@@ -1407,7 +1407,7 @@ void Ekf::updateBaroHgtOffset()
 	}
 }
 
-Vector3f Ekf::getVisionVelocityInEkfFrame()
+Vector3f Ekf::getVisionVelocityInEkfFrame() const
 {
 	Vector3f vel;
 	// correct velocity for offset relative to IMU
@@ -1432,7 +1432,7 @@ Vector3f Ekf::getVisionVelocityInEkfFrame()
 	return vel;
 }
 
-Vector3f Ekf::getVisionVelocityVarianceInEkfFrame()
+Vector3f Ekf::getVisionVelocityVarianceInEkfFrame() const
 {
 	Matrix3f ev_vel_cov = _ev_sample_delayed.velCov;
 

--- a/EKF/ekf_helper.cpp
+++ b/EKF/ekf_helper.cpp
@@ -518,7 +518,7 @@ bool Ekf::resetMagHeading(const Vector3f &mag_init, bool increase_yaw_var, bool 
 			yaw_new_variance = sq(fmaxf(_params.mag_heading_noise, 1.0e-2f));
 		}
 
-	} else if (_params.mag_fusion_type == MAG_FUSE_TYPE_INDOOR && _yaw_use_inhibit) {
+	} else if (_params.mag_fusion_type == MAG_FUSE_TYPE_INDOOR && _yaw_fusion_is_inhibited) {
 		// we are operating temporarily without knowing the earth frame yaw angle
 		return true;
 

--- a/EKF/estimator_interface.cpp
+++ b/EKF/estimator_interface.cpp
@@ -186,7 +186,7 @@ void EstimatorInterface::setGpsData(const gps_message &gps)
 	}
 
 	// limit data rate to prevent data being lost
-	bool need_gps = (_params.fusion_mode & MASK_USE_GPS) || (_params.vdist_sensor_type == VDIST_SENSOR_GPS);
+	const bool need_gps = (_params.fusion_mode & MASK_USE_GPS) || (_params.vdist_sensor_type == VDIST_SENSOR_GPS);
 
 	// TODO: remove checks that are not timing related
 	if (((gps.time_usec - _time_last_gps) > _min_obs_interval_us) && need_gps && gps.fix_type > 2) {
@@ -357,7 +357,7 @@ void EstimatorInterface::setOpticalFlowData(const flowSample& flow)
 		// of min arrival interval because too much data is being lost
 		float delta_time = flow.dt; // in seconds
 		const float delta_time_min = 0.5e-6f * (float)_min_obs_interval_us;
-		bool delta_time_good = delta_time >= delta_time_min;
+		const bool delta_time_good = delta_time >= delta_time_min;
 
 		bool flow_magnitude_good = true;
 
@@ -510,14 +510,15 @@ void EstimatorInterface::setDragData()
 bool EstimatorInterface::initialise_interface(uint64_t timestamp)
 {
 	// find the maximum time delay the buffers are required to handle
-	uint16_t max_time_delay_ms = math::max(_params.mag_delay_ms,
-					 math::max(_params.range_delay_ms,
-					     math::max(_params.gps_delay_ms,
+	const uint16_t max_time_delay_ms = math::max(_params.mag_delay_ms,
+					     math::max(_params.range_delay_ms,
+					       math::max(_params.gps_delay_ms,
 						 math::max(_params.flow_delay_ms,
-						     math::max(_params.ev_delay_ms,
-							 math::max(_params.auxvel_delay_ms,
-							     math::max(_params.min_delay_ms,
-								 math::max(_params.airspeed_delay_ms, _params.baro_delay_ms))))))));
+						   math::max(_params.ev_delay_ms,
+						     math::max(_params.auxvel_delay_ms,
+						       math::max(_params.min_delay_ms,
+							 math::max(_params.airspeed_delay_ms,
+							 	     _params.baro_delay_ms))))))));
 
 	// calculate the IMU buffer length required to accomodate the maximum delay with some allowance for jitter
 	_imu_buffer_length = (max_time_delay_ms / FILTER_UPDATE_PERIOD_MS) + 1;

--- a/EKF/gps_checks.cpp
+++ b/EKF/gps_checks.cpp
@@ -139,7 +139,7 @@ bool Ekf::gps_is_good(const gps_message &gps)
 
 	// Calculate time lapsed since last update, limit to prevent numerical errors and calculate a lowpass filter coefficient
 	constexpr float filt_time_const = 10.0f;
-	const float dt = fminf(fmaxf(float(int64_t(_time_last_imu) - int64_t(_gps_pos_prev.timestamp)) * 1e-6f, 0.001f), filt_time_const);
+	const float dt = math::constrain(float(int64_t(_time_last_imu) - int64_t(_gps_pos_prev.timestamp)) * 1e-6f, 0.001f, filt_time_const);
 	const float filter_coef = dt / filt_time_const;
 
 	// The following checks are only valid when the vehicle is at rest
@@ -209,7 +209,7 @@ bool Ekf::gps_is_good(const gps_message &gps)
 
 	// Check  the filtered difference between GPS and EKF vertical velocity
 	const float vz_diff_limit = 10.0f * _params.req_vdrift;
-	float vertVel = fminf(fmaxf((gps.vel_ned(2) - _state.vel(2)), -vz_diff_limit), vz_diff_limit);
+	const float vertVel = math::constrain(gps.vel_ned(2) - _state.vel(2), -vz_diff_limit, vz_diff_limit);
 	_gps_velD_diff_filt = vertVel * filter_coef + _gps_velD_diff_filt * (1.0f - filter_coef);
 	_gps_check_fail_status.flags.vspeed = (fabsf(_gps_velD_diff_filt) > _params.req_vdrift);
 

--- a/EKF/gps_checks.cpp
+++ b/EKF/gps_checks.cpp
@@ -134,7 +134,7 @@ bool Ekf::gps_is_good(const gps_message &gps)
 	_gps_check_fail_status.flags.sacc = (gps.sacc > _params.req_sacc);
 
 	// check if GPS quality is degraded
-	_gps_error_norm = fmaxf((gps.eph / _params.req_hacc) , (gps.epv / _params.req_vacc));
+	_gps_error_norm = fmaxf((gps.eph / _params.req_hacc), (gps.epv / _params.req_vacc));
 	_gps_error_norm = fmaxf(_gps_error_norm , (gps.sacc / _params.req_sacc));
 
 	// Calculate time lapsed since last update, limit to prevent numerical errors and calculate a lowpass filter coefficient

--- a/EKF/gps_checks.cpp
+++ b/EKF/gps_checks.cpp
@@ -138,7 +138,7 @@ bool Ekf::gps_is_good(const gps_message &gps)
 	_gps_error_norm = fmaxf(_gps_error_norm , (gps.sacc / _params.req_sacc));
 
 	// Calculate time lapsed since last update, limit to prevent numerical errors and calculate a lowpass filter coefficient
-	const float filt_time_const = 10.0f;
+	constexpr float filt_time_const = 10.0f;
 	const float dt = fminf(fmaxf(float(int64_t(_time_last_imu) - int64_t(_gps_pos_prev.timestamp)) * 1e-6f, 0.001f), filt_time_const);
 	const float filter_coef = dt / filt_time_const;
 
@@ -177,9 +177,9 @@ bool Ekf::gps_is_good(const gps_message &gps)
 		_gps_check_fail_status.flags.vdrift = (_gps_drift_metrics[1] > _params.req_vdrift);
 
 		// Check the magnitude of the filtered horizontal GPS velocity
-		Vector2f gps_velNE = matrix::constrain(Vector2f(gps.vel_ned.xy()),
-							-10.0f * _params.req_hdrift,
-							 10.0f * _params.req_hdrift);
+		const Vector2f gps_velNE = matrix::constrain(Vector2f(gps.vel_ned.xy()),
+							     -10.0f * _params.req_hdrift,
+							      10.0f * _params.req_hdrift);
 		_gps_velNE_filt = gps_velNE * filter_coef + _gps_velNE_filt * (1.0f - filter_coef);
 		_gps_drift_metrics[2] = _gps_velNE_filt.norm();
 		_gps_check_fail_status.flags.hspeed = (_gps_drift_metrics[2] > _params.req_hdrift);
@@ -208,7 +208,7 @@ bool Ekf::gps_is_good(const gps_message &gps)
 	_gps_alt_prev = 1e-3f * (float)gps.alt;
 
 	// Check  the filtered difference between GPS and EKF vertical velocity
-	float vz_diff_limit = 10.0f * _params.req_vdrift;
+	const float vz_diff_limit = 10.0f * _params.req_vdrift;
 	float vertVel = fminf(fmaxf((gps.vel_ned(2) - _state.vel(2)), -vz_diff_limit), vz_diff_limit);
 	_gps_velD_diff_filt = vertVel * filter_coef + _gps_velD_diff_filt * (1.0f - filter_coef);
 	_gps_check_fail_status.flags.vspeed = (fabsf(_gps_velD_diff_filt) > _params.req_vdrift);

--- a/EKF/gps_yaw_fusion.cpp
+++ b/EKF/gps_yaw_fusion.cpp
@@ -146,13 +146,10 @@ void Ekf::fuseGpsYaw()
 		_heading_innov_var += H_YAW[row] * PH[row];
 	}
 
-	float heading_innov_var_inv;
-
 	// check if the innovation variance calculation is badly conditioned
 	if (_heading_innov_var >= R_YAW) {
 		// the innovation variance contribution from the state covariances is not negative, no fault
 		_fault_status.flags.bad_hdg = false;
-		heading_innov_var_inv = 1.0f / _heading_innov_var;
 
 	} else {
 		// the innovation variance contribution from the state covariances is negative which means the covariance matrix is badly conditioned
@@ -163,6 +160,8 @@ void Ekf::fuseGpsYaw()
 		ECL_ERR_TIMESTAMPED("GPS yaw numerical error - covariance reset");
 		return;
 	}
+
+	const float heading_innov_var_inv = 1.f / _heading_innov_var;
 
 	// calculate the Kalman gains
 	// only calculate gains for states we are using

--- a/EKF/gps_yaw_fusion.cpp
+++ b/EKF/gps_yaw_fusion.cpp
@@ -250,7 +250,6 @@ void Ekf::fuseGpsYaw()
 	}
 
 	if (healthy) {
-		_time_last_gps_yaw_fuse = _time_last_imu;
 		// apply the covariance corrections
 		P -= KHP;
 
@@ -259,6 +258,7 @@ void Ekf::fuseGpsYaw()
 		// apply the state corrections
 		fuse(Kfusion, _heading_innov);
 
+		_time_last_gps_yaw_fuse = _time_last_imu;
 	}
 }
 

--- a/EKF/gps_yaw_fusion.cpp
+++ b/EKF/gps_yaw_fusion.cpp
@@ -202,7 +202,7 @@ void Ekf::fuseGpsYaw()
 
 		} else {
 			// constrain the innovation to the maximum set by the gate
-			float gate_limit = sqrtf((sq(innov_gate) * _heading_innov_var));
+			const float gate_limit = sqrtf((sq(innov_gate) * _heading_innov_var));
 			_heading_innov = math::constrain(_heading_innov, -gate_limit, gate_limit);
 		}
 

--- a/EKF/gps_yaw_fusion.cpp
+++ b/EKF/gps_yaw_fusion.cpp
@@ -232,21 +232,9 @@ void Ekf::fuseGpsYaw()
 		}
 	}
 
-	// if the covariance correction will result in a negative variance, then
-	// the covariance matrix is unhealthy and must be corrected
-	bool healthy = true;
-	_fault_status.flags.bad_hdg = false;
+	const bool healthy = isCovarianceUpdateHealthy(KHP);
 
-	for (int i = 0; i < _k_num_states; i++) {
-		if (P(i,i) < KHP(i,i)) {
-			P.uncorrelateCovarianceSetVariance<1>(i, 0.0f);
-
-			healthy = false;
-
-			_fault_status.flags.bad_hdg = true;
-
-		}
-	}
+	_fault_status.flags.bad_hdg = !healthy;
 
 	if (healthy) {
 		// apply the covariance corrections

--- a/EKF/mag_control.cpp
+++ b/EKF/mag_control.cpp
@@ -52,7 +52,7 @@ void Ekf::controlMagFusion()
 	if (_params.mag_fusion_type == MAG_FUSE_TYPE_NONE) {
 		if (noOtherYawAidingThanMag())
 		{
-			_yaw_use_inhibit = true;
+			_yaw_fusion_is_inhibited = true;
 			fuseHeading();
 		}
 		return;
@@ -156,7 +156,7 @@ void Ekf::runOnGroundYawReset()
 
 bool Ekf::isYawResetAuthorized() const
 {
-	return !_yaw_use_inhibit;
+	return !_yaw_fusion_is_inhibited;
 }
 
 bool Ekf::canResetMagHeading() const
@@ -268,8 +268,8 @@ void Ekf::checkMagDeclRequired()
 
 void Ekf::checkMagInhibition()
 {
-	_yaw_use_inhibit = shouldInhibitMag();
-	if (!_yaw_use_inhibit) {
+	_yaw_fusion_is_inhibited = shouldInhibitMag();
+	if (!_yaw_fusion_is_inhibited) {
 		_mag_use_not_inhibit_us = _imu_sample_delayed.time_us;
 	}
 

--- a/EKF/mag_fusion.cpp
+++ b/EKF/mag_fusion.cpp
@@ -792,7 +792,7 @@ void Ekf::fuseHeading()
 				// unconstrained quaternion variance growth and record the predicted heading
 				// to use as an observation when movement ceases.
 				// TODO a better way of determining when this is necessary
-				float sumQuatVar = P(0,0) + P(1,1) + P(2,2) + P(3,3);
+				const float sumQuatVar = P(0,0) + P(1,1) + P(2,2) + P(3,3);
 				if (sumQuatVar > _params.quat_max_variance) {
 					fuse_zero_innov = true;
 					R_YAW = 0.25f;
@@ -859,7 +859,7 @@ void Ekf::fuseHeading()
 				// unconstrained quaterniion variance growth and record the predicted heading
 				// to use as an observation when movement ceases.
 				// TODO a better way of determining when this is necessary
-				float sumQuatVar = P(0,0) + P(1,1) + P(2,2) + P(3,3);
+				const float sumQuatVar = P(0,0) + P(1,1) + P(2,2) + P(3,3);
 				if (sumQuatVar > _params.quat_max_variance) {
 					fuse_zero_innov = true;
 					R_YAW = 0.25f;
@@ -891,7 +891,7 @@ void Ekf::fuseDeclination(float decl_sigma)
 	const float magE = _state.mag_I(1);
 
 	// minimum horizontal field strength before calculation becomes badly conditioned (T)
-	const float h_field_min = 0.001f;
+	constexpr float h_field_min = 0.001f;
 
 	// observation variance (rad**2)
 	const float R_DECL = sq(decl_sigma);
@@ -1050,7 +1050,7 @@ void Ekf::limitDeclination()
 	}
 
 	// do not allow the declination estimate to vary too much relative to the reference value
-	const float decl_tolerance = 0.5f;
+	constexpr float decl_tolerance = 0.5f;
 	const float decl_max = decl_reference + decl_tolerance;
 	const float decl_min = decl_reference - decl_tolerance;
 	const float decl_estimate = atan2f(_state.mag_I(1) , _state.mag_I(0));

--- a/EKF/mag_fusion.cpp
+++ b/EKF/mag_fusion.cpp
@@ -414,8 +414,8 @@ void Ekf::fuseYaw321(float yaw, float yaw_variance, bool zero_innovation)
 	const float q2 = _state.quat_nominal(2);
 	const float q3 = _state.quat_nominal(3);
 
-	float R_YAW = fmaxf(yaw_variance, 1.0e-4f);
-	float measurement = wrap_pi(yaw);
+	const float R_YAW = fmaxf(yaw_variance, 1.0e-4f);
+	const float measurement = wrap_pi(yaw);
 	float H_YAW[4];
 
 	// calculate observation jacobian when we are observing the first rotation in a 321 sequence
@@ -509,8 +509,8 @@ void Ekf::fuseYaw312(float yaw, float yaw_variance, bool zero_innovation)
 	const float q2 = _state.quat_nominal(2);
 	const float q3 = _state.quat_nominal(3);
 
-	float R_YAW = fmaxf(yaw_variance, 1.0e-4f);
-	float measurement = wrap_pi(yaw);
+	const float R_YAW = fmaxf(yaw_variance, 1.0e-4f);
+	const float measurement = wrap_pi(yaw);
 	float H_YAW[4];
 
 	// calculate observation jacobian when we are observing a rotation in a 312 sequence

--- a/EKF/mag_fusion.cpp
+++ b/EKF/mag_fusion.cpp
@@ -784,7 +784,7 @@ void Ekf::fuseHeading()
 
 		// handle special case where yaw measurement is unavailable
 		bool fuse_zero_innov = false;
-		if (_yaw_use_inhibit) {
+		if (_yaw_fusion_is_inhibited) {
 			// The yaw measurement cannot be trusted but we need to fuse something to prevent a badly
 			// conditioned covariance matrix developing over time.
 			if (!_control_status.flags.vehicle_at_rest) {
@@ -851,7 +851,7 @@ void Ekf::fuseHeading()
 
 		// handle special case where yaw measurement is unavailable
 		bool fuse_zero_innov = false;
-		if (_yaw_use_inhibit) {
+		if (_yaw_fusion_is_inhibited) {
 			// The yaw measurement cannot be trusted but we need to fuse something to prevent a badly
 			// conditioned covariance matrix developing over time.
 			if (!_control_status.flags.vehicle_at_rest) {

--- a/EKF/mag_fusion.cpp
+++ b/EKF/mag_fusion.cpp
@@ -143,13 +143,13 @@ void Ekf::fuseMag()
 	}
 
 	// Perform an innovation consistency check and report the result
-	bool healthy = true;
+	bool all_innovation_checks_passed = true;
 
 	for (uint8_t index = 0; index <= 2; index++) {
 		_mag_test_ratio(index) = sq(_mag_innov(index)) / (sq(math::max(_params.mag_innov_gate, 1.0f)) * _mag_innov_var(index));
 
 		if (_mag_test_ratio(index) > 1.0f) {
-			healthy = false;
+			all_innovation_checks_passed = false;
 			_innov_check_fail_status.value |= (1 << (index + 3));
 
 		} else {
@@ -161,17 +161,13 @@ void Ekf::fuseMag()
 	_yaw_test_ratio = 0.0f;
 
 	// if any axis fails, abort the mag fusion
-	if (!healthy) {
+	if (!all_innovation_checks_passed) {
 		return;
 	}
 
 	// For the first few seconds after in-flight alignment we allow the magnetic field state estimates to stabilise
 	// before they are used to constrain heading drift
 	const bool update_all_states = ((_imu_sample_delayed.time_us - _flt_mag_align_start_time) > (uint64_t)5e6);
-
-	_fault_status.flags.bad_mag_x = false;
-	_fault_status.flags.bad_mag_y = false;
-	_fault_status.flags.bad_mag_z = false;
 
 	// Observation jacobian and Kalman gain vectors
 	Vector24f H_MAG;
@@ -367,28 +363,16 @@ void Ekf::fuseMag()
 			}
 		}
 
-		// if the covariance correction will result in a negative variance, then
-		// the covariance matrix is unhealthy and must be corrected
+		const bool healthy = isCovarianceUpdateHealthy(KHP);
 
-		for (int i = 0; i < _k_num_states; i++) {
-			if (P(i,i) < KHP(i,i)) {
-				// zero rows and columns
-				P.uncorrelateCovarianceSetVariance<1>(i, 0.0f);
+		if (index == 0) {
+			_fault_status.flags.bad_mag_x = !healthy;
 
-				//flag as unhealthy
-				healthy = false;
+		} else if (index == 1) {
+			_fault_status.flags.bad_mag_y = !healthy;
 
-				// update individual measurement health status
-				if (index == 0) {
-					_fault_status.flags.bad_mag_x = true;
-
-				} else if (index == 1) {
-					_fault_status.flags.bad_mag_y = true;
-
-				} else if (index == 2) {
-					_fault_status.flags.bad_mag_z = true;
-				}
-			}
+		} else if (index == 2) {
+			_fault_status.flags.bad_mag_z = !healthy;
 		}
 
 		if (healthy) {
@@ -698,21 +682,9 @@ void Ekf::updateQuaternion(const float innovation, const float variance, const f
 		}
 	}
 
-	// if the covariance correction will result in a negative variance, then
-	// the covariance matrix is unhealthy and must be corrected
-	bool healthy = true;
-	_fault_status.flags.bad_hdg = false;
+	const bool healthy = isCovarianceUpdateHealthy(KHP);
 
-	for (int i = 0; i < _k_num_states; i++) {
-		if (P(i,i) < KHP(i,i)) {
-			P.uncorrelateCovarianceSetVariance<1>(i, 0.0f);
-
-			healthy = false;
-
-			_fault_status.flags.bad_hdg = true;
-
-		}
-	}
+	_fault_status.flags.bad_hdg = !healthy;
 
 	if (healthy) {
 		// apply the covariance corrections
@@ -983,20 +955,9 @@ void Ekf::fuseDeclination(float decl_sigma)
 		}
 	}
 
-	// if the covariance correction will result in a negative variance, then
-	// the covariance matrix is unhealthy and must be corrected
-	bool healthy = true;
-	_fault_status.flags.bad_mag_decl = false;
-	for (int i = 0; i < _k_num_states; i++) {
-		if (P(i,i) < KHP(i,i)) {
-			P.uncorrelateCovarianceSetVariance<1>(i, 0.0f);
+	const bool healthy = isCovarianceUpdateHealthy(KHP);
 
-			healthy = false;
-
-			_fault_status.flags.bad_mag_decl = true;
-
-		}
-	}
+	_fault_status.flags.bad_mag_decl = !healthy;
 
 	if (healthy) {
 		// apply the covariance corrections

--- a/EKF/mag_fusion.cpp
+++ b/EKF/mag_fusion.cpp
@@ -332,36 +332,7 @@ void Ekf::fuseMag()
 		// apply covariance correction via P_new = (I -K*H)*P
 		// first calculate expression for KHP
 		// then calculate P - KHP
-		SquareMatrix24f KHP;
-		float KH[10];
-
-		for (unsigned row = 0; row < _k_num_states; row++) {
-
-			KH[0] = Kfusion(row) * H_MAG(0);
-			KH[1] = Kfusion(row) * H_MAG(1);
-			KH[2] = Kfusion(row) * H_MAG(2);
-			KH[3] = Kfusion(row) * H_MAG(3);
-			KH[4] = Kfusion(row) * H_MAG(16);
-			KH[5] = Kfusion(row) * H_MAG(17);
-			KH[6] = Kfusion(row) * H_MAG(18);
-			KH[7] = Kfusion(row) * H_MAG(19);
-			KH[8] = Kfusion(row) * H_MAG(20);
-			KH[9] = Kfusion(row) * H_MAG(21);
-
-			for (unsigned column = 0; column < _k_num_states; column++) {
-				float tmp = KH[0] * P(0,column);
-				tmp += KH[1] * P(1,column);
-				tmp += KH[2] * P(2,column);
-				tmp += KH[3] * P(3,column);
-				tmp += KH[4] * P(16,column);
-				tmp += KH[5] * P(17,column);
-				tmp += KH[6] * P(18,column);
-				tmp += KH[7] * P(19,column);
-				tmp += KH[8] * P(20,column);
-				tmp += KH[9] * P(21,column);
-				KHP(row,column) = tmp;
-			}
-		}
+		const SquareMatrix24f KHP = computeKHP<0,1,2,3,16,17,18,19,20,21>(Kfusion, H_MAG);
 
 		const bool healthy = isCovarianceUpdateHealthy(KHP);
 
@@ -941,19 +912,7 @@ void Ekf::fuseDeclination(float decl_sigma)
 	// first calculate expression for KHP
 	// then calculate P - KHP
 	// take advantage of the empty columns in KH to reduce the number of operations
-	SquareMatrix24f KHP;
-	float KH[2];
-	for (unsigned row = 0; row < _k_num_states; row++) {
-
-		KH[0] = Kfusion(row) * H_DECL(16);
-		KH[1] = Kfusion(row) * H_DECL(17);
-
-		for (unsigned column = 0; column < _k_num_states; column++) {
-			float tmp = KH[0] * P(16,column);
-			tmp += KH[1] * P(17,column);
-			KHP(row,column) = tmp;
-		}
-	}
+	const SquareMatrix24f KHP = computeKHP<16,17>(Kfusion, H_DECL);
 
 	const bool healthy = isCovarianceUpdateHealthy(KHP);
 

--- a/EKF/optflow_fusion.cpp
+++ b/EKF/optflow_fusion.cpp
@@ -220,18 +220,16 @@ void Ekf::fuseOptFlow()
 			float t87 = t2*t22*t56;
 			float t92 = t2*t7*t69;
 			float t77 = R_LOS+t37+t43+t50+t63+t76-t87-t92;
-			float t78;
 
-			// calculate innovation variance for X axis observation and protect against a badly conditioned calculation
-			if (t77 >= R_LOS) {
-				t78 = 1.0f / t77;
-				_flow_innov_var(0) = t77;
-
-			} else {
+			// protect against a badly conditioned calculation
+			if (t77 < R_LOS) {
 				// we need to reinitialise the covariance matrix and abort this fusion step
 				initialiseCovariance();
 				return;
 			}
+
+			float t78 = 1.0f / t77;
+			_flow_innov_var(0) = t77;
 
 			// calculate Kalman gains for X-axis observation
 			Kfusion[0][0] = t78*(t12-P(0,4)*t2*t7+P(0,1)*t2*t15+P(0,6)*t2*t10+P(0,2)*t2*t19-P(0,3)*t2*t22+P(0,5)*t2*t27);
@@ -363,17 +361,16 @@ void Ekf::fuseOptFlow()
 			float t85 = t2*t19*t49;
 			float t94 = t2*t10*t76;
 			float t77 = R_LOS+t37+t43+t56+t63+t70-t85-t94;
-			float t78;
-			// calculate innovation variance for Y axis observation and protect against a badly conditioned calculation
-			if (t77 >= R_LOS) {
-				t78 = 1.0f / t77;
-				_flow_innov_var(1) = t77;
 
-			} else {
+			// protect against a badly conditioned calculation
+			if (t77 < R_LOS) {
 				// we need to reinitialise the covariance matrix and abort this fusion step
 				initialiseCovariance();
 				return;
 			}
+
+			float t78 = 1.0f / t77;
+			_flow_innov_var(1) = t77;
 
 			// calculate Kalman gains for Y-axis observation
 			Kfusion[0][1] = -t78*(t12+P(0,5)*t2*t8-P(0,6)*t2*t10+P(0,1)*t2*t16-P(0,2)*t2*t19+P(0,3)*t2*t22+P(0,4)*t2*t27);

--- a/EKF/optflow_fusion.cpp
+++ b/EKF/optflow_fusion.cpp
@@ -425,9 +425,6 @@ void Ekf::fuseOptFlow()
 
 	}
 
-	_fault_status.flags.bad_optflow_X = false;
-	_fault_status.flags.bad_optflow_Y = false;
-
 	for (uint8_t obs_index = 0; obs_index <= 1; obs_index++) {
 
 		// copy the Kalman gain vector for the axis we are fusing
@@ -465,23 +462,13 @@ void Ekf::fuseOptFlow()
 			}
 		}
 
-		// if the covariance correction will result in a negative variance, then
-		// the covariance matrix is unhealthy and must be corrected
-		bool healthy = true;
+		const bool healthy = isCovarianceUpdateHealthy(KHP);
 
-		for (int i = 0; i < _k_num_states; i++) {
-			if (P(i,i) < KHP(i,i)) {
-				P.uncorrelateCovarianceSetVariance<1>(i, 0.0f);
+		if (obs_index == 0) {
+			_fault_status.flags.bad_optflow_X = !healthy;
 
-				healthy = false;
-
-				if (obs_index == 0) {
-					_fault_status.flags.bad_optflow_X = true;
-
-				} else if (obs_index == 1) {
-					_fault_status.flags.bad_optflow_Y = true;
-				}
-			}
+		} else if (obs_index == 1) {
+			_fault_status.flags.bad_optflow_Y = !healthy;
 		}
 
 		if (healthy) {

--- a/EKF/sideslip_fusion.cpp
+++ b/EKF/sideslip_fusion.cpp
@@ -106,10 +106,6 @@ void Ekf::fuseSideslip()
 		H_BETA[22] = SH_BETA[5]*(SH_BETA[12] - 2.0f*q1*q2) + SH_BETA[1]*SH_BETA[4]*SH_BETA[7];
 		H_BETA[23] = SH_BETA[1]*SH_BETA[4]*(SH_BETA[12] + 2.0f*q1*q2) - SH_BETA[6];
 
-		for (uint8_t i = 7; i <= 21; i++) {
-			H_BETA[i] = 0.0f;
-		}
-
 		// determine if we need the sideslip fusion to correct states other than wind
 		bool update_wind_only = !_is_wind_dead_reckoning;
 

--- a/EKF/sideslip_fusion.cpp
+++ b/EKF/sideslip_fusion.cpp
@@ -192,9 +192,6 @@ void Ekf::fuseSideslip()
 			_innov_check_fail_status.flags.reject_sideslip = false;
 		}
 
-		// synthetic sideslip measurement sample has passed check so record it
-		_time_last_beta_fuse = _time_last_imu;
-
 		// apply covariance correction via P_new = (I -K*H)*P
 		// first calculate expression for KHP
 		// then calculate P - KHP
@@ -249,6 +246,8 @@ void Ekf::fuseSideslip()
 
 			// apply the state corrections
 			fuse(Kfusion, _beta_innov);
+
+			_time_last_beta_fuse = _time_last_imu;
 		}
 	}
 }

--- a/EKF/sideslip_fusion.cpp
+++ b/EKF/sideslip_fusion.cpp
@@ -93,17 +93,17 @@ void Ekf::fuseSideslip()
 		SH_BETA[11] = 2.0f*q1*SH_BETA[2] + 2.0f*q2*SH_BETA[3] + 2.0f*q3*vd;
 		SH_BETA[12] = 2.0f*q0*q3;
 
-		float H_BETA[24] = {}; // Observation Jacobian
+		Vector24f H_BETA; // Observation Jacobian
 
-		H_BETA[0] = SH_BETA[5]*SH_BETA[8] - SH_BETA[1]*SH_BETA[4]*SH_BETA[9];
-		H_BETA[1] = SH_BETA[5]*SH_BETA[10] - SH_BETA[1]*SH_BETA[4]*SH_BETA[11];
-		H_BETA[2] = SH_BETA[5]*SH_BETA[11] + SH_BETA[1]*SH_BETA[4]*SH_BETA[10];
-		H_BETA[3] = - SH_BETA[5]*SH_BETA[9] - SH_BETA[1]*SH_BETA[4]*SH_BETA[8];
-		H_BETA[4] = - SH_BETA[5]*(SH_BETA[12] - 2.0f*q1*q2) - SH_BETA[1]*SH_BETA[4]*SH_BETA[7];
-		H_BETA[5] = SH_BETA[6] - SH_BETA[1]*SH_BETA[4]*(SH_BETA[12] + 2.0f*q1*q2);
-		H_BETA[6] = SH_BETA[5]*(2.0f*q0*q1 + 2.0f*q2*q3) + SH_BETA[1]*SH_BETA[4]*(2.0f*q0*q2 - 2.0f*q1*q3);
-		H_BETA[22] = SH_BETA[5]*(SH_BETA[12] - 2.0f*q1*q2) + SH_BETA[1]*SH_BETA[4]*SH_BETA[7];
-		H_BETA[23] = SH_BETA[1]*SH_BETA[4]*(SH_BETA[12] + 2.0f*q1*q2) - SH_BETA[6];
+		H_BETA(0) = SH_BETA[5]*SH_BETA[8] - SH_BETA[1]*SH_BETA[4]*SH_BETA[9];
+		H_BETA(1) = SH_BETA[5]*SH_BETA[10] - SH_BETA[1]*SH_BETA[4]*SH_BETA[11];
+		H_BETA(2) = SH_BETA[5]*SH_BETA[11] + SH_BETA[1]*SH_BETA[4]*SH_BETA[10];
+		H_BETA(3) = - SH_BETA[5]*SH_BETA[9] - SH_BETA[1]*SH_BETA[4]*SH_BETA[8];
+		H_BETA(4) = - SH_BETA[5]*(SH_BETA[12] - 2.0f*q1*q2) - SH_BETA[1]*SH_BETA[4]*SH_BETA[7];
+		H_BETA(5) = SH_BETA[6] - SH_BETA[1]*SH_BETA[4]*(SH_BETA[12] + 2.0f*q1*q2);
+		H_BETA(6) = SH_BETA[5]*(2.0f*q0*q1 + 2.0f*q2*q3) + SH_BETA[1]*SH_BETA[4]*(2.0f*q0*q2 - 2.0f*q1*q3);
+		H_BETA(22) = SH_BETA[5]*(SH_BETA[12] - 2.0f*q1*q2) + SH_BETA[1]*SH_BETA[4]*SH_BETA[7];
+		H_BETA(23) = SH_BETA[1]*SH_BETA[4]*(SH_BETA[12] + 2.0f*q1*q2) - SH_BETA[6];
 
 		// determine if we need the sideslip fusion to correct states other than wind
 		bool update_wind_only = !_is_wind_dead_reckoning;
@@ -200,15 +200,15 @@ void Ekf::fuseSideslip()
 		float KH[9];
 
 		for (unsigned row = 0; row < _k_num_states; row++) {
-			KH[0] = Kfusion(row) * H_BETA[0];
-			KH[1] = Kfusion(row) * H_BETA[1];
-			KH[2] = Kfusion(row) * H_BETA[2];
-			KH[3] = Kfusion(row) * H_BETA[3];
-			KH[4] = Kfusion(row) * H_BETA[4];
-			KH[5] = Kfusion(row) * H_BETA[5];
-			KH[6] = Kfusion(row) * H_BETA[6];
-			KH[7] = Kfusion(row) * H_BETA[22];
-			KH[8] = Kfusion(row) * H_BETA[23];
+			KH[0] = Kfusion(row) * H_BETA(0);
+			KH[1] = Kfusion(row) * H_BETA(1);
+			KH[2] = Kfusion(row) * H_BETA(2);
+			KH[3] = Kfusion(row) * H_BETA(3);
+			KH[4] = Kfusion(row) * H_BETA(4);
+			KH[5] = Kfusion(row) * H_BETA(5);
+			KH[6] = Kfusion(row) * H_BETA(6);
+			KH[7] = Kfusion(row) * H_BETA(22);
+			KH[8] = Kfusion(row) * H_BETA(23);
 
 			for (unsigned column = 0; column < _k_num_states; column++) {
 				float tmp = KH[0] * P(0,column);

--- a/EKF/sideslip_fusion.cpp
+++ b/EKF/sideslip_fusion.cpp
@@ -46,7 +46,7 @@
 
 void Ekf::fuseSideslip()
 {
-	float R_BETA = _params.beta_noise;
+	const float R_BETA = _params.beta_noise;
 
 	// get latest estimated orientation
 	const float q0 = _state.quat_nominal(0);

--- a/EKF/sideslip_fusion.cpp
+++ b/EKF/sideslip_fusion.cpp
@@ -224,20 +224,9 @@ void Ekf::fuseSideslip()
 			}
 		}
 
-		// if the covariance correction will result in a negative variance, then
-		// the covariance matrix is unhealthy and must be corrected
-		bool healthy = true;
-		_fault_status.flags.bad_sideslip = false;
+		const bool healthy = isCovarianceUpdateHealthy(KHP);
 
-		for (int i = 0; i < _k_num_states; i++) {
-			if (P(i,i) < KHP(i,i)) {
-				P.uncorrelateCovarianceSetVariance<1>(i, 0.0f);
-
-				healthy = false;
-
-				_fault_status.flags.bad_sideslip = true;
-			}
-		}
+		_fault_status.flags.bad_sideslip = !healthy;
 
 		if (healthy) {
 			// apply the covariance corrections

--- a/EKF/sideslip_fusion.cpp
+++ b/EKF/sideslip_fusion.cpp
@@ -196,33 +196,7 @@ void Ekf::fuseSideslip()
 		// apply covariance correction via P_new = (I -K*H)*P
 		// first calculate expression for KHP
 		// then calculate P - KHP
-		SquareMatrix24f KHP;
-		float KH[9];
-
-		for (unsigned row = 0; row < _k_num_states; row++) {
-			KH[0] = Kfusion(row) * H_BETA(0);
-			KH[1] = Kfusion(row) * H_BETA(1);
-			KH[2] = Kfusion(row) * H_BETA(2);
-			KH[3] = Kfusion(row) * H_BETA(3);
-			KH[4] = Kfusion(row) * H_BETA(4);
-			KH[5] = Kfusion(row) * H_BETA(5);
-			KH[6] = Kfusion(row) * H_BETA(6);
-			KH[7] = Kfusion(row) * H_BETA(22);
-			KH[8] = Kfusion(row) * H_BETA(23);
-
-			for (unsigned column = 0; column < _k_num_states; column++) {
-				float tmp = KH[0] * P(0,column);
-				tmp += KH[1] * P(1,column);
-				tmp += KH[2] * P(2,column);
-				tmp += KH[3] * P(3,column);
-				tmp += KH[4] * P(4,column);
-				tmp += KH[5] * P(5,column);
-				tmp += KH[6] * P(6,column);
-				tmp += KH[7] * P(22,column);
-				tmp += KH[8] * P(23,column);
-				KHP(row,column) = tmp;
-			}
-		}
+		const SquareMatrix24f KHP = computeKHP<0,1,2,3,4,5,6,22,23>(Kfusion, H_BETA);
 
 		const bool healthy = isCovarianceUpdateHealthy(KHP);
 

--- a/EKF/terrain_estimator.cpp
+++ b/EKF/terrain_estimator.cpp
@@ -165,7 +165,7 @@ void Ekf::fuseHagl()
 
 	if (_hagl_test_ratio <= 1.0f) {
 		// calculate the Kalman gain
-		float gain = _terrain_var / _hagl_innov_var;
+		const float gain = _terrain_var / _hagl_innov_var;
 		// correct the state
 		_terrain_vpos -= gain * _hagl_innov;
 		// correct the variance

--- a/EKF/utils.cpp
+++ b/EKF/utils.cpp
@@ -26,24 +26,24 @@ matrix::Dcmf taitBryan312ToRotMat(const matrix::Vector3f &rot312)
 
 float kahanSummation(float sum_previous, float input, float &accumulator)
 {
-	float y = input - accumulator;
-	float t = sum_previous + y;
+	const float y = input - accumulator;
+	const float t = sum_previous + y;
 	accumulator = (t - sum_previous) - y;
 	return t;
 }
 
 matrix::Dcmf quatToInverseRotMat(const  matrix::Quatf &quat)
 {
-	float q00 = quat(0) * quat(0);
-	float q11 = quat(1) * quat(1);
-	float q22 = quat(2) * quat(2);
-	float q33 = quat(3) * quat(3);
-	float q01 = quat(0) * quat(1);
-	float q02 = quat(0) * quat(2);
-	float q03 = quat(0) * quat(3);
-	float q12 = quat(1) * quat(2);
-	float q13 = quat(1) * quat(3);
-	float q23 = quat(2) * quat(3);
+	const float q00 = quat(0) * quat(0);
+	const float q11 = quat(1) * quat(1);
+	const float q22 = quat(2) * quat(2);
+	const float q33 = quat(3) * quat(3);
+	const float q01 = quat(0) * quat(1);
+	const float q02 = quat(0) * quat(2);
+	const float q03 = quat(0) * quat(3);
+	const float q12 = quat(1) * quat(2);
+	const float q13 = quat(1) * quat(3);
+	const float q23 = quat(2) * quat(3);
 
 	matrix::Dcmf dcm;
 	dcm(0, 0) = q00 + q11 - q22 - q33;


### PR DESCRIPTION
I just learned about variadic functions and templates. It seems that they could be used to define a single function that performs a sparse computation of the KHP matrix, which can be reused in multiple places through the code base. 5 places without further modifications.
Since the measurement jacobian is often very sparse, it is beneficial to neglect the zero entries during the vector-matrix multiplication.

Variadic functions are usually implemented in a recursive manner, so is this proposed implementation. This has the drawback that we can not explicitly cache the KH[i] = K(row) * H(x) terms to reduce the amount of multiplications.

TODO:
-[] Add test to cover these changes. Add the moment it is not covered at all. Plus and minus can be exchanged without failure.
-[] Test performance issues
-[] Test numeric stability