### PR TITLE
Yaw helper functions

### DIFF
--- a/EKF/EKFGSF_yaw.cpp
+++ b/EKF/EKFGSF_yaw.cpp
@@ -224,7 +224,7 @@ void EKFGSF_yaw::ahrsAlignYaw()
 {
 	// Align yaw angle for each model
 	for (uint8_t model_index = 0; model_index < N_MODELS_EKFGSF; model_index++) {
-		if (fabsf(_ahrs_ekf_gsf[model_index].R(2, 0)) < fabsf(_ahrs_ekf_gsf[model_index].R(2, 1))) {
+		if (shouldUse321RotationSequence(_ahrs_ekf_gsf[model_index].R)) {
 			// get the roll, pitch, yaw estimates from the rotation matrix using a  321 Tait-Bryan rotation sequence
 			Eulerf euler_init(_ahrs_ekf_gsf[model_index].R);
 
@@ -260,7 +260,7 @@ void EKFGSF_yaw::predictEKF(const uint8_t model_index)
 	}
 
 	// Calculate the yaw state using a projection onto the horizontal that avoids gimbal lock
-	if (fabsf(_ahrs_ekf_gsf[model_index].R(2, 0)) < fabsf(_ahrs_ekf_gsf[model_index].R(2, 1))) {
+	if (shouldUse321RotationSequence(_ahrs_ekf_gsf[model_index].R)) {
 		// use 321 Tait-Bryan rotation to define yaw state
 		_ekf_gsf[model_index].X(2) = atan2f(_ahrs_ekf_gsf[model_index].R(1, 0), _ahrs_ekf_gsf[model_index].R(0, 0));
 	} else {

--- a/EKF/EKFGSF_yaw.cpp
+++ b/EKF/EKFGSF_yaw.cpp
@@ -261,11 +261,9 @@ void EKFGSF_yaw::predictEKF(const uint8_t model_index)
 
 	// Calculate the yaw state using a projection onto the horizontal that avoids gimbal lock
 	if (shouldUse321RotationSequence(_ahrs_ekf_gsf[model_index].R)) {
-		// use 321 Tait-Bryan rotation to define yaw state
-		_ekf_gsf[model_index].X(2) = atan2f(_ahrs_ekf_gsf[model_index].R(1, 0), _ahrs_ekf_gsf[model_index].R(0, 0));
+		_ekf_gsf[model_index].X(2) = getEuler321Yaw(_ahrs_ekf_gsf[model_index].R);
 	} else {
-		// use 312 Tait-Bryan rotation to define yaw state
-		_ekf_gsf[model_index].X(2) = atan2f(-_ahrs_ekf_gsf[model_index].R(0, 1), _ahrs_ekf_gsf[model_index].R(1, 1)); // first rotation (yaw)
+		_ekf_gsf[model_index].X(2) = getEuler312Yaw(_ahrs_ekf_gsf[model_index].R);
 	}
 
 	// calculate delta velocity in a horizontal front-right frame

--- a/EKF/EKFGSF_yaw.cpp
+++ b/EKF/EKFGSF_yaw.cpp
@@ -225,24 +225,14 @@ void EKFGSF_yaw::ahrsAlignYaw()
 	// Align yaw angle for each model
 	for (uint8_t model_index = 0; model_index < N_MODELS_EKFGSF; model_index++) {
 		if (shouldUse321RotationSequence(_ahrs_ekf_gsf[model_index].R)) {
-			// get the roll, pitch, yaw estimates from the rotation matrix using a  321 Tait-Bryan rotation sequence
-			Eulerf euler_init(_ahrs_ekf_gsf[model_index].R);
-
-			// set the yaw angle
-			euler_init(2) = wrap_pi(_ekf_gsf[model_index].X(2));
-
-			// update the rotation matrix
-			_ahrs_ekf_gsf[model_index].R = Dcmf(euler_init);
+			// update the rotation matrix with 321 rotation sequence
+			_ahrs_ekf_gsf[model_index].R = updateEuler321YawInRotMat(wrap_pi(_ekf_gsf[model_index].X(2)),
+										_ahrs_ekf_gsf[model_index].R);
 
 		} else {
-			// Calculate the 312 Tait-Bryan rotation sequence that rotates from earth to body frame
-			const Vector3f rot312(wrap_pi(_ekf_gsf[model_index].X(2)),  // yaw
-					      asinf(_ahrs_ekf_gsf[model_index].R(2, 1)),  // roll
-					      atan2f(-_ahrs_ekf_gsf[model_index].R(2, 0),
-						      _ahrs_ekf_gsf[model_index].R(2, 2)));  // pitch
-
-			// Calculate the body to earth frame rotation matrix
-			_ahrs_ekf_gsf[model_index].R = taitBryan312ToRotMat(rot312);
+			// update the rotation matrix with 312 rotation sequence
+			_ahrs_ekf_gsf[model_index].R = updateEuler312YawInRotMat(wrap_pi(_ekf_gsf[model_index].X(2)),
+										_ahrs_ekf_gsf[model_index].R);
 
 		}
 		_ahrs_ekf_gsf[model_index].aligned = true;

--- a/EKF/EKFGSF_yaw.cpp
+++ b/EKF/EKFGSF_yaw.cpp
@@ -226,9 +226,7 @@ void EKFGSF_yaw::ahrsAlignYaw()
 	for (uint8_t model_index = 0; model_index < N_MODELS_EKFGSF; model_index++) {
 		Dcmf& R = _ahrs_ekf_gsf[model_index].R;
 		const float yaw = wrap_pi(_ekf_gsf[model_index].X(2));
-		R = shouldUse321RotationSequence(R) ?
-		    updateEuler321YawInRotMat(yaw, R) :
-		    updateEuler312YawInRotMat(yaw, R);
+		R = updateYawInRotMat(yaw, R);
 
 		_ahrs_ekf_gsf[model_index].aligned = true;
 	}

--- a/EKF/airspeed_fusion.cpp
+++ b/EKF/airspeed_fusion.cpp
@@ -182,8 +182,7 @@ void Ekf::get_true_airspeed(float *tas)
 */
 void Ekf::resetWindStates()
 {
-	const Eulerf euler321(_state.quat_nominal);
-	const float euler_yaw = euler321(2);
+	const float euler_yaw = getEuler321Yaw(_state.quat_nominal);
 
 	if (_tas_data_ready && (_imu_sample_delayed.time_us - _airspeed_sample_delayed.time_us < (uint64_t)5e5)) {
 		// estimate wind using zero sideslip assumption and airspeed measurement if airspeed available

--- a/EKF/covariance.cpp
+++ b/EKF/covariance.cpp
@@ -1096,8 +1096,7 @@ void Ekf::resetWindCovariance()
 	if (_tas_data_ready && (_imu_sample_delayed.time_us - _airspeed_sample_delayed.time_us < (uint64_t)5e5)) {
 		// Derived using EKF/matlab/scripts/Inertial Nav EKF/wind_cov.py
 		// TODO: explicitly include the sideslip angle in the derivation
-		Eulerf euler321(_state.quat_nominal);
-		const float euler_yaw = euler321(2);
+		const float euler_yaw = getEuler321Yaw(_state.quat_nominal);
 		const float R_TAS = sq(math::constrain(_params.eas_noise, 0.5f, 5.0f) * math::constrain(_airspeed_sample_delayed.eas2tas, 0.9f, 10.0f));
 		constexpr float initial_sideslip_uncertainty = math::radians(15.0f);
 		const float initial_wind_var_body_y = sq(_airspeed_sample_delayed.true_airspeed * sinf(initial_sideslip_uncertainty));

--- a/EKF/ekf.h
+++ b/EKF/ekf.h
@@ -816,9 +816,6 @@ private:
 	void checkRangeAidSuitability();
 	bool isRangeAidSuitable() { return _is_range_aid_suitable; }
 
-	// return the square of two floating point numbers - used in auto coded sections
-	static constexpr float sq(float var) { return var * var; }
-
 	// set control flags to use baro height
 	void setControlBaroHeight();
 

--- a/EKF/ekf_helper.cpp
+++ b/EKF/ekf_helper.cpp
@@ -481,9 +481,7 @@ bool Ekf::resetMagHeading(const Vector3f &mag_init, bool increase_yaw_var, bool 
 
 	} else if (_params.mag_fusion_type <= MAG_FUSE_TYPE_3D) {
 		// rotate the magnetometer measurements into earth frame using a zero yaw angle
-		const Dcmf R_to_earth = shouldUse321RotationSequence(_R_to_earth) ?
-						updateEuler321YawInRotMat(0.f, _R_to_earth) :
-						updateEuler312YawInRotMat(0.f, _R_to_earth);
+		const Dcmf R_to_earth = updateYawInRotMat(0.f, _R_to_earth);
 
 		// the angle of the projection onto the horizontal gives the yaw angle
 		const Vector3f mag_earth_pred = R_to_earth * mag_init;
@@ -1640,9 +1638,7 @@ void Ekf::resetQuatStateYaw(float yaw, float yaw_variance, bool update_buffer)
 	_R_to_earth = Dcmf(_state.quat_nominal);
 
 	// update the rotation matrix using the new yaw value
-	_R_to_earth = shouldUse321RotationSequence(_R_to_earth) ?
-			updateEuler321YawInRotMat(yaw, _R_to_earth) :
-			updateEuler312YawInRotMat(yaw, _R_to_earth);
+	_R_to_earth = updateYawInRotMat(yaw, _R_to_earth);
 
 	// calculate the amount that the quaternion has changed by
 	const Quatf quat_after_reset(_R_to_earth);

--- a/EKF/ekf_helper.cpp
+++ b/EKF/ekf_helper.cpp
@@ -486,7 +486,7 @@ bool Ekf::resetMagHeading(const Vector3f &mag_init, bool increase_yaw_var, bool 
 	} else if (_params.mag_fusion_type <= MAG_FUSE_TYPE_3D) {
 		// rotate the magnetometer measurements into earth frame using a zero yaw angle
 		Dcmf R_to_earth;
-		if (fabsf(_R_to_earth(2, 0)) < fabsf(_R_to_earth(2, 1))) {
+		if (shouldUse321RotationSequence(_R_to_earth)) {
 			// rolled more than pitched so use 321 rotation order
 			Eulerf euler321(_state.quat_nominal);
 			euler321(2) = 0.0f;
@@ -1658,7 +1658,7 @@ void Ekf::resetQuatStateYaw(float yaw, float yaw_variance, bool update_buffer)
 
 	// update the rotation matrix using the new yaw value
 	// determine if a 321 or 312 Euler sequence is best
-	if (fabsf(_R_to_earth(2, 0)) < fabsf(_R_to_earth(2, 1))) {
+	if (shouldUse321RotationSequence(_R_to_earth)) {
 		// use a 321 sequence
 		Eulerf euler321(_R_to_earth);
 		euler321(2) = yaw;

--- a/EKF/mag_fusion.cpp
+++ b/EKF/mag_fusion.cpp
@@ -744,10 +744,7 @@ void Ekf::fuseHeading()
 
 		} else if (_control_status.flags.ev_yaw) {
 			// calculate the yaw angle for a 321 sequence
-			// Expressions obtained from yaw_input_321.c produced by https://github.com/PX4/ecl/blob/master/matlab/scripts/Inertial%20Nav%20EKF/quat2yaw321.m
-			const float Tbn_1_0 = 2.0f*(_ev_sample_delayed.quat(0)*_ev_sample_delayed.quat(3)+_ev_sample_delayed.quat(1)*_ev_sample_delayed.quat(2));
-			const float Tbn_0_0 = sq(_ev_sample_delayed.quat(0))+sq(_ev_sample_delayed.quat(1))-sq(_ev_sample_delayed.quat(2))-sq(_ev_sample_delayed.quat(3));
-			measured_hdg = atan2f(Tbn_1_0,Tbn_0_0);
+			measured_hdg = getEuler321Yaw(_ev_sample_delayed.quat);
 
 		} else {
 			measured_hdg = predicted_hdg;
@@ -786,9 +783,9 @@ void Ekf::fuseHeading()
 		fuseYaw321(measured_hdg, R_YAW, fuse_zero_innov);
 
 	} else {
-
 		// pitched more than rolled so use 312 rotation order to calculate the observed yaw angle
-		predicted_hdg = atan2f(-_R_to_earth(0, 1), _R_to_earth(1, 1));
+		const float predicted_hdg = getEuler312Yaw(_R_to_earth);
+
 		if (_control_status.flags.mag_hdg) {
 
 			// Calculate the body to earth frame rotation matrix from the euler angles using a 312 rotation sequence
@@ -810,11 +807,7 @@ void Ekf::fuseHeading()
 			measured_hdg = -atan2f(mag_earth_pred(1), mag_earth_pred(0)) + getMagDeclination();
 
 		} else if (_control_status.flags.ev_yaw) {
-			// calculate the yaw angle for a 312 sequence
-			// Values from yaw_input_312.c file produced by https://github.com/PX4/ecl/blob/master/matlab/scripts/Inertial%20Nav%20EKF/quat2yaw312.m
-			const float Tbn_0_1_neg = 2.0f*(_ev_sample_delayed.quat(0)*_ev_sample_delayed.quat(3)-_ev_sample_delayed.quat(1)*_ev_sample_delayed.quat(2));
-			const float Tbn_1_1 = sq(_ev_sample_delayed.quat(0))-sq(_ev_sample_delayed.quat(1))+sq(_ev_sample_delayed.quat(2))-sq(_ev_sample_delayed.quat(3));
-			measured_hdg = atan2f(Tbn_0_1_neg,Tbn_1_1);
+			measured_hdg = getEuler312Yaw(_ev_sample_delayed.quat);
 
 		} else {
 			measured_hdg = predicted_hdg;

--- a/EKF/mag_fusion.cpp
+++ b/EKF/mag_fusion.cpp
@@ -723,7 +723,7 @@ void Ekf::fuseHeading()
 	_R_to_earth = Dcmf(_state.quat_nominal);
 
 	// determine if a 321 or 312 Euler sequence is best
-	if (fabsf(_R_to_earth(2, 0)) < fabsf(_R_to_earth(2, 1))) {
+	if (shouldUse321RotationSequence(_R_to_earth)) {
 		// rolled more than pitched so use 321 rotation order to calculate the observed yaw angle
 		Eulerf euler321(_state.quat_nominal);
 		predicted_hdg = euler321(2);

--- a/EKF/mag_fusion.cpp
+++ b/EKF/mag_fusion.cpp
@@ -721,9 +721,7 @@ void Ekf::fuseHeading()
 	// update transformation matrix from body to world frame using the current state estimate
 	_R_to_earth = Dcmf(_state.quat_nominal);
 
-	// determine if a 321 or 312 Euler sequence is best
 	if (shouldUse321RotationSequence(_R_to_earth)) {
-		// rolled more than pitched so use 321 rotation order to calculate the observed yaw angle
 		const float predicted_hdg = getEuler321Yaw(_R_to_earth);
 
 		if (_control_status.flags.mag_hdg) {
@@ -741,7 +739,6 @@ void Ekf::fuseHeading()
 			measured_hdg = -atan2f(mag_earth_pred(1), mag_earth_pred(0)) + getMagDeclination();
 
 		} else if (_control_status.flags.ev_yaw) {
-			// calculate the yaw angle for a 321 sequence
 			measured_hdg = getEuler321Yaw(_ev_sample_delayed.quat);
 
 		} else {
@@ -781,16 +778,13 @@ void Ekf::fuseHeading()
 		fuseYaw321(measured_hdg, R_YAW, fuse_zero_innov);
 
 	} else {
-		// pitched more than rolled so use 312 rotation order to calculate the observed yaw angle
 		const float predicted_hdg = getEuler312Yaw(_R_to_earth);
 
 		if (_control_status.flags.mag_hdg) {
 
-			// Calculate the body to earth frame rotation matrix from the euler angles
-			// using a 312 rotation sequence with yaw angle set to to zero
+			// rotate the magnetometer measurements into earth frame using a zero yaw angle
 			const Dcmf R_to_earth = updateEuler312YawInRotMat(0.f, _R_to_earth);
 
-			// rotate the magnetometer measurements into earth frame using a zero yaw angle
 			if (_control_status.flags.mag_3D) {
 				// don't apply bias corrections if we are learning them
 				mag_earth_pred = R_to_earth * _mag_sample_delayed.mag;

--- a/EKF/utils.cpp
+++ b/EKF/utils.cpp
@@ -62,3 +62,27 @@ matrix::Dcmf quatToInverseRotMat(const  matrix::Quatf &quat)
 bool shouldUse321RotationSequence(const matrix::Dcmf& R) {
 	return fabsf(R(2, 0)) < fabsf(R(2, 1));
 }
+
+float getEuler321Yaw(const matrix::Quatf& q) {
+	// Values from yaw_input_321.c file produced by
+	// https://github.com/PX4/ecl/blob/master/matlab/scripts/Inertial%20Nav%20EKF/quat2yaw321.m
+	const float a = 2.f * (q(0) * q(3) + q(1) * q(2));
+	const float b = sq(q(0)) + sq(q(1)) - sq(q(2)) - sq(q(3));
+	return atan2f(a, b);
+}
+
+float getEuler321Yaw(const matrix::Dcmf& R) {
+	return atan2f(R(1, 0), R(0, 0));
+}
+
+float getEuler312Yaw(const matrix::Quatf& q) {
+	// Values from yaw_input_312.c file produced by
+	// https://github.com/PX4/ecl/blob/master/matlab/scripts/Inertial%20Nav%20EKF/quat2yaw312.m
+	const float a = 2.f * (q(0) * q(3) - q(1) * q(2));
+	const float b = sq(q(0)) - sq(q(1)) + sq(q(2)) - sq(q(3));
+	return atan2f(a, b);
+}
+
+float getEuler312Yaw(const matrix::Dcmf& R) {
+	return atan2f(-R(0, 1), R(1, 1));
+}

--- a/EKF/utils.cpp
+++ b/EKF/utils.cpp
@@ -86,3 +86,16 @@ float getEuler312Yaw(const matrix::Quatf& q) {
 float getEuler312Yaw(const matrix::Dcmf& R) {
 	return atan2f(-R(0, 1), R(1, 1));
 }
+
+matrix::Dcmf updateEuler321YawInRotMat(float yaw, const matrix::Dcmf& rot_in) {
+	matrix::Eulerf euler321(rot_in);
+	euler321(2) = yaw;
+	return matrix::Dcmf(euler321);
+}
+
+matrix::Dcmf updateEuler312YawInRotMat(float yaw, const matrix::Dcmf& rot_in) {
+	const matrix::Vector3f rotVec312(yaw,  // yaw
+				asinf(rot_in(2, 1)),  // roll
+				atan2f(-rot_in(2, 0), rot_in(2, 2)));  // pitch
+	return taitBryan312ToRotMat(rotVec312);
+}

--- a/EKF/utils.cpp
+++ b/EKF/utils.cpp
@@ -99,3 +99,9 @@ matrix::Dcmf updateEuler312YawInRotMat(float yaw, const matrix::Dcmf& rot_in) {
 				atan2f(-rot_in(2, 0), rot_in(2, 2)));  // pitch
 	return taitBryan312ToRotMat(rotVec312);
 }
+
+matrix::Dcmf updateYawInRotMat(float yaw, const matrix::Dcmf& rot_in) {
+	return shouldUse321RotationSequence(rot_in) ?
+		updateEuler321YawInRotMat(yaw, rot_in) :
+		updateEuler312YawInRotMat(yaw, rot_in);
+}

--- a/EKF/utils.cpp
+++ b/EKF/utils.cpp
@@ -58,3 +58,7 @@ matrix::Dcmf quatToInverseRotMat(const  matrix::Quatf &quat)
 
 	return dcm;
 }
+
+bool shouldUse321RotationSequence(const matrix::Dcmf& R) {
+	return fabsf(R(2, 0)) < fabsf(R(2, 1));
+}

--- a/EKF/utils.hpp
+++ b/EKF/utils.hpp
@@ -20,6 +20,7 @@ float kahanSummation(float sum_previous, float input, float &accumulator);
 // this produces the inverse rotation to that produced by the math library quaternion to Dcmf operator
 matrix::Dcmf quatToInverseRotMat(const matrix::Quatf &quat);
 
+bool shouldUse321RotationSequence(const matrix::Dcmf& R);
 namespace ecl{
 	inline float powf(float x, int exp)
 	{

--- a/EKF/utils.hpp
+++ b/EKF/utils.hpp
@@ -23,6 +23,9 @@ float kahanSummation(float sum_previous, float input, float &accumulator);
 // this produces the inverse rotation to that produced by the math library quaternion to Dcmf operator
 matrix::Dcmf quatToInverseRotMat(const matrix::Quatf &quat);
 
+// We should use a 3-2-1 Tait-Bryan (yaw-pitch-roll) rotation sequence
+// when there is more roll than pitch tilt and a 3-1-2 rotation sequence
+// when there is more pitch than roll tilt to avoid gimbal lock.
 bool shouldUse321RotationSequence(const matrix::Dcmf& R);
 
 float getEuler321Yaw(const matrix::Quatf& q);

--- a/EKF/utils.hpp
+++ b/EKF/utils.hpp
@@ -2,6 +2,9 @@
 
 #pragma once
 
+// return the square of two floating point numbers - used in auto coded sections
+static constexpr float sq(float var) { return var * var; }
+
 // converts Tait-Bryan 312 sequence of rotations from frame 1 to frame 2
 // to the corresponding rotation matrix that rotates from frame 2 to frame 1
 // rot312(0) - First rotation is a RH rotation about the Z axis (rad)
@@ -21,6 +24,13 @@ float kahanSummation(float sum_previous, float input, float &accumulator);
 matrix::Dcmf quatToInverseRotMat(const matrix::Quatf &quat);
 
 bool shouldUse321RotationSequence(const matrix::Dcmf& R);
+
+float getEuler321Yaw(const matrix::Quatf& q);
+float getEuler321Yaw(const matrix::Dcmf& R);
+
+float getEuler312Yaw(const matrix::Quatf& q);
+float getEuler312Yaw(const matrix::Dcmf& R);
+
 namespace ecl{
 	inline float powf(float x, int exp)
 	{

--- a/EKF/utils.hpp
+++ b/EKF/utils.hpp
@@ -31,6 +31,9 @@ float getEuler321Yaw(const matrix::Dcmf& R);
 float getEuler312Yaw(const matrix::Quatf& q);
 float getEuler312Yaw(const matrix::Dcmf& R);
 
+matrix::Dcmf updateEuler321YawInRotMat(float yaw, const matrix::Dcmf& rot_in);
+matrix::Dcmf updateEuler312YawInRotMat(float yaw, const matrix::Dcmf& rot_in);
+
 namespace ecl{
 	inline float powf(float x, int exp)
 	{

--- a/EKF/utils.hpp
+++ b/EKF/utils.hpp
@@ -37,6 +37,9 @@ float getEuler312Yaw(const matrix::Dcmf& R);
 matrix::Dcmf updateEuler321YawInRotMat(float yaw, const matrix::Dcmf& rot_in);
 matrix::Dcmf updateEuler312YawInRotMat(float yaw, const matrix::Dcmf& rot_in);
 
+// Checks which euler rotation sequence to use and update yaw in rotation matrix
+matrix::Dcmf updateYawInRotMat(float yaw, const matrix::Dcmf& rot_in);
+
 namespace ecl{
 	inline float powf(float x, int exp)
 	{

--- a/test/test_EKF_utils.cpp
+++ b/test/test_EKF_utils.cpp
@@ -55,3 +55,16 @@ TEST(eclPowfTest, compareToStandardImplementation)
 		}
 	}
 }
+
+TEST(euler312YawTest, fromQuaternion)
+{
+	matrix::Quatf q1(3.5f,2.4f,-0.5f,-3.f);
+	q1.normalize();
+	const matrix::Eulerf euler1(q1);
+	EXPECT_FLOAT_EQ(euler1(2), getEuler321Yaw(q1));
+
+	matrix::Quatf q2(0.f,0,-1.f,0.f);
+	q2.normalize();
+	const matrix::Eulerf euler2(q2);
+	EXPECT_FLOAT_EQ(euler2(2), getEuler321Yaw(q2));
+}

--- a/test/test_EKF_utils.cpp
+++ b/test/test_EKF_utils.cpp
@@ -40,6 +40,7 @@
 #include <gtest/gtest.h>
 #include <cmath>
 #include <vector>
+#include <mathlib/mathlib.h>
 
 #include "EKF/utils.hpp"
 
@@ -67,4 +68,32 @@ TEST(euler312YawTest, fromQuaternion)
 	q2.normalize();
 	const matrix::Eulerf euler2(q2);
 	EXPECT_FLOAT_EQ(euler2(2), getEuler321Yaw(q2));
+}
+
+TEST(shouldUse321RotationSequenceTest, pitch90)
+{
+	matrix::Eulerf euler(0.f, math::radians(90), 0.f);
+	matrix::Dcmf R(euler);
+	EXPECT_FALSE(shouldUse321RotationSequence(R));
+}
+
+TEST(shouldUse321RotationSequenceTest, roll90)
+{
+	matrix::Eulerf euler(math::radians(90.f), 0.f, 0.f);
+	matrix::Dcmf R(euler);
+	EXPECT_TRUE(shouldUse321RotationSequence(R));
+}
+
+TEST(shouldUse321RotationSequenceTest, moreRollThanPitch)
+{
+	matrix::Eulerf euler(math::radians(45.f), math::radians(30.f), 0.f);
+	matrix::Dcmf R(euler);
+	EXPECT_TRUE(shouldUse321RotationSequence(R));
+}
+
+TEST(shouldUse321RotationSequenceTest, morePitchThanRoll)
+{
+	matrix::Eulerf euler(math::radians(30.f), math::radians(45.f), 0.f);
+	matrix::Dcmf R(euler);
+	EXPECT_FALSE(shouldUse321RotationSequence(R));
 }


### PR DESCRIPTION
This PR adds multiple helper functions related to heading computation. It contains helper functions to compute a heading with either 321 or 312 rotation sequence, and more ...

Best to review commit by commit.