### PR TITLE
Allow global position to be published after setting origin

### DIFF
--- a/EKF/control.cpp
+++ b/EKF/control.cpp
@@ -1079,20 +1079,13 @@ void Ekf::controlHeightFusion()
 			}
 		}
 
-		if (_control_status.flags.rng_hgt && _range_sensor.isDataHealthy()) {
-			// Allow RangeFinder Fusion
-			fuse_height = true;
-		}
-
-		if (_control_status.flags.baro_hgt && _baro_data_ready && !_baro_hgt_faulty) {
-			// switch to baro if there was a reset to baro
-			fuse_height = true;
-		}
-
-		// determine if we should use the vertical position observation
-		if (_control_status.flags.ev_hgt) {
-			fuse_height = true;
-		}
+		if (_control_status.flags.ev_hgt && _ev_data_ready) {
+		     fuse_height = true;
+		} else if (_control_status.flags.rng_hgt && _range_sensor.isDataHealthy()) {
+		      fuse_height = true;
+		} else if (_control_status.flags.baro_hgt && _baro_data_ready && !_baro_hgt_faulty) {
+		      fuse_height = true;
+	    }
 
 		break;
 	}

--- a/EKF/control.cpp
+++ b/EKF/control.cpp
@@ -1079,6 +1079,11 @@ void Ekf::controlHeightFusion()
 			}
 		}
 
+		if (_control_status.flags.rng_hgt) {
+			// Allow RangeFinder Fusion
+			fuse_height = true;
+		}
+
 		if (_control_status.flags.baro_hgt && _baro_data_ready && !_baro_hgt_faulty) {
 			// switch to baro if there was a reset to baro
 			fuse_height = true;

--- a/EKF/control.cpp
+++ b/EKF/control.cpp
@@ -788,8 +788,7 @@ void Ekf::controlHeightSensorTimeouts()
 
 	// check if height has been inertial deadreckoning for too long
 	// in vision hgt mode check for vision data
-	const bool hgt_fusion_timeout = isTimedOut(_time_last_hgt_fuse, (uint64_t)5e6)  ||
-			 (_control_status.flags.ev_hgt && !isRecent(_time_last_ext_vision, 5 * EV_MAX_INTERVAL));
+	const bool hgt_fusion_timeout = isTimedOut(_time_last_hgt_fuse, (uint64_t)5e6);
 
 	if (hgt_fusion_timeout || continuous_bad_accel_hgt) {
 

--- a/EKF/control.cpp
+++ b/EKF/control.cpp
@@ -1079,7 +1079,7 @@ void Ekf::controlHeightFusion()
 			}
 		}
 
-		if (_control_status.flags.rng_hgt) {
+		if (_control_status.flags.rng_hgt && _range_sensor.isDataHealthy()) {
 			// Allow RangeFinder Fusion
 			fuse_height = true;
 		}

--- a/EKF/ekf.cpp
+++ b/EKF/ekf.cpp
@@ -119,8 +119,13 @@ bool Ekf::update()
 		// control fusion of observation data
 		controlFusionModes();
 
-		// run a separate filter for terrain estimation
-		runTerrainEstimator();
+		if(_control_status.flags.rng_hgt) {
+		    // do not update hagl in range finder mode, but keep it valid
+			_time_last_hagl_fuse = _time_last_imu;
+		} else {
+		    // run a separate filter for terrain if other height sources available
+			runTerrainEstimator();
+		}
 
 		updated = true;
 

--- a/EKF/ekf_helper.cpp
+++ b/EKF/ekf_helper.cpp
@@ -719,6 +719,8 @@ bool Ekf::setEkfGlobalOrigin(const double latitude, const double longitude, cons
 		map_projection_reproject(&_pos_ref, _state.pos(0), _state.pos(1), &current_lat, &current_lon);
 		current_alt = -_state.pos(2) + _gps_alt_ref;
 		current_pos_available = true;
+	} else {
+		_NED_origin_initialised = true;
 	}
 
 	// reinitialize map projection to latitude, longitude, altitude, and reset position


### PR DESCRIPTION
Sending a set_gps_global_origin message to EKF2 via MAVLINK sets the NED origin as reported by EKF2 but does not switch to publish global position. This would be helpful in use cases where no GPS is available but LPOS is provided by other means.
Reason for this is, that the flag _NED_origin_initialised is not set to true inEkf::setEkfGlobalOrigin. 

Doing so in elf_helper.cpp would work as long as the parameter EKF2_DECL_TYPE is set to 0. Otherwise an invalid look up of the magnetic declination results an invalid EKF2_MAG_DECL value. 