### PR TITLE
Optical flow: compute velociy from corrected flow data for logging

### DIFF
--- a/EKF/ekf.h
+++ b/EKF/ekf.h
@@ -107,6 +107,9 @@ public:
 
 	void getFlowVelBody(float flow_vel_body[2]) const override;
 	void getFlowVelNE(float flow_vel_ne[2]) const override;
+	void getFlowCompensated(float flow_compensated[2]) const override;
+	void getFlowUncompensated(float flow_uncompensated[2]) const override;
+	void getFlowGyro(float flow_gyro[3]) const override;
 
 	void getHeadingInnov(float &heading_innov) const override;
 

--- a/EKF/ekf.h
+++ b/EKF/ekf.h
@@ -105,6 +105,9 @@ public:
 
 	void getFlowInnovRatio(float &flow_innov_ratio) const override;
 
+	void getFlowVelBody(float flow_vel_body[2]) const override;
+	void getFlowVelNE(float flow_vel_ne[2]) const override;
+
 	void getHeadingInnov(float &heading_innov) const override;
 
 	void getHeadingInnovVar(float &heading_innov_var) const override;
@@ -437,6 +440,8 @@ private:
 	Vector2f _flow_innov;		///< flow measurement innovation (rad/sec)
 	Vector2f _flow_innov_var;	///< flow innovation variance ((rad/sec)**2)
 	Vector3f _flow_gyro_bias;	///< bias errors in optical flow sensor rate gyro outputs (rad/sec)
+	Vector2f _flow_vel_body;	///< velocity from corrected flow measurement (body frame)(m/s)
+	Vector2f _flow_vel_ne;		///< velocity from corrected flow measurement (local frame) (m/s)
 	Vector3f _imu_del_ang_of;	///< bias corrected delta angle measurements accumulated across the same time frame as the optical flow rates (rad)
 	float _delta_time_of{0.0f};	///< time in sec that _imu_del_ang_of was accumulated over (sec)
 	uint64_t _time_bad_motion_us{0};	///< last system time that on-ground motion exceeded limits (uSec)

--- a/EKF/ekf.h
+++ b/EKF/ekf.h
@@ -105,11 +105,11 @@ public:
 
 	void getFlowInnovRatio(float &flow_innov_ratio) const override;
 
-	void getFlowVelBody(float flow_vel_body[2]) const override;
-	void getFlowVelNE(float flow_vel_ne[2]) const override;
-	void getFlowCompensated(float flow_compensated[2]) const override;
-	void getFlowUncompensated(float flow_uncompensated[2]) const override;
-	void getFlowGyro(float flow_gyro[3]) const override;
+	Vector2f getFlowVelBody() const override;
+	Vector2f getFlowVelNE() const override;
+	Vector2f getFlowCompensated() const override;
+	Vector2f getFlowUncompensated() const override;
+	Vector3f getFlowGyro() const override;
 
 	void getHeadingInnov(float &heading_innov) const override;
 

--- a/EKF/ekf_helper.cpp
+++ b/EKF/ekf_helper.cpp
@@ -718,6 +718,21 @@ void Ekf::getFlowVelNE(float flow_vel_ne[2]) const
 	_flow_vel_ne.copyTo(flow_vel_ne);
 }
 
+void Ekf::getFlowCompensated(float flow_compensated[2]) const
+{
+	_flow_compensated_XY_rad.copyTo(flow_compensated);
+}
+
+void Ekf::getFlowUncompensated(float flow_uncompensated[2]) const
+{
+	_flow_sample_delayed.flow_xy_rad.copyTo(flow_uncompensated);
+}
+
+void Ekf::getFlowGyro(float flow_gyro[3]) const
+{
+	_flow_sample_delayed.gyro_xyz.copyTo(flow_gyro);
+}
+
 void Ekf::getHeadingInnov(float &heading_innov) const
 {
 	heading_innov = _heading_innov;

--- a/EKF/ekf_helper.cpp
+++ b/EKF/ekf_helper.cpp
@@ -708,29 +708,29 @@ void Ekf::getFlowInnovRatio(float &flow_innov_ratio) const
 	flow_innov_ratio = _optflow_test_ratio;
 }
 
-void Ekf::getFlowVelBody(float flow_vel_body[2]) const
+Vector2f Ekf::getFlowVelBody() const
 {
-	_flow_vel_body.copyTo(flow_vel_body);
+	return _flow_vel_body;
 }
 
-void Ekf::getFlowVelNE(float flow_vel_ne[2]) const
+Vector2f Ekf::getFlowVelNE() const
 {
-	_flow_vel_ne.copyTo(flow_vel_ne);
+	return _flow_vel_ne;
 }
 
-void Ekf::getFlowCompensated(float flow_compensated[2]) const
+Vector2f Ekf::getFlowCompensated() const
 {
-	_flow_compensated_XY_rad.copyTo(flow_compensated);
+	return _flow_compensated_XY_rad;
 }
 
-void Ekf::getFlowUncompensated(float flow_uncompensated[2]) const
+Vector2f Ekf::getFlowUncompensated() const
 {
-	_flow_sample_delayed.flow_xy_rad.copyTo(flow_uncompensated);
+	return _flow_sample_delayed.flow_xy_rad;
 }
 
-void Ekf::getFlowGyro(float flow_gyro[3]) const
+Vector3f Ekf::getFlowGyro() const
 {
-	_flow_sample_delayed.gyro_xyz.copyTo(flow_gyro);
+	return _flow_sample_delayed.gyro_xyz;
 }
 
 void Ekf::getHeadingInnov(float &heading_innov) const

--- a/EKF/ekf_helper.cpp
+++ b/EKF/ekf_helper.cpp
@@ -708,6 +708,16 @@ void Ekf::getFlowInnovRatio(float &flow_innov_ratio) const
 	flow_innov_ratio = _optflow_test_ratio;
 }
 
+void Ekf::getFlowVelBody(float flow_vel_body[2]) const
+{
+	_flow_vel_body.copyTo(flow_vel_body);
+}
+
+void Ekf::getFlowVelNE(float flow_vel_ne[2]) const
+{
+	_flow_vel_ne.copyTo(flow_vel_ne);
+}
+
 void Ekf::getHeadingInnov(float &heading_innov) const
 {
 	heading_innov = _heading_innov;

--- a/EKF/estimator_interface.h
+++ b/EKF/estimator_interface.h
@@ -91,11 +91,11 @@ public:
 	virtual void getFlowInnov(float flow_innov[2]) const = 0;
 	virtual void getFlowInnovVar(float flow_innov_var[2]) const = 0;
 	virtual void getFlowInnovRatio(float &flow_innov_ratio) const = 0;
-	virtual void getFlowVelBody(float flow_vel_body[2]) const = 0;
-	virtual void getFlowVelNE(float flow_vel_ne[2]) const = 0;
-	virtual void getFlowCompensated(float flow_compensated[2]) const = 0;
-	virtual void getFlowUncompensated(float flow_uncompensated[2]) const = 0;
-	virtual void getFlowGyro(float flow_gyro[3]) const = 0;
+	virtual Vector2f getFlowVelBody() const = 0;
+	virtual Vector2f getFlowVelNE() const = 0;
+	virtual Vector2f getFlowCompensated() const = 0;
+	virtual Vector2f getFlowUncompensated() const = 0;
+	virtual Vector3f getFlowGyro() const = 0;
 
 	virtual void getHeadingInnov(float &heading_innov) const = 0;
 	virtual void getHeadingInnovVar(float &heading_innov_var) const = 0;

--- a/EKF/estimator_interface.h
+++ b/EKF/estimator_interface.h
@@ -93,6 +93,9 @@ public:
 	virtual void getFlowInnovRatio(float &flow_innov_ratio) const = 0;
 	virtual void getFlowVelBody(float flow_vel_body[2]) const = 0;
 	virtual void getFlowVelNE(float flow_vel_ne[2]) const = 0;
+	virtual void getFlowCompensated(float flow_compensated[2]) const = 0;
+	virtual void getFlowUncompensated(float flow_uncompensated[2]) const = 0;
+	virtual void getFlowGyro(float flow_gyro[3]) const = 0;
 
 	virtual void getHeadingInnov(float &heading_innov) const = 0;
 	virtual void getHeadingInnovVar(float &heading_innov_var) const = 0;

--- a/EKF/estimator_interface.h
+++ b/EKF/estimator_interface.h
@@ -91,6 +91,8 @@ public:
 	virtual void getFlowInnov(float flow_innov[2]) const = 0;
 	virtual void getFlowInnovVar(float flow_innov_var[2]) const = 0;
 	virtual void getFlowInnovRatio(float &flow_innov_ratio) const = 0;
+	virtual void getFlowVelBody(float flow_vel_body[2]) const = 0;
+	virtual void getFlowVelNE(float flow_vel_ne[2]) const = 0;
 
 	virtual void getHeadingInnov(float &heading_innov) const = 0;
 	virtual void getHeadingInnovVar(float &heading_innov_var) const = 0;

--- a/EKF/optflow_fusion.cpp
+++ b/EKF/optflow_fusion.cpp
@@ -102,6 +102,12 @@ void Ekf::fuseOptFlow()
 	// Note the sign convention used: A positive LOS rate is a RH rotation of the scene about that axis.
 	const Vector2f opt_flow_rate = _flow_compensated_XY_rad / _flow_sample_delayed.dt + Vector2f(_flow_gyro_bias);
 
+	// compute the velocities in body and local frames from corrected optical flow measurement
+	// for logging only
+	_flow_vel_body(0) = -opt_flow_rate(1) * range;
+	_flow_vel_body(1) = opt_flow_rate(0) * range;
+	_flow_vel_ne = Vector2f(_R_to_earth * Vector3f(_flow_vel_body(0), _flow_vel_body(1), 0.f));
+
 	if (opt_flow_rate.norm() < _flow_max_rate) {
 		_flow_innov(0) =  vel_body(1) / range - opt_flow_rate(0); // flow around the X axis
 		_flow_innov(1) = -vel_body(0) / range - opt_flow_rate(1); // flow around the Y axis


### PR DESCRIPTION
This is something I always needed when working with optical flow sensors. It allows to easily fine tune the delay and scale factor of the optical flow measurements to get the best possible gyro compensation.
It's also extremely useful to see if the measurements make sense because looking at flow innovations isn't really intuitive.

Here's an example of what you can get in the log (I'll make the corresponding firmware PR to add the logging part):

![2020-10-23_12-30-04_01_plot](https://user-images.githubusercontent.com/14822839/96993456-a02cce00-152b-11eb-8d5d-06c8033bacc4.png)