### PR TITLE
Make delayed output state non-member variable

### DIFF
--- a/EKF/ekf.h
+++ b/EKF/ekf.h
@@ -514,8 +514,8 @@ private:
 	// update the real time complementary filter states. This includes the prediction
 	// and the correction step
 	void calculateOutputStates();
-	void applyCorrectionToVerticalOutputBuffer(float vel_gain, float pos_gain);
-	void applyCorrectionToOutputBuffer(float vel_gain, float pos_gain);
+	void applyCorrectionToVerticalOutputBuffer(float vert_vel_correction);
+	void applyCorrectionToOutputBuffer(const Vector3f& vel_correction, const Vector3f& pos_correction);
 
 	// initialise filter states of both the delayed ekf and the real time complementary filter
 	bool initialiseFilter(void);

--- a/EKF/ekf_helper.cpp
+++ b/EKF/ekf_helper.cpp
@@ -353,9 +353,7 @@ void Ekf::alignOutputFilter()
 		_output_buffer[i].pos += pos_delta;
 	}
 
-	_output_new.quat_nominal = q_delta * _output_new.quat_nominal;
-	_output_new.quat_nominal.normalize();
-	// TODO: what about vel and pos of _output_new, shouldn't they be aligned too?
+	_output_new = _output_buffer.get_newest();
 }
 
 // Do a forced re-alignment of the yaw angle to align with the horizontal velocity vector from the GPS.

--- a/EKF/estimator_interface.h
+++ b/EKF/estimator_interface.h
@@ -456,9 +456,7 @@ protected:
 	float _flow_max_distance{0.0f};	///< maximum distance that the optical flow sensor can operate at (m)
 
 	// Output Predictor
-	outputSample _output_sample_delayed{};	// filter output on the delayed time horizon
 	outputSample _output_new{};		// filter output on the non-delayed time horizon
-	outputVert _output_vert_delayed{};	// vertical filter output on the delayed time horizon
 	outputVert _output_vert_new{};		// vertical filter output on the non-delayed time horizon
 	imuSample _newest_high_rate_imu_sample{};		// imu sample capturing the newest imu data
 	Matrix3f _R_to_earth_now;		// rotation matrix from body to earth frame at current time


### PR DESCRIPTION
It helps to look at commit it by commit.
The `output_*_delayed` states are used to compute the correction that gets applied to the output filter, such that the `output_*_delayed` states are tracking the EKF delayed states.

It seems that it is not necessary to have a member variable to store this delayed output. Storing it only introduces the need to keep it in sync with the buffer itself, during a EKF state reset.

In addition, I notice that we get the delayed output by calling the buffers `get_oldest` function. Will the oldest entry in the buffer always be close to the delayed fusion horizon?
Plus, in the alignOutputFilter, the output_new's quaternion gets updated, but not its velocity or position. Bug?