### PR TITLE
Terrain estimation when height estimation is based on range finder data

### DIFF
--- a/EKF/ekf.cpp
+++ b/EKF/ekf.cpp
@@ -119,8 +119,9 @@ bool Ekf::update()
 		// control fusion of observation data
 		controlFusionModes();
 
-		// run a separate filter for terrain estimation
-		runTerrainEstimator();
+		// run a separate filter for terrain estimation if not in vision fallback with rangefinder
+		if(!(_control_status.flags.rng_hgt && _params.vdist_sensor_type == VDIST_SENSOR_EV))
+			runTerrainEstimator();
 
 		updated = true;
 

--- a/EKF/ekf.cpp
+++ b/EKF/ekf.cpp
@@ -119,8 +119,11 @@ bool Ekf::update()
 		// control fusion of observation data
 		controlFusionModes();
 
-		// run a separate filter for terrain estimation if not in vision fallback with rangefinder
-		if(!(_control_status.flags.rng_hgt && _params.vdist_sensor_type == VDIST_SENSOR_EV)) {
+		if(_control_status.flags.rng_hgt) {
+		    // do not update hagl in range finder mode, but keep it valid
+			_time_last_hagl_fuse = _time_last_imu;
+		} else {
+		    // run a separate filter for terrain if other height sources available
 			runTerrainEstimator();
 		}
 

--- a/EKF/ekf.cpp
+++ b/EKF/ekf.cpp
@@ -120,8 +120,9 @@ bool Ekf::update()
 		controlFusionModes();
 
 		// run a separate filter for terrain estimation if not in vision fallback with rangefinder
-		if(!(_control_status.flags.rng_hgt && _params.vdist_sensor_type == VDIST_SENSOR_EV))
+		if(!(_control_status.flags.rng_hgt && _params.vdist_sensor_type == VDIST_SENSOR_EV)) {
 			runTerrainEstimator();
+		}
 
 		updated = true;
 


### PR DESCRIPTION
When height estimation is based on range finder data, the terrain estimation must not use a range finder as source. Either terrain estimation needs to be stopped or uses a different source. This is an open PR to find an appropriate and generic solution to this issue. 


As a first step, terrain estimation is paused as soon as a fallback from vision based to range finder based height estimation occurs. Terrain estimation is continued when vision data is available again. However, this workaround is not generic enough as it only covers the specific use case described.

Refer to https://github.com/PX4/PX4-ECL/pull/994#issuecomment-810309127