### PR TITLE
Extend firmware build checks

### DIFF
--- a/.github/workflows/firmware_build_test.yml
+++ b/.github/workflows/firmware_build_test.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   Firmware-build:
     runs-on: ubuntu-latest
-    container: px4io/px4-dev-base-focal:2020-05-12
+    container: px4io/px4-dev-nuttx-focal:2020-06-21
     env:
       GIT_COMMITTER_EMAIL: bot@px4.io
       GIT_COMMITTER_NAME: PX4BuildBot
@@ -41,3 +41,6 @@ jobs:
     - name: Build Firmware
       working-directory: Firmware
       run: make
+    - name: Build fmu v2 target to check flash size
+      working-directory: Firmware
+      run: make px4_fmu-v2_default


### PR DESCRIPTION
Extend firmware build checks to check if the resulting firmware will fit on fmu-v2. If this is only noticed once it is brought to the Firmware, it can be a blocker.