### PR TITLE
EKF: allow initialising without baro depending on configuration

### DIFF
--- a/EKF/MedianFilter.hpp
+++ b/EKF/MedianFilter.hpp
@@ -1,0 +1,88 @@
+/****************************************************************************
+ *
+ *   Copyright (C) 2020-2021 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/*
+ * @file MedianFilter.hpp
+ *
+ * @brief Implementation of a median filter with C qsort.
+ *
+ */
+
+#pragma once
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+template<typename T, int WINDOW = 3>
+class MedianFilter
+{
+public:
+	static_assert(WINDOW >= 3, "MedianFilter window size must be >= 3");
+	static_assert(WINDOW % 2, "MedianFilter window size must be odd"); // odd
+
+	MedianFilter() = default;
+
+	void insert(const T &sample)
+	{
+		_head = (_head + 1) % WINDOW;
+		_buffer[_head] = sample;
+	}
+
+	T median()
+	{
+		T sorted[WINDOW];
+		memcpy(sorted, _buffer, sizeof(_buffer));
+		qsort(&sorted, WINDOW, sizeof(T), cmp);
+
+		return sorted[WINDOW / 2];
+	}
+
+	T update(const T &sample)
+	{
+		insert(sample);
+		return median();
+	}
+
+	unsigned window_size() const { return WINDOW; }
+
+private:
+
+	static int cmp(const void *a, const void *b)
+	{
+		return (*(T *)a >= *(T *)b) ? 1 : -1;
+	}
+
+	T _buffer[WINDOW] {};
+	uint8_t _head{0};
+};

--- a/EKF/RingBuffer.h
+++ b/EKF/RingBuffer.h
@@ -153,6 +153,27 @@ public:
 		return false;
 	}
 
+	bool peek_first_older_than(const uint64_t &timestamp, data_type *sample) const
+	{
+		// start looking from newest observation data
+		for (uint8_t i = 0; i < _size; i++) {
+			int index = (_head - i);
+			index = index < 0 ? _size + index : index;
+
+			if (timestamp >= _buffer[index].time_us && timestamp < _buffer[index].time_us + (uint64_t)1e5) {
+				*sample = _buffer[index];
+				return true;
+			}
+
+			if (index == _tail) {
+				// we have reached the tail and haven't got a match
+				return false;
+			}
+		}
+
+		return false;
+	}
+
 	int get_total_size() const { return sizeof(*this) + sizeof(data_type) * _size; }
 
 private:

--- a/EKF/ekf.cpp
+++ b/EKF/ekf.cpp
@@ -102,16 +102,17 @@ bool Ekf::update()
 {
 	bool updated = false;
 
-	if (!_filter_initialised) {
-		_filter_initialised = initialiseFilter();
-
-		if (!_filter_initialised) {
-			return false;
-		}
-	}
-
 	// Only run the filter if IMU data in the buffer has been updated
 	if (_imu_updated) {
+
+		if (!_filter_initialised) {
+			_filter_initialised = initialiseFilter();
+
+			if (!_filter_initialised) {
+				return false;
+			}
+		}
+
 		// perform state and covariance prediction for the main filter
 		predictState();
 		predictCovariance();
@@ -137,50 +138,19 @@ bool Ekf::update()
 
 bool Ekf::initialiseFilter()
 {
-	// Filter accel for tilt initialization
-	const imuSample &imu_init = _imu_buffer.get_newest();
-
 	// protect against zero data
-	if (imu_init.delta_vel_dt < 1e-4f || imu_init.delta_ang_dt < 1e-4f) {
+	if (_imu_sample_delayed.delta_vel_dt < 1e-4f || _imu_sample_delayed.delta_ang_dt < 1e-4f) {
 		return false;
 	}
 
 	if (_is_first_imu_sample) {
-		_accel_lpf.reset(imu_init.delta_vel / imu_init.delta_vel_dt);
-		_gyro_lpf.reset(imu_init.delta_ang / imu_init.delta_ang_dt);
+		_accel_lpf.reset(_imu_sample_delayed.delta_vel / _imu_sample_delayed.delta_vel_dt);
+		_gyro_lpf.reset(_imu_sample_delayed.delta_ang / _imu_sample_delayed.delta_ang_dt);
 		_is_first_imu_sample = false;
 
 	} else {
-		_accel_lpf.update(imu_init.delta_vel / imu_init.delta_vel_dt);
-		_gyro_lpf.update(imu_init.delta_ang / imu_init.delta_ang_dt);
-	}
-
-	// Sum the magnetometer measurements
-	if (_mag_buffer.pop_first_older_than(_imu_sample_delayed.time_us, &_mag_sample_delayed)) {
-		if (_mag_sample_delayed.time_us != 0) {
-			if (_mag_counter == 0) {
-				_mag_lpf.reset(_mag_sample_delayed.mag);
-
-			} else {
-				_mag_lpf.update(_mag_sample_delayed.mag);
-			}
-
-			_mag_counter++;
-		}
-	}
-
-	// accumulate enough height measurements to be confident in the quality of the data
-	if (_baro_buffer.pop_first_older_than(_imu_sample_delayed.time_us, &_baro_sample_delayed)) {
-		if (_baro_sample_delayed.time_us != 0) {
-			if (_baro_counter == 0) {
-				_baro_hgt_offset = _baro_sample_delayed.hgt;
-
-			} else {
-				_baro_hgt_offset = 0.9f * _baro_hgt_offset + 0.1f * _baro_sample_delayed.hgt;
-			}
-
-			_baro_counter++;
-		}
+		_accel_lpf.update(_imu_sample_delayed.delta_vel / _imu_sample_delayed.delta_vel_dt);
+		_gyro_lpf.update(_imu_sample_delayed.delta_ang / _imu_sample_delayed.delta_ang_dt);
 	}
 
 	if (_params.mag_fusion_type <= MAG_FUSE_TYPE_3D) {
@@ -190,13 +160,57 @@ bool Ekf::initialiseFilter()
 		}
 	}
 
-	if (_baro_counter < _obs_buffer_length) {
-		// not enough baro samples accumulated
-		return false;
+	if (_baro_hgt_counter >= 1) {
+		_baro_hgt_offset = _baro_hgt_lpf.getState();
 	}
 
-	// we use baro height initially and switch to GPS/range/EV finder later when it passes checks.
-	setControlBaroHeight();
+	if (_gps_hgt_counter >= 1) {
+		_gps_hgt_offset = _gps_hgt_lpf.getState();
+	}
+
+	if (_rng_hgt_counter >= _rng_hgt_filter.window_size()) {
+		_rng_hgt_offset = _rng_hgt_filter.median();
+	}
+
+	if (_ev_hgt_counter >= 1) {
+		_ev_hgt_offset = _ev_hgt_lpf.getState();
+	}
+
+	switch (_params.vdist_sensor_type) {
+	default:
+	// FALLTHROUGH
+	case VDIST_SENSOR_BARO:
+		if (_baro_hgt_counter < _obs_buffer_length) {
+			// not enough samples accumulated
+			return false;
+		}
+		setControlBaroHeight();
+		break;
+
+	case VDIST_SENSOR_GPS:
+		if (_gps_hgt_counter < _obs_buffer_length) {
+			// not enough samples accumulated
+			return false;
+		}
+		setControlGPSHeight();
+		break;
+
+	case VDIST_SENSOR_RANGE:
+		if (_rng_hgt_counter < _obs_buffer_length) {
+			// not enough samples accumulated
+			return false;
+		}
+		setControlRangeHeight();
+		break;
+
+	case VDIST_SENSOR_EV:
+		if (_ev_hgt_counter < _obs_buffer_length) {
+			// not enough samples accumulated
+			return false;
+		}
+		setControlEVHeight();
+		break;
+	}
 
 	if (!initialiseTilt()) {
 		return false;
@@ -215,6 +229,8 @@ bool Ekf::initialiseFilter()
 		// using magnetic heading tuning parameter
 		increaseQuatYawErrVariance(sq(fmaxf(_params.mag_heading_noise, 1.0e-2f)));
 	}
+
+	resetHeight();
 
 	// try to initialise the terrain estimator
 	_terrain_initialised = initHagl();

--- a/EKF/ekf.h
+++ b/EKF/ekf.h
@@ -347,6 +347,7 @@ private:
 	bool _gps_data_ready{false};	///< true when new GPS data has fallen behind the fusion time horizon and is available to be fused
 	bool _mag_data_ready{false};	///< true when new magnetometer data has fallen behind the fusion time horizon and is available to be fused
 	bool _baro_data_ready{false};	///< true when new baro height data has fallen behind the fusion time horizon and is available to be fused
+	bool _rng_data_ready{false};
 	bool _flow_data_ready{false};	///< true when the leading edge of the optical flow integration period has fallen behind the fusion time horizon
 	bool _ev_data_ready{false};	///< true when new external vision system data has fallen behind the fusion time horizon and is available to be fused
 	bool _tas_data_ready{false};	///< true when new true airspeed data has fallen behind the fusion time horizon and is available to be fused
@@ -377,6 +378,9 @@ private:
 
 	uint64_t _time_acc_bias_check{0};	///< last time the  accel bias check passed (uSec)
 	uint64_t _delta_time_baro_us{0};	///< delta time between two consecutive delayed baro samples from the buffer (uSec)
+	uint64_t _delta_time_gps_us{0};
+	uint64_t _delta_time_rng_us{0};
+	uint64_t _delta_time_ev_us{0};
 
 	Vector3f _earth_rate_NED;	///< earth rotation vector (NED) in rad/s
 
@@ -487,15 +491,15 @@ private:
 
 	// Variables used by the initial filter alignment
 	bool _is_first_imu_sample{true};
-	uint32_t _baro_counter{0};		///< number of baro samples read during initialisation
-	uint32_t _mag_counter{0};		///< number of magnetometer samples read during initialisation
 	AlphaFilter<Vector3f> _accel_lpf{0.1f};	///< filtered accelerometer measurement used to align tilt (m/s/s)
 	AlphaFilter<Vector3f> _gyro_lpf{0.1f};	///< filtered gyro measurement used for alignment excessive movement check (rad/sec)
 
 	// Variables used to perform in flight resets and switch between height sources
 	AlphaFilter<Vector3f> _mag_lpf{0.1f};	///< filtered magnetometer measurement for instant reset (Gauss)
-	float _hgt_sensor_offset{0.0f};		///< set as necessary if desired to maintain the same height after a height reset (m)
-	float _baro_hgt_offset{0.0f};		///< baro height reading at the local NED origin (m)
+	float _baro_hgt_offset{NAN};		///< baro height reading at the local NED origin (m)
+	float _gps_hgt_offset{NAN};
+	float _rng_hgt_offset{NAN};
+	float _ev_hgt_offset{NAN};
 
 	// Variables used to control activation of post takeoff functionality
 	float _last_on_ground_posD{0.0f};	///< last vertical position when the in_air status was false (m)
@@ -884,8 +888,6 @@ private:
 
 	void startBaroHgtFusion();
 	void startGpsHgtFusion();
-
-	void updateBaroHgtOffset();
 
 	// return an estimation of the GPS altitude variance
 	float getGpsHeightVariance();

--- a/EKF/ekf_helper.cpp
+++ b/EKF/ekf_helper.cpp
@@ -257,41 +257,54 @@ void Ekf::resetVerticalPositionTo(const float &new_vert_pos)
 // Reset height state using the last height measurement
 void Ekf::resetHeight()
 {
-	// Get the most recent GPS data
-	const gpsSample &gps_newest = _gps_buffer.get_newest();
+	// use median filtered range data
+	// correct the range data for position offset relative to the IMU
+	const Vector3f pos_offset_body{_params.rng_pos_body - _params.imu_pos_body};
+	const Vector3f pos_offset_earth{_R_to_earth * pos_offset_body};
+	const float range = _rng_hgt_filter.median() + pos_offset_earth(2) / _range_sensor.getCosTilt();
+	float dist_bottom = range * _range_sensor.getCosTilt();
+
+	if (!_control_status.flags.in_air && (range < _range_sensor.getValidMinVal() || range > _range_sensor.getValidMaxVal())) {
+		dist_bottom = _params.rng_gnd_clearance;
+	}
 
 	// reset the vertical position
 	if (_control_status.flags.rng_hgt) {
 
-		// a fallback from any other height source to rangefinder happened
-		if(!_control_status_prev.flags.rng_hgt) {
+		if (_range_sensor.isHealthy()) {
+			// a fallback from any other height source to rangefinder happened
+			if (!ISFINITE(_rng_hgt_offset) && !_control_status_prev.flags.rng_hgt) {
+				if (_control_status.flags.in_air && isTerrainEstimateValid()) {
+					_rng_hgt_offset = _terrain_vpos;
 
-			if (_control_status.flags.in_air && isTerrainEstimateValid()) {
-			    _hgt_sensor_offset = _terrain_vpos;
-			} else if (_control_status.flags.in_air) {
-				 _hgt_sensor_offset = _range_sensor.getDistBottom() + _state.pos(2);
-			} else {
-				_hgt_sensor_offset = _params.rng_gnd_clearance;
+				} else if (_control_status.flags.in_air) {
+					_rng_hgt_offset = dist_bottom + _state.pos(2);
+
+				} else {
+					_rng_hgt_offset = _params.rng_gnd_clearance;
+				}
 			}
 
+			// update the state and associated variance
+			resetVerticalPositionTo(_rng_hgt_offset - dist_bottom);
+
+			// the state variance is the same as the observation
+			P.uncorrelateCovarianceSetVariance<1>(9, sq(_params.range_noise));
+
+		} else {
+			// TODO: reset to last known baro based estimate
 		}
 
-		// update the state and associated variance
-		resetVerticalPositionTo(_hgt_sensor_offset - _range_sensor.getDistBottom());
-
-		// the state variance is the same as the observation
-		P.uncorrelateCovarianceSetVariance<1>(9, sq(_params.range_noise));
-
-		// reset the baro offset which is subtracted from the baro reading if we need to use it as a backup
-		const baroSample &baro_newest = _baro_buffer.get_newest();
-		_baro_hgt_offset = baro_newest.hgt + _state.pos(2);
-
 	} else if (_control_status.flags.baro_hgt) {
-		// initialize vertical position with newest baro measurement
-		const baroSample &baro_newest = _baro_buffer.get_newest();
 
 		if (!_baro_hgt_faulty) {
-			resetVerticalPositionTo(-baro_newest.hgt + _baro_hgt_offset);
+
+			if (!ISFINITE(_baro_hgt_offset) && !_control_status_prev.flags.baro_hgt) {
+				_baro_hgt_offset = _state.pos(2) + _baro_hgt_lpf.getState();
+			}
+
+			// initialize vertical position with newest baro measurement
+			resetVerticalPositionTo(-_baro_hgt_lpf.getState() + _baro_hgt_offset);
 
 			// the state variance is the same as the observation
 			P.uncorrelateCovarianceSetVariance<1>(9, sq(_params.baro_noise));
@@ -303,39 +316,74 @@ void Ekf::resetHeight()
 	} else if (_control_status.flags.gps_hgt) {
 		// initialize vertical position and velocity with newest gps measurement
 		if (!_gps_hgt_intermittent) {
-			resetVerticalPositionTo(_hgt_sensor_offset - gps_newest.hgt + _gps_alt_ref);
+
+			if (!ISFINITE(_gps_hgt_offset) && !_control_status_prev.flags.gps_hgt) {
+				_gps_hgt_offset = _state.pos(2) + _gps_hgt_lpf.getState() - _gps_alt_ref;
+			}
+
+			gpsSample gps_sample;
+
+			if (!_gps_buffer.peek_first_older_than(_imu_sample_delayed.time_us, &gps_sample)) {
+				gps_sample = _gps_buffer.get_newest();
+			}
+
+			resetVerticalPositionTo(_gps_hgt_offset - _gps_hgt_lpf.getState() + _gps_alt_ref);
 
 			// the state variance is the same as the observation
-			P.uncorrelateCovarianceSetVariance<1>(9, sq(gps_newest.vacc));
-
-			// reset the baro offset which is subtracted from the baro reading if we need to use it as a backup
-			const baroSample &baro_newest = _baro_buffer.get_newest();
-			_baro_hgt_offset = baro_newest.hgt + _state.pos(2);
+			P.uncorrelateCovarianceSetVariance<1>(9, sq(gps_sample.vacc));
 
 		} else {
 			// TODO: reset to last known gps based estimate
 		}
 
 	} else if (_control_status.flags.ev_hgt) {
-		// initialize vertical position with newest measurement
-		const extVisionSample &ev_newest = _ext_vision_buffer.get_newest();
+		if (!ISFINITE(_ev_hgt_offset) &&!_control_status_prev.flags.ev_hgt) {
+			_ev_hgt_offset = _state.pos(2) + _ev_hgt_lpf.getState();
+		}
+
+		extVisionSample ext_vision_sample;
+
+		if (!_ext_vision_buffer.peek_first_older_than(_imu_sample_delayed.time_us, &ext_vision_sample)) {
+			ext_vision_sample = _ext_vision_buffer.get_newest();
+		}
 
 		// use the most recent data if it's time offset from the fusion time horizon is smaller
-		if (ev_newest.time_us >= _ev_sample_delayed.time_us) {
-			resetVerticalPositionTo(ev_newest.pos(2));
+		resetVerticalPositionTo(_ev_hgt_lpf.getState());
 
-		} else {
-			resetVerticalPositionTo(_ev_sample_delayed.pos(2));
-		}
+		P.uncorrelateCovarianceSetVariance<1>(9, sq(ext_vision_sample.posVar(2)));
 	}
+
+	// reset the height sensor offsets which is subtracted from the readings if we need to use it as a backup
+	_baro_hgt_offset = _state.pos(2) + _baro_hgt_lpf.getState();
+	_gps_hgt_offset  = _state.pos(2) + _gps_hgt_lpf.getState() - _gps_alt_ref;
+	_rng_hgt_offset  = _state.pos(2) + dist_bottom;
+	_ev_hgt_offset   = _state.pos(2) + _ev_hgt_lpf.getState();
 
 	// reset the vertical velocity state
 	if (_control_status.flags.gps && !_gps_hgt_intermittent) {
+		gpsSample gps_sample;
+
+		if (!_gps_buffer.peek_first_older_than(_imu_sample_delayed.time_us, &gps_sample)) {
+			gps_sample = _gps_buffer.get_newest();
+		}
+
 		// If we are using GPS, then use it to reset the vertical velocity
-		resetVerticalVelocityTo(gps_newest.vel(2));
+		resetVerticalVelocityTo(gps_sample.vel(2));
 
 		// the state variance is the same as the observation
-		P.uncorrelateCovarianceSetVariance<1>(6, sq(1.5f * gps_newest.sacc));
+		P.uncorrelateCovarianceSetVariance<1>(6, sq(1.5f * gps_sample.sacc));
+
+	} else if (_control_status.flags.ev_vel) {
+		extVisionSample ext_vision_sample;
+
+		if (!_ext_vision_buffer.peek_first_older_than(_imu_sample_delayed.time_us, &ext_vision_sample)) {
+			ext_vision_sample = _ext_vision_buffer.get_newest();
+		}
+
+		// use the most recent data if it's time offset from the fusion time horizon is smaller
+		resetVerticalVelocityTo(ext_vision_sample.vel(2));
+
+		P.uncorrelateCovarianceSetVariance<1>(6, math::max(getVisionVelocityVarianceInEkfFrame()(2), sq(0.05f)));
 
 	} else {
 		// we don't know what the vertical velocity is, so set it to zero
@@ -1286,10 +1334,6 @@ void Ekf::startBaroHgtFusion()
 {
 	setControlBaroHeight();
 
-	// We don't need to set a height sensor offset
-	// since we track a separate _baro_hgt_offset
-	_hgt_sensor_offset = 0.0f;
-
 	// Turn off ground effect compensation if it times out
 	if (_control_status.flags.gnd_effect) {
 		if (isTimedOut(_time_last_gnd_effect_on, GNDEFFECT_TIMEOUT)) {
@@ -1302,26 +1346,6 @@ void Ekf::startBaroHgtFusion()
 void Ekf::startGpsHgtFusion()
 {
 	setControlGPSHeight();
-
-	// we have just switched to using gps height, calculate height sensor offset such that current
-	// measurement matches our current height estimate
-	if (_control_status_prev.flags.gps_hgt != _control_status.flags.gps_hgt) {
-		_hgt_sensor_offset = _gps_sample_delayed.hgt - _gps_alt_ref + _state.pos(2);
-	}
-}
-
-void Ekf::updateBaroHgtOffset()
-{
-	// calculate a filtered offset between the baro origin and local NED origin if we are not
-	// using the baro as a height reference
-	if (!_control_status.flags.baro_hgt && _baro_data_ready) {
-		const float local_time_step = math::constrain(1e-6f * _delta_time_baro_us, 0.0f, 1.0f);
-
-		// apply a 10 second first order low pass filter to baro offset
-		const float offset_rate_correction =  0.1f * (_baro_sample_delayed.hgt + _state.pos(2) -
-								_baro_hgt_offset);
-		_baro_hgt_offset += local_time_step * math::constrain(offset_rate_correction, -0.1f, 0.1f);
-	}
 }
 
 float Ekf::getGpsHeightVariance()

--- a/EKF/estimator_interface.h
+++ b/EKF/estimator_interface.h
@@ -43,6 +43,7 @@
 
 #include <ecl.h>
 #include "common.h"
+#include "MedianFilter.hpp"
 #include "RingBuffer.h"
 #include <AlphaFilter/AlphaFilter.hpp>
 #include "imu_down_sampler.hpp"
@@ -394,6 +395,25 @@ protected:
 	warning_event_status_u _warning_events{};
 	information_event_status_u _information_events{};
 
+	uint64_t _baro_sample_delayed_time_us_last{0};
+	uint32_t _baro_hgt_counter{0};
+	AlphaFilter<float> _baro_hgt_lpf{0.1f};
+
+	uint64_t _gps_sample_delayed_time_us_last{0};
+	uint32_t _gps_hgt_counter{0};
+	AlphaFilter<float> _gps_hgt_lpf{0.1f};
+
+	uint32_t _rng_hgt_counter{0};
+	MedianFilter<float, 5> _rng_hgt_filter{};
+
+	uint64_t _ev_sample_delayed_time_us_last{0};
+	uint32_t _ev_hgt_counter{0};
+	AlphaFilter<float> _ev_hgt_lpf{0.1f};
+
+	uint64_t _mag_sample_delayed_time_us_last{0};
+	uint32_t _mag_counter{0};
+	AlphaFilter<Vector3f> _mag_lpf{0.1f}; ///< filtered magnetometer measurement for instant reset (Gauss)
+
 private:
 
 	inline void setDragData(const imuSample &imu);
@@ -439,5 +459,4 @@ private:
 	bool _ev_buffer_fail{false};
 	bool _drag_buffer_fail{false};
 	bool _auxvel_buffer_fail{false};
-
 };

--- a/EKF/sensor_range_finder.hpp
+++ b/EKF/sensor_range_finder.hpp
@@ -101,6 +101,8 @@ public:
 	float getValidMinVal() const { return _rng_valid_min_val; }
 	float getValidMaxVal() const { return _rng_valid_max_val; }
 
+	const rangeSample& sample() const { return _sample; }
+
 private:
 	void updateSensorToEarthRotation(const matrix::Dcmf &R_to_earth);
 


### PR DESCRIPTION
Attempted followup to https://github.com/PX4/PX4-ECL/pull/931.


 - every potential height source maintains a filtered value at the delayed time horizon
 - in Ekf::initialiseFilter() only the configured height source is used, but valid height data is required at init time
 - height resets use filtered delayed time horizon data rather than most recent measurement