### PR TITLE
WindEstimator: Fix incorrect _state accessing, clarify enums

### DIFF
--- a/airdata/WindEstimator.hpp
+++ b/airdata/WindEstimator.hpp
@@ -62,8 +62,8 @@ public:
 
 	void get_wind(float wind[2])
 	{
-		wind[0] = _state(w_n);
-		wind[1] = _state(w_e);
+		wind[0] = _state(INDEX_W_N);
+		wind[1] = _state(INDEX_W_E);
 	}
 
 	bool is_estimate_valid() { return _initialised; }
@@ -71,7 +71,7 @@ public:
 	bool check_if_meas_is_rejected(uint64_t time_now, float innov, float innov_var, uint8_t gate_size,
 				       uint64_t &time_meas_rejected, bool &reinit_filter);
 
-	float get_tas_scale() { return _state(tas); }
+	float get_tas_scale() { return _state(INDEX_TAS_SCALE); }
 	float get_tas_innov() { return _tas_innov; }
 	float get_tas_innov_var() { return _tas_innov_var; }
 	float get_beta_innov() { return _beta_innov; }
@@ -96,9 +96,9 @@ public:
 
 private:
 	enum {
-		w_n = 0,
-		w_e,
-		tas
+		INDEX_W_N = 0,
+		INDEX_W_E,
+		INDEX_TAS_SCALE
 	};	///< enum which can be used to access state.
 
 	matrix::Vector3f _state;		///< state vector


### PR DESCRIPTION
The WindEstimator class uses an enum to index into its _state vector. However, in a few places (lines 166, 170, 171, 239 and 241), it mistakenly uses those enums as if they are variables representing the states, entirely corrupting the validity of the math.  

This change fixes that and also renames the enums using a style less likely to be mistaken for local variables in the future.