### PR TITLE
AlphaFilter: include float.h for FLT_EPSILON

### DIFF
--- a/AlphaFilter/AlphaFilter.hpp
+++ b/AlphaFilter/AlphaFilter.hpp
@@ -42,6 +42,8 @@
 
 #pragma once
 
+#include <float.h>
+
 template <typename T>
 class AlphaFilter {
 public:


### PR DESCRIPTION
I forgot to include `float.h` in https://github.com/PX4/ecl/pull/843 when using `FLT_EPSILON`.
Not sure why nothing ever complained until I used it recently.