### PR TITLE
Do not update output filter a second time after reset to flow.

### DIFF
--- a/EKF/control.cpp
+++ b/EKF/control.cpp
@@ -453,9 +453,6 @@ void Ekf::controlOpticalFlowFusion()
 					// but _flow_compensated_XY_rad is this zero as it gets updated for the first time below here.
 					resetVelocity();
 					resetHorizontalPosition();
-
-					// align the output observer to the EKF states
-					alignOutputFilter();
 				}
 			}
 


### PR DESCRIPTION
This is the only place where we use the alignOutputFilter function after a reset. We update the position and velocity states of the output_buffer already inside the reset functions above.

alignOutputFilter does also update the quaternion state, but I see no need for this inside the flow fusion.